### PR TITLE
Fix crash when display invalid history

### DIFF
--- a/edit/history/walker.go
+++ b/edit/history/walker.go
@@ -42,7 +42,7 @@ func (w *Walker) Prefix() string {
 
 // CurrentSeq returns the sequence number of the current entry.
 func (w *Walker) CurrentSeq() int {
-	if len(w.seq) > 0 && w.top <= len(w.seq) {
+	if len(w.seq) > 0 && w.top <= len(w.seq) && w.top > 0 {
 		return w.seq[w.top-1]
 	}
 	return -1
@@ -50,7 +50,7 @@ func (w *Walker) CurrentSeq() int {
 
 // CurrentSeq returns the content of the current entry.
 func (w *Walker) CurrentCmd() string {
-	if len(w.stack) > 0 && w.top <= len(w.stack) {
+	if len(w.stack) > 0 && w.top <= len(w.stack) && w.top > 0 {
 		return w.stack[w.top-1]
 	}
 	return ""

--- a/eval/embedded-modules.go
+++ b/eval/embedded-modules.go
@@ -52,7 +52,7 @@ bind-mode navigation Ctrl-N $le:nav:&down
 bind-mode navigation Ctrl-P $le:nav:&up
 bind-mode navigation Alt-f  $le:nav:&trigger-filter
 
-bind-mode history Ctrl-N $le:history:&down
+bind-mode history Ctrl-N $le:history:&down-or-quit
 bind-mode history Ctrl-P $le:history:&up
 `,
 }

--- a/eval/readline-binding.elv
+++ b/eval/readline-binding.elv
@@ -44,5 +44,5 @@ bind-mode navigation Ctrl-N $le:nav:&down
 bind-mode navigation Ctrl-P $le:nav:&up
 bind-mode navigation Alt-f  $le:nav:&trigger-filter
 
-bind-mode history Ctrl-N $le:history:&down
+bind-mode history Ctrl-N $le:history:&down-or-quit
 bind-mode history Ctrl-P $le:history:&up


### PR DESCRIPTION
When calling `$le:history:&down` at the last entry of history, current
command and sequence are supposed to be displayed, which will crash
the program since the value of `w.top` is `0`.

Changes:
  1. restrict the min value of `w.top` in `Walker.Next` call
  2. modify the default readline-binding to use `down-or-quit` instead
of `down`

Fix #358