### PR TITLE
Added styles type, which translates human-readable values to ANSI codes

### DIFF
--- a/edit/buffer.go
+++ b/edit/buffer.go
@@ -134,7 +134,7 @@ func (b *buffer) writes(s string, style string) {
 }
 
 func (b *buffer) writeStyled(s *styled) {
-	b.writes(s.text, s.style)
+	b.writes(s.text, s.styles.String())
 }
 
 func (b *buffer) writeStyleds(ss []*styled) {

--- a/edit/call.go
+++ b/edit/call.go
@@ -97,7 +97,7 @@ func callFnForPrompt(ed *Editor, fn eval.Fn) []*styled {
 		if s, ok := v.(*styled); ok {
 			ss = append(ss, s)
 		} else {
-			ss = append(ss, &styled{eval.ToString(v), ""})
+			ss = append(ss, &styled{eval.ToString(v), styles{}})
 		}
 	}
 	return ss

--- a/edit/completers.go
+++ b/edit/completers.go
@@ -270,7 +270,7 @@ func complFilenameInner(head string, executableOnly bool) ([]*candidate, error) 
 
 		cands = append(cands, &candidate{
 			text: full, suffix: suffix,
-			display: styled{name, lsColor.getStyle(full)},
+			display: styled{name, stylesFromString(lsColor.getStyle(full))},
 		})
 	}
 

--- a/edit/completion.go
+++ b/edit/completion.go
@@ -39,11 +39,11 @@ func (c *completion) ModeLine(width int) *buffer {
 	b.writes(" ", "")
 	// Write title
 	title := fmt.Sprintf("COMPLETING %s", c.completer)
-	b.writes(util.TrimWcwidth(title, width), styleForMode)
+	b.writes(util.TrimWcwidth(title, width), styleForMode.String())
 	// Write filter
 	if c.filtering {
 		b.writes(" ", "")
-		b.writes(c.filter, styleForFilter)
+		b.writes(c.filter, styleForFilter.String())
 		b.dot = b.cursor()
 	}
 	// Write horizontal scrollbar, using the remaining space
@@ -331,15 +331,15 @@ func (comp *completion) List(width, maxHeight int) *buffer {
 			}
 			if j >= len(cands) {
 				// Write padding to make the listing a rectangle.
-				col.writePadding(totalColWidth, styleForCompletion)
+				col.writePadding(totalColWidth, styleForCompletion.String())
 			} else {
-				col.writePadding(completionColMarginLeft, styleForCompletion)
-				style := joinStyle(styleForCompletion, cands[j].display.style)
+				col.writePadding(completionColMarginLeft, styleForCompletion.String())
+				s := joinStyles(styleForCompletion, cands[j].display.styles)
 				if j == comp.selected {
-					style = joinStyle(style, styleForSelectedCompletion)
+					s = append(s, styleForSelectedCompletion)
 				}
-				col.writes(util.ForceWcwidth(cands[j].display.text, colWidth), style)
-				col.writePadding(completionColMarginRight, styleForCompletion)
+				col.writes(util.ForceWcwidth(cands[j].display.text, colWidth), s.String())
+				col.writePadding(completionColMarginRight, styleForCompletion.String())
 				if !trimmed {
 					comp.lastShownInFull = j
 				}
@@ -360,7 +360,7 @@ func (comp *completion) List(width, maxHeight int) *buffer {
 			if i > 0 {
 				col.newline()
 			}
-			col.writePadding(remainedWidth, styleForCompletion)
+			col.writePadding(remainedWidth, styleForCompletion.String())
 		}
 		b.extendHorizontal(col, 0)
 		remainedWidth = 0

--- a/edit/editor.go
+++ b/edit/editor.go
@@ -172,7 +172,7 @@ func (ed *Editor) refresh(fullRefresh bool, tips bool) error {
 					p := err.Begin
 					for i, token := range ed.tokens {
 						if token.Node.Begin() <= p && p < token.Node.End() {
-							ed.tokens[i].addStyle(styleForCompilerError)
+							ed.tokens[i].MoreStyle = joinStyles(ed.tokens[i].MoreStyle, styleForCompilerError)
 							break
 						}
 					}

--- a/edit/listing.go
+++ b/edit/listing.go
@@ -44,9 +44,9 @@ func (l *listing) ModeLine(width int) *buffer {
 	title := l.provider.ModeTitle(l.selected)
 	// TODO keep it one line.
 	b := newBuffer(width)
-	b.writes(util.TrimWcwidth(title, width), styleForMode)
+	b.writes(util.TrimWcwidth(title, width), styleForMode.String())
 	b.writes(" ", "")
-	b.writes(l.filter, styleForFilter)
+	b.writes(l.filter, styleForFilter.String())
 	b.dot = b.cursor()
 	return b
 }
@@ -78,13 +78,13 @@ func (l *listing) List(width, maxHeight int) *buffer {
 	getEntry := func(i int) []styled {
 		s := l.provider.Show(i, width)
 		lines := strings.Split(s.text, "\n")
-		style := s.style
+		st := s.styles
 		if i == l.selected {
-			style = joinStyle(style, styleForSelected)
+			st = append(st, styleForSelected.String())
 		}
 		styleds := make([]styled, len(lines))
 		for i, line := range lines {
-			styleds[i] = styled{line, style}
+			styleds[i] = styled{line, st}
 		}
 		return styleds
 	}
@@ -135,7 +135,7 @@ func (l *listing) List(width, maxHeight int) *buffer {
 		if p != lines.Front() {
 			b.newline()
 		}
-		b.writes(s.text, s.style)
+		b.writes(s.text, s.styles.String())
 	}
 
 	if scrollbar != nil {
@@ -148,9 +148,9 @@ func writeHorizontalScrollbar(b *buffer, n, low, high, width int) {
 	slow, shigh := findScrollInterval(n, low, high, width)
 	for i := 0; i < width; i++ {
 		if slow <= i && i < shigh {
-			b.write(' ', styleForScrollBarThumb)
+			b.write(' ', styleForScrollBarThumb.String())
 		} else {
-			b.write('━', styleForScrollBarArea)
+			b.write('━', styleForScrollBarArea.String())
 		}
 	}
 }
@@ -164,9 +164,9 @@ func renderScrollbar(n, low, high, height int) *buffer {
 			b.newline()
 		}
 		if slow <= i && i < shigh {
-			b.write(' ', styleForScrollBarThumb)
+			b.write(' ', styleForScrollBarThumb.String())
 		} else {
-			b.write('│', styleForScrollBarArea)
+			b.write('│', styleForScrollBarArea.String())
 		}
 	}
 	return b

--- a/edit/navigation.go
+++ b/edit/navigation.go
@@ -34,9 +34,9 @@ func (n *navigation) ModeLine(width int) *buffer {
 		s += "(show hidden) "
 	}
 	b := newBuffer(width)
-	b.writes(util.TrimWcwidth(s, width), styleForMode)
+	b.writes(util.TrimWcwidth(s, width), styleForMode.String())
 	b.writes(" ", "")
-	b.writes(n.filter, styleForFilter)
+	b.writes(n.filter, styleForFilter.String())
 	b.dot = b.cursor()
 	return b
 }
@@ -283,7 +283,7 @@ func (n *navigation) loaddir(dir string) ([]styled, error) {
 	for _, info := range infos {
 		if n.showHidden || info.Name()[0] != '.' {
 			name := info.Name()
-			all = append(all, styled{name, lsColor.getStyle(path.Join(dir, name))})
+			all = append(all, styled{name, stylesFromString(lsColor.getStyle(path.Join(dir, name)))})
 		}
 	}
 	sortStyleds(all)
@@ -393,7 +393,7 @@ func newFilePreviewNavColumn(fname string) *navColumn {
 	lines := strings.Split(content, "\n")
 	styleds := make([]styled, len(lines))
 	for i, line := range lines {
-		styleds[i] = styled{strings.Replace(line, "\t", "    ", -1), ""}
+		styleds[i] = styled{strings.Replace(line, "\t", "    ", -1), styles{}}
 	}
 	return newNavColumn(styleds, func(int) bool { return false })
 }
@@ -412,9 +412,9 @@ func (nc *navColumn) Len() int {
 func (nc *navColumn) Show(i, w int) styled {
 	s := nc.candidates[i]
 	if w >= navigationListingMinWidthForPadding {
-		return styled{" " + util.ForceWcwidth(s.text, w-2), s.style}
+		return styled{" " + util.ForceWcwidth(s.text, w-2), s.styles}
 	}
-	return styled{util.ForceWcwidth(s.text, w), s.style}
+	return styled{util.ForceWcwidth(s.text, w), s.styles}
 }
 
 func (nc *navColumn) Filter(filter string) int {

--- a/edit/prompt.go
+++ b/edit/prompt.go
@@ -23,7 +23,7 @@ func defaultPrompts() (eval.FnValue, eval.FnValue) {
 	// Make default prompts.
 	prompt := func(ec *eval.EvalCtx, args []eval.Value, opts map[string]eval.Value) {
 		out := ec.OutputChan()
-		out <- &styled{util.Getwd() + "> ", ""}
+		out <- &styled{util.Getwd() + "> ", styles{}}
 	}
 
 	username := "???"
@@ -38,7 +38,7 @@ func defaultPrompts() (eval.FnValue, eval.FnValue) {
 	rpromptStr := username + "@" + hostname
 	rprompt := func(ec *eval.EvalCtx, args []eval.Value, opts map[string]eval.Value) {
 		out := ec.OutputChan()
-		out <- &styled{rpromptStr, "7"}
+		out <- &styled{rpromptStr, styles{"7"}}
 	}
 
 	return &eval.BuiltinFn{"default prompt", prompt}, &eval.BuiltinFn{"default rprompt", rprompt}

--- a/edit/style.go
+++ b/edit/style.go
@@ -23,7 +23,7 @@ var (
 )
 
 var styleForType = map[TokenKind]styles{
-	ParserError:  styles{"red", "3"},
+	ParserError:  styles{"red", "italic"},
 	Bareword:     styles{},
 	SingleQuoted: styles{"red"},
 	DoubleQuoted: styles{"red"},
@@ -76,10 +76,9 @@ var styleForSep = map[string]string{
 }
 
 var styleTranslationTable = map[string]string{
-	//"unknown": "3",
-
 	"bold":       "1",
 	"dim":        "2",
+	"italic":     "3",
 	"underlined": "4",
 	"blink":      "5",
 	"inverse":    "7",
@@ -124,8 +123,8 @@ var styleTranslationTable = map[string]string{
 var (
 	styleForGoodCommand   = styles{"green"}
 	styleForBadCommand    = styles{"red"}
-	styleForBadVariable   = styles{"red", "3"}
-	styleForCompilerError = styles{"red", "3"}
+	styleForBadVariable   = styles{"red", "italic"}
+	styleForCompilerError = styles{"red", "italic"}
 )
 
 type styles []string

--- a/edit/style.go
+++ b/edit/style.go
@@ -1,89 +1,170 @@
 package edit
 
+import "strings"
+
 // Styles for UI.
 var (
 	//styleForPrompt           = ""
-	//styleForRPrompt          = "7"
-	styleForCompleted        = "2"
-	styleForMode             = "1;37;45"
-	styleForTip              = ""
-	styleForCompletedHistory = "2"
-	styleForFilter           = "4"
-	styleForSelected         = "7"
-	styleForScrollBarArea    = "35"
-	styleForScrollBarThumb   = "35;7"
-	styleForSideArrow        = "7"
+	//styleForRPrompt          = "inverse"
+	styleForCompleted        = styles{"dim"}
+	styleForMode             = styles{"bold", "lightgray", "magenta"}
+	styleForTip              = styles{}
+	styleForCompletedHistory = styles{"dim"}
+	styleForFilter           = styles{"underlined"}
+	styleForSelected         = styles{"inverse"}
+	styleForScrollBarArea    = styles{"magenta"}
+	styleForScrollBarThumb   = styles{"magenta", "inverse"}
+	styleForSideArrow        = styles{"inverse"}
 
 	// Use black text on white for completion listing.
-	styleForCompletion = "30;47"
+	styleForCompletion = styles{"black", "bg_white"}
 	// Use white text on black for selected completion.
-	styleForSelectedCompletion = "7"
+	styleForSelectedCompletion = "inverse"
 )
 
-var styleForType = map[TokenKind]string{
-	ParserError:  "31;3",
-	Bareword:     "",
-	SingleQuoted: "33",
-	DoubleQuoted: "33",
-	Variable:     "35",
-	Wildcard:     "",
-	Tilde:        "",
-	Sep:          "",
+var styleForType = map[TokenKind]styles{
+	ParserError:  styles{"red", "3"},
+	Bareword:     styles{},
+	SingleQuoted: styles{"red"},
+	DoubleQuoted: styles{"red"},
+	Variable:     styles{"magenta"},
+	Wildcard:     styles{},
+	Tilde:        styles{},
+	Sep:          styles{},
 }
 
 var styleForSep = map[string]string{
-	// unknown : "31",
-	"#": "36",
+	// unknown : "red",
+	"#": "cyan",
 
-	">":  "32",
-	">>": "32",
-	"<":  "32",
-	"?>": "32",
-	"|":  "32",
+	">":  "green",
+	">>": "green",
+	"<":  "green",
+	"?>": "green",
+	"|":  "green",
 
-	"?(": "1",
-	"(":  "1",
-	")":  "1",
-	"[":  "1",
-	"]":  "1",
-	"{":  "1",
-	"}":  "1",
+	"?(": "bold",
+	"(":  "bold",
+	")":  "bold",
+	"[":  "bold",
+	"]":  "bold",
+	"{":  "bold",
+	"}":  "bold",
 
-	"&": "1",
+	"&": "bold",
 
-	"if":   "33",
-	"then": "33",
-	"elif": "33",
-	"else": "33",
-	"fi":   "33",
+	"if":   "yellow",
+	"then": "yellow",
+	"elif": "yellow",
+	"else": "yellow",
+	"fi":   "yellow",
 
-	"while": "33",
-	"do":    "33",
-	"done":  "33",
+	"while": "yellow",
+	"do":    "yellow",
+	"done":  "yellow",
 
-	"for": "33",
-	"in":  "33",
+	"for": "yellow",
+	"in":  "yellow",
 
-	"try":     "33",
-	"except":  "33",
-	"finally": "33",
-	"tried":   "33",
+	"try":     "yellow",
+	"except":  "yellow",
+	"finally": "yellow",
+	"tried":   "yellow",
 
-	"begin": "33",
-	"end":   "33",
+	"begin": "yellow",
+	"end":   "yellow",
+}
+
+var styleTranslationTable = map[string]string{
+	//"unknown": "3",
+
+	"bold":       "1",
+	"dim":        "2",
+	"underlined": "4",
+	"blink":      "5",
+	"inverse":    "7",
+
+	"black":        "30",
+	"red":          "31",
+	"green":        "32",
+	"yellow":       "33",
+	"blue":         "34",
+	"magenta":      "35",
+	"cyan":         "36",
+	"lightgray":    "37",
+	"gray":         "90",
+	"lightred":     "91",
+	"lightgreen":   "92",
+	"lightyellow":  "93",
+	"lightblue":    "94",
+	"lightmagenta": "95",
+	"lightcyan":    "96",
+	"white":        "97",
+
+	"bg_default":      "49",
+	"bg_black":        "40",
+	"bg_red":          "41",
+	"bg_green":        "42",
+	"bg_yellow":       "43",
+	"bg_blue":         "44",
+	"bg_magenta":      "45",
+	"bg_cyan":         "46",
+	"bg_lightgray":    "47",
+	"bg_gray":         "100",
+	"bg_lightred":     "101",
+	"bg_lightgreen":   "102",
+	"bg_lightyellow":  "103",
+	"bg_lightblue":    "104",
+	"bg_lightmagenta": "105",
+	"bg_lightcyan":    "106",
+	"bg_white":        "107",
 }
 
 // Styles for semantic coloring.
 var (
-	styleForGoodCommand   = "32"
-	styleForBadCommand    = "31"
-	styleForBadVariable   = "31;3"
-	styleForCompilerError = "31;3"
+	styleForGoodCommand   = styles{"green"}
+	styleForBadCommand    = styles{"red"}
+	styleForBadVariable   = styles{"red", "3"}
+	styleForCompilerError = styles{"red", "3"}
 )
 
-func joinStyle(s, t string) string {
-	if s != "" && t != "" {
-		return s + ";" + t
+type styles []string
+
+func joinStyles(so styles, st ...styles) styles {
+	for _, v := range st {
+		so = append(so, v...)
 	}
-	return s + t
+
+	return so
+}
+
+func styleTranslated(s string) string {
+	v, ok := styleTranslationTable[s]
+	if ok {
+		return v
+	}
+	return s
+}
+
+func stylesFromString(s string) styles {
+	var st styles
+	for _, v := range strings.Split(s, ";") {
+		st = append(st, v)
+	}
+
+	return st
+}
+
+func (s styles) String() string {
+	var o string
+	for i, v := range s {
+		if len(v) > 0 {
+			if i > 0 {
+				o += ";"
+			}
+			o += styleTranslated(v)
+		}
+	}
+
+	return o
 }

--- a/edit/styled.go
+++ b/edit/styled.go
@@ -9,16 +9,16 @@ import (
 
 // styled is a piece of text with style.
 type styled struct {
-	text  string
-	style string
+	text   string
+	styles styles
 }
 
 func unstyled(s string) styled {
-	return styled{s, ""}
+	return styled{s, styles{}}
 }
 
 func (s *styled) addStyle(st string) {
-	s.style = joinStyle(s.style, st)
+	s.styles = append(s.styles, st)
 }
 
 func (s *styled) Kind() string {
@@ -26,16 +26,16 @@ func (s *styled) Kind() string {
 }
 
 func (s *styled) String() string {
-	return "\033[" + s.style + "m" + s.text + "\033[m"
+	return "\033[" + s.styles.String() + "m" + s.text + "\033[m"
 }
 
 func (s *styled) Repr(indent int) string {
-	return "(le:styled " + parse.Quote(s.text) + " " + parse.Quote(s.style) + ")"
+	return "(le:styled " + parse.Quote(s.text) + " " + parse.Quote(s.styles.String()) + ")"
 }
 
 func styledBuiltin(ec *eval.EvalCtx, text, style string) {
 	out := ec.OutputChan()
-	out <- &styled{text, style}
+	out <- &styled{text, stylesFromString(style)}
 }
 
 // Boilerplates for sorting.

--- a/edit/stylist.go
+++ b/edit/stylist.go
@@ -30,7 +30,7 @@ func (s *Stylist) apply() {
 			tokens = tokens[1:]
 		}
 		for len(tokens) > 0 && tokens[0].Node.End() <= cmd.end {
-			tokens[0].addStyle(cmd.style)
+			tokens[0].MoreStyle = append(tokens[0].MoreStyle, cmd.style)
 			tokens = tokens[1:]
 		}
 		commands = commands[1:]
@@ -46,7 +46,7 @@ func (s *Stylist) style(n parse.Node) {
 		for _, an := range fn.Assignments {
 			if an.Dst != nil && an.Dst.Head != nil {
 				v := an.Dst.Head
-				s.add(styleForType[Variable], v.Begin(), v.End())
+				s.add(styleForType[Variable].String(), v.Begin(), v.End())
 			}
 		}
 		if fn.Head != nil {
@@ -58,12 +58,12 @@ func (s *Stylist) style(n parse.Node) {
 		case parse.ForControl:
 			if cn.Iterator != nil {
 				v := cn.Iterator.Head
-				s.add(styleForType[Variable], v.Begin(), v.End())
+				s.add(styleForType[Variable].String(), v.Begin(), v.End())
 			}
 		case parse.TryControl:
 			if cn.ExceptVar != nil {
 				v := cn.ExceptVar.Head
-				s.add(styleForType[Variable], v.Begin(), v.End())
+				s.add(styleForType[Variable].String(), v.Begin(), v.End())
 			}
 		}
 	}
@@ -74,7 +74,7 @@ func (s *Stylist) style(n parse.Node) {
 
 func (s *Stylist) formHead(n *parse.Compound) {
 	simple, head, err := simpleCompound(n, nil)
-	st := ""
+	st := styles{}
 	if simple {
 		if goodFormHead(head, s.editor) {
 			st = styleForGoodCommand
@@ -84,8 +84,8 @@ func (s *Stylist) formHead(n *parse.Compound) {
 	} else if err != nil {
 		st = styleForBadCommand
 	}
-	if st != "" {
-		s.add(st, n.Begin(), n.End())
+	if len(st) > 0 {
+		s.add(st.String(), n.Begin(), n.End())
 	}
 }
 

--- a/edit/token.go
+++ b/edit/token.go
@@ -15,7 +15,7 @@ type Token struct {
 	Type      TokenKind
 	Text      string
 	Node      parse.Node
-	MoreStyle string
+	MoreStyle styles
 }
 
 // TokenKind classifies Token's.
@@ -33,12 +33,8 @@ const (
 	Sep
 )
 
-func (t *Token) addStyle(st string) {
-	t.MoreStyle = joinStyle(t.MoreStyle, st)
-}
-
 func parserError(src string, begin, end int) Token {
-	return Token{ParserError, src[begin:end], parse.NewSep(src, begin, end), ""}
+	return Token{ParserError, src[begin:end], parse.NewSep(src, begin, end), styles{}}
 }
 
 // tokenize returns all leaves in an AST.
@@ -78,7 +74,7 @@ func produceTokens(n parse.Node, tokenCh chan<- Token) {
 	}
 	if len(n.Children()) == 0 {
 		tokenType := ParserError
-		moreStyle := ""
+		moreStyle := styles{}
 		switch n := n.(type) {
 		case *parse.Primary:
 			switch n.Type {
@@ -99,9 +95,9 @@ func produceTokens(n parse.Node, tokenCh chan<- Token) {
 			tokenType = Sep
 			septext := n.SourceText()
 			if strings.HasPrefix(septext, "#") {
-				moreStyle = styleForSep["#"]
+				moreStyle = append(moreStyle, styleForSep["#"])
 			} else {
-				moreStyle = styleForSep[septext]
+				moreStyle = append(moreStyle, styleForSep[septext])
 			}
 		default:
 			Logger.Printf("bad leaf type %T", n)

--- a/edit/writer.go
+++ b/edit/writer.go
@@ -197,7 +197,7 @@ func trimToWindow(s []string, selected, max int) ([]string, int) {
 
 func makeModeLine(text string, width int) *buffer {
 	b := newBuffer(width)
-	b.writes(util.TrimWcwidth(text, width), styleForMode)
+	b.writes(util.TrimWcwidth(text, width), styleForMode.String())
 	b.dot = b.cursor()
 	return b
 }
@@ -235,7 +235,7 @@ func (w *writer) refresh(es *editorState, fullRefresh bool) error {
 	nowAt := func(i int) {
 		if mode == modeCompletion && i == es.completion.begin {
 			c := es.completion.selectedCandidate()
-			b.writes(c.text, styleForCompleted)
+			b.writes(c.text, styleForCompleted.String())
 		}
 		if i == es.dot {
 			b.dot = b.cursor()
@@ -249,7 +249,7 @@ tokens:
 				es.completion.begin <= i && i <= es.completion.end {
 				// Do nothing. This part is replaced by the completion candidate.
 			} else {
-				b.write(r, joinStyle(styleForType[token.Type], token.MoreStyle))
+				b.write(r, joinStyles(styleForType[token.Type], token.MoreStyle).String())
 			}
 			i += utf8.RuneLen(r)
 
@@ -264,7 +264,7 @@ tokens:
 		// Put the rest of current history, position the cursor at the
 		// end of the line, and finish writing
 		h := es.hist
-		b.writes(h.line[len(h.prefix):], styleForCompletedHistory)
+		b.writes(h.line[len(h.prefix):], styleForCompletedHistory.String())
 		b.dot = b.cursor()
 	}
 
@@ -286,7 +286,7 @@ tokens:
 	// TODO tips is assumed to contain no newlines.
 	if len(es.tips) > 0 {
 		bufTips = newBuffer(width)
-		bufTips.writes(strings.Join(es.tips, "\n"), styleForTip)
+		bufTips.writes(strings.Join(es.tips, "\n"), styleForTip.String())
 	}
 
 	hListing := 0


### PR DESCRIPTION
Added a translation table, so that we / users can specify human-readable color values and style settings (like "bold", "italic").

I've tried to keep it simple and not make the 'styles' struct keep a private array of style settings. That way, you can simply append to it and operate on it as you would with any other string slice. That in turn means, that we can't guarantee any values in that array being pre-translated before output. The styles.String() method compiles all set styles, translates them and returns a semicolon-concatenated string, which gets used by 'styled'.

There's an argument to be had, that pre-translating styles upon appending them would be faster if you re-use the 'styled' struct several times. I don't see this happening in code, though, so - as mentioned - I opted for simplicity.