### PR TITLE
Completion style

### DIFF
--- a/edit/completion.go
+++ b/edit/completion.go
@@ -336,7 +336,7 @@ func (comp *completion) List(width, maxHeight int) *buffer {
 				col.writePadding(completionColMarginLeft, styleForCompletion.String())
 				s := joinStyles(styleForCompletion, cands[j].display.styles)
 				if j == comp.selected {
-					s = append(s, styleForSelectedCompletion)
+					s = append(s, styleForSelectedCompletion.String())
 				}
 				col.writes(util.ForceWcwidth(cands[j].display.text, colWidth), s.String())
 				col.writePadding(completionColMarginRight, styleForCompletion.String())

--- a/edit/style.go
+++ b/edit/style.go
@@ -17,9 +17,9 @@ var (
 	styleForSideArrow        = styles{"inverse"}
 
 	// Use black text on white for completion listing.
-	styleForCompletion = styles{"black", "bg_white"}
+	styleForCompletion = styles{}
 	// Use white text on black for selected completion.
-	styleForSelectedCompletion = "inverse"
+	styleForSelectedCompletion = styles{"black", "bg_white", "bold"}
 )
 
 var styleForType = map[TokenKind]styles{

--- a/eval/builtin_special.go
+++ b/eval/builtin_special.go
@@ -201,7 +201,7 @@ func use(ec *EvalCtx, modname string, pfilename *string) {
 		filename, source,
 		local, Namespace{},
 		ec.ports, nil, true,
-		0, len(source), ec.addTraceback(),
+		0, len(source), ec.addTraceback(), false,
 	}
 
 	op, err := newEc.Compile(n, filename, source)

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -41,6 +41,7 @@ func (cp *compiler) pipeline(n *parse.Pipeline) OpFunc {
 		if bg {
 			ec = ec.fork("background job " + n.SourceText())
 			ec.intCh = nil
+			ec.background = true
 
 			if ec.Editor != nil {
 				// TODO: Redirect output in interactive mode so that the line

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -55,6 +55,8 @@ type EvalCtx struct {
 
 	begin, end int
 	traceback  *util.Traceback
+
+	background bool
 }
 
 func (ec *EvalCtx) falsify() {
@@ -84,7 +86,7 @@ func NewTopEvalCtx(ev *Evaler, name, text string, ports []*Port) *EvalCtx {
 		name, text,
 		ev.Global, Namespace{},
 		ports, nil, true,
-		0, len(text), nil,
+		0, len(text), nil, false,
 	}
 }
 
@@ -100,7 +102,7 @@ func (ec *EvalCtx) fork(name string) *EvalCtx {
 		ec.srcName, ec.src,
 		ec.local, ec.up,
 		newPorts, ec.positionals, true,
-		ec.begin, ec.end, ec.traceback,
+		ec.begin, ec.end, ec.traceback, ec.background,
 	}
 }
 

--- a/eval/external_cmd.go
+++ b/eval/external_cmd.go
@@ -65,7 +65,7 @@ func (e ExternalCmd) Call(ec *EvalCtx, argVals []Value, opts map[string]Value) {
 		args[i+1] = ToString(a)
 	}
 
-	sys := syscall.SysProcAttr{}
+	sys := syscall.SysProcAttr{Setpgid: ec.background}
 	attr := syscall.ProcAttr{Env: os.Environ(), Files: files[:], Sys: &sys}
 
 	path, err := ec.Search(e.Name)


### PR DESCRIPTION
Made remaining strings proper styles.

Slightly changed completion colors for consistency with common HIGs: bright background, darker text means current selection. I hope I'm not stepping on anyone's toe (and favourite color values) here. Eventually this should be user-configurable/-themeable - but I think sane default values / common practices are always an improvement.