### PR TITLE
edit: Fix crash in history listing mode

### DIFF
--- a/edit/writer.go
+++ b/edit/writer.go
@@ -591,11 +591,26 @@ tokens:
 			}
 		} else if hist != nil {
 			n := len(hist.all)
-			for i := n - hListing; i < n; i++ {
+
+			i := 0
+			if n > hListing {
+				i = n - hListing
+			}
+
+			for ; i < n; i++ {
 				b.writes("\n"+hist.all[i], "")
 			}
+
 			n = len(b.cells)
-			b.trimToLines(n-hListing, n)
+
+			startIndex := 0
+			if n > hListing {
+				startIndex = n - hListing
+			}
+
+			if len(b.cells) > 0 {
+				b.trimToLines(startIndex, n)
+			}
 		}
 	}
 


### PR DESCRIPTION
When you had too few history entries to display in the terminal,
entering history listing mode attempted to access a negative index and
crashed.