### PR TITLE
add a new builtin func: kill small word

### DIFF
--- a/edit/builtins.go
+++ b/edit/builtins.go
@@ -17,6 +17,7 @@ var builtins = []Builtin{
 	{"kill-line-left", killLineLeft},
 	{"kill-line-right", killLineRight},
 	{"kill-word-left", killWordLeft},
+	{"kill-small-word-left", killSmallWordLeft},
 	{"kill-rune-left", killRuneLeft},
 	{"kill-rune-right", killRuneRight},
 	{"move-dot-left", moveDotLeft},

--- a/edit/insert.go
+++ b/edit/insert.go
@@ -63,6 +63,17 @@ func killWordLeft(ed *Editor) {
 	ed.dot = space
 }
 
+func killSmallWordLeft(ed *Editor) {
+	if ed.dot == 0 {
+		return
+	}
+	split := strings.LastIndexFunc(
+		strings.TrimRightFunc(ed.line[:ed.dot], isSplit),
+		isSplit) + 1
+	ed.line = ed.line[:split] + ed.line[ed.dot:]
+	ed.dot = split
+}
+
 func killRuneLeft(ed *Editor) {
 	if ed.dot > 0 {
 		_, w := utf8.DecodeLastRuneInString(ed.line[:ed.dot])
@@ -121,6 +132,17 @@ func moveDotRightWord(ed *Editor) {
 
 func notSpace(r rune) bool {
 	return !unicode.IsSpace(r)
+}
+
+func isSplit(r rune) bool {
+	if unicode.IsSpace(r) {
+		return true
+	}
+	switch r {
+	case '-', '_', '/', '—', '[', ']', '{', '}', '(', ')':
+		return true
+	}
+	return false
 }
 
 func moveDotSOL(ed *Editor) {


### PR DESCRIPTION
It considers a word is splitted by following char:
'-', '_', '/', '—', '[', ']', '{', '}', '(', ')' and space.