### PR TITLE
Solution to issue when window size equals zero

### DIFF
--- a/sys/winsize.go
+++ b/sys/winsize.go
@@ -29,5 +29,16 @@ func GetWinsize(fd int) (row, col int) {
 		fmt.Printf("error in winSize: %v", err)
 		return -1, -1
 	}
+
+	// Pick up a reasonable value for row and col
+	// if they equal zero in special case,
+	// e.g. serial console
+	if ws.col == 0 {
+		ws.col = 80
+	}
+	if ws.row == 0 {
+		ws.row = 24
+	}
+
 	return int(ws.row), int(ws.col)
 }


### PR DESCRIPTION
Weirdly, window size is determined to be zero when someone brings up elvish with a serial console. In such case, the shell only displays the last character that the user is typing in. Previous characters keep being covered by the latest one.

A simple check and valuation would let us get around such issue.

Signed-off-by: xchenan <xchenan@gmail.com>