### PR TITLE
Background processes get their own pgid

### DIFF
--- a/eval/builtin_special.go
+++ b/eval/builtin_special.go
@@ -201,7 +201,7 @@ func use(ec *EvalCtx, modname string, pfilename *string) {
 		filename, source,
 		local, Namespace{},
 		ec.ports, nil, true,
-		0, len(source), ec.addTraceback(),
+		0, len(source), ec.addTraceback(), false,
 	}
 
 	op, err := newEc.Compile(n, filename, source)

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -41,6 +41,7 @@ func (cp *compiler) pipeline(n *parse.Pipeline) OpFunc {
 		if bg {
 			ec = ec.fork("background job " + n.SourceText())
 			ec.intCh = nil
+			ec.background = true
 
 			if ec.Editor != nil {
 				// TODO: Redirect output in interactive mode so that the line

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -55,6 +55,8 @@ type EvalCtx struct {
 
 	begin, end int
 	traceback  *util.Traceback
+
+	background bool
 }
 
 func (ec *EvalCtx) falsify() {
@@ -84,7 +86,7 @@ func NewTopEvalCtx(ev *Evaler, name, text string, ports []*Port) *EvalCtx {
 		name, text,
 		ev.Global, Namespace{},
 		ports, nil, true,
-		0, len(text), nil,
+		0, len(text), nil, false,
 	}
 }
 
@@ -100,7 +102,7 @@ func (ec *EvalCtx) fork(name string) *EvalCtx {
 		ec.srcName, ec.src,
 		ec.local, ec.up,
 		newPorts, ec.positionals, true,
-		ec.begin, ec.end, ec.traceback,
+		ec.begin, ec.end, ec.traceback, ec.background,
 	}
 }
 

--- a/eval/external_cmd.go
+++ b/eval/external_cmd.go
@@ -65,7 +65,7 @@ func (e ExternalCmd) Call(ec *EvalCtx, argVals []Value, opts map[string]Value) {
 		args[i+1] = ToString(a)
 	}
 
-	sys := syscall.SysProcAttr{}
+	sys := syscall.SysProcAttr{Setpgid: ec.background}
 	attr := syscall.ProcAttr{Env: os.Environ(), Files: files[:], Sys: &sys}
 
 	path, err := ec.Search(e.Name)


### PR DESCRIPTION
This fixes SIGINT reaching and killing them even though they're in background and shouldn't be bothered.