### PR TITLE
Completion style

### DIFF
--- a/edit/completion.go
+++ b/edit/completion.go
@@ -336,7 +336,7 @@ func (comp *completion) List(width, maxHeight int) *buffer {
 				col.writePadding(completionColMarginLeft, styleForCompletion.String())
 				s := joinStyles(styleForCompletion, cands[j].display.styles)
 				if j == comp.selected {
-					s = append(s, styleForSelectedCompletion)
+					s = append(s, styleForSelectedCompletion.String())
 				}
 				col.writes(util.ForceWcwidth(cands[j].display.text, colWidth), s.String())
 				col.writePadding(completionColMarginRight, styleForCompletion.String())

--- a/edit/style.go
+++ b/edit/style.go
@@ -16,10 +16,10 @@ var (
 	styleForScrollBarThumb   = styles{"magenta", "inverse"}
 	styleForSideArrow        = styles{"inverse"}
 
-	// Use white text on black background for completion listing.
-	styleForCompletion = styles{"white", "bg-black"}
-	// Use black text on white background for selected completion.
-	styleForSelectedCompletion = styles{"black", "bg-white"}
+	// Use default style for completion listing
+	styleForCompletion = styles{}
+	// Use inverse style for selected completion entry
+	styleForSelectedCompletion = styles{"inverse"}
 )
 
 var styleForType = map[TokenKind]styles{

--- a/edit/style.go
+++ b/edit/style.go
@@ -16,10 +16,10 @@ var (
 	styleForScrollBarThumb   = styles{"magenta", "inverse"}
 	styleForSideArrow        = styles{"inverse"}
 
-	// Use black text on white for completion listing.
-	styleForCompletion = styles{}
-	// Use white text on black for selected completion.
-	styleForSelectedCompletion = styles{"black", "bg-white", "bold"}
+	// Use white text on black background for completion listing.
+	styleForCompletion = styles{"white", "bg-black"}
+	// Use black text on white background for selected completion.
+	styleForSelectedCompletion = styles{"black", "bg-white"}
 )
 
 var styleForType = map[TokenKind]styles{

--- a/edit/style.go
+++ b/edit/style.go
@@ -7,9 +7,9 @@ var (
 	//styleForPrompt           = ""
 	//styleForRPrompt          = "inverse"
 	styleForCompleted        = styles{"dim"}
+	styleForCompletedHistory = styles{"dim"}
 	styleForMode             = styles{"bold", "lightgray", "magenta"}
 	styleForTip              = styles{}
-	styleForCompletedHistory = styles{"dim"}
 	styleForFilter           = styles{"underlined"}
 	styleForSelected         = styles{"inverse"}
 	styleForScrollBarArea    = styles{"magenta"}
@@ -17,9 +17,9 @@ var (
 	styleForSideArrow        = styles{"inverse"}
 
 	// Use black text on white for completion listing.
-	styleForCompletion = styles{"black", "bg_white"}
+	styleForCompletion = styles{}
 	// Use white text on black for selected completion.
-	styleForSelectedCompletion = "inverse"
+	styleForSelectedCompletion = styles{"black", "bg-white", "bold"}
 )
 
 var styleForType = map[TokenKind]styles{


### PR DESCRIPTION
Made remaining strings proper styles.

Slightly changed completion colors for consistency with common HIGs: bright background, darker text means current selection. I hope I'm not stepping on anyone's toe (and favourite color values) here. Eventually this should be user-configurable/-themeable - but I think sane default values / common practices are always an improvement.