### PR TITLE
Added Editor.NotifyOnce

### DIFF
--- a/edit/builtin-fn.go
+++ b/edit/builtin-fn.go
@@ -239,5 +239,5 @@ func redraw(ed *Editor) {
 }
 
 func endOfHistory(ed *Editor) {
-	ed.Notify("End of history")
+	ed.NotifyOnce("End of history")
 }

--- a/edit/editor.go
+++ b/edit/editor.go
@@ -56,8 +56,9 @@ type editorState struct {
 
 	notificationMutex sync.Mutex
 
-	notifications []string
-	tips          []string
+	lastNotification string
+	notifications    []string
+	tips             []string
 
 	tokens  []Token
 	prompt  []*styled
@@ -141,7 +142,30 @@ func (ed *Editor) addTip(format string, args ...interface{}) {
 func (ed *Editor) Notify(format string, args ...interface{}) {
 	ed.notificationMutex.Lock()
 	defer ed.notificationMutex.Unlock()
-	ed.notifications = append(ed.notifications, fmt.Sprintf(format, args...))
+
+	s := fmt.Sprintf(format, args...)
+	ed.notifications = append(ed.notifications, s)
+	ed.lastNotification = s
+}
+
+// ClearLastNotification resets the last notification cache
+func (ed *Editor) ClearLastNotification() {
+	ed.notificationMutex.Lock()
+	defer ed.notificationMutex.Unlock()
+
+	ed.lastNotification = ""
+}
+
+// NotifyOnce will only call Notify if the notification isn't a dupe of the previous one
+func (ed *Editor) NotifyOnce(format string, args ...interface{}) {
+	ed.notificationMutex.Lock()
+	s := ed.lastNotification
+	// need to unlock before calling Notify
+	ed.notificationMutex.Unlock()
+
+	if s != fmt.Sprintf(format, args...) {
+		ed.Notify(format, args...)
+	}
 }
 
 func (ed *Editor) refresh(fullRefresh bool, tips bool) error {

--- a/edit/history.go
+++ b/edit/history.go
@@ -27,6 +27,7 @@ func (h *hist) ModeLine(width int) *buffer {
 }
 
 func startHistory(ed *Editor) {
+	ed.ClearLastNotification()
 	ed.hist.prefix = ed.line[:ed.dot]
 	ed.hist.current = -1
 	ed.hist.last = make(map[string]int)


### PR DESCRIPTION
NotifyOnce can be used to make sure we're not spamming the terminal
with dupe notifications. "End of history" notification is using
this now. Fixes #296