### PR TITLE
Changed Enter behavior in histlist- and nav-mode

### DIFF
--- a/edit/builtin-fn.go
+++ b/edit/builtin-fn.go
@@ -182,7 +182,7 @@ var defaultBindings = map[ModeType]map[Key]string{
 		Key{PageDown, 0}: "nav-page-down",
 		Key{Left, 0}:     "nav-left",
 		Key{Right, 0}:    "nav-right",
-		Key{Tab, 0}:      "nav-insert-selected",
+		Key{Enter, Alt}:  "nav-insert-selected",
 		Key{Enter, 0}:    "nav-insert-selected-and-quit",
 		Key{'H', Ctrl}:   "nav-trigger-shown-hidden",
 		Key{'F', Ctrl}:   "nav-trigger-filter",

--- a/edit/listing.go
+++ b/edit/listing.go
@@ -286,6 +286,7 @@ func addListingBuiltins(prefix string, l func(*Editor) *listing) {
 	add("page-down", func(ed *Editor) { l(ed).pageDown() })
 	add("backspace", func(ed *Editor) { l(ed).backspace() })
 	add("accept", func(ed *Editor) { l(ed).accept(ed) })
+	add("accept-close", func(ed *Editor) { l(ed).accept(ed); startInsert(ed) })
 	add("default", func(ed *Editor) { l(ed).defaultBinding(ed) })
 }
 
@@ -301,7 +302,8 @@ func addListingDefaultBindings(prefix string, m ModeType) {
 	add(Key{PageDown, 0}, "page-down")
 	add(Key{Tab, 0}, "down-cycle")
 	add(Key{Backspace, 0}, "backspace")
-	add(Key{Enter, 0}, "accept")
+	add(Key{Enter, 0}, "accept-close")
+	add(Key{Enter, Alt}, "accept")
 	add(Default, "default")
 	defaultBindings[m][Key{'[', Ctrl}] = "start-insert"
 }


### PR DESCRIPTION
Make [enter] in histlist or nav-mode return to insert-mode. Alt+Enter keeps you in the current mode.