### PR TITLE
Ignore OK when printing PipelineError

### DIFF
--- a/eval/exception.go
+++ b/eval/exception.go
@@ -47,6 +47,9 @@ func (exc *Exception) Pprint(indent string) string {
 	if pipeExcs, ok := exc.Cause.(PipelineError); ok {
 		buf.WriteString("\n" + indent + "Caused by:")
 		for _, e := range pipeExcs.Errors {
+			if e == OK {
+				continue
+			}
 			buf.WriteString("\n" + indent + "  " + e.Pprint(indent+"  "))
 		}
 	}


### PR DESCRIPTION
The program crashes when trying to print PipelineError if there's an
OK inside since its content is barely empty. Simple ignore the OK
value will fix it.

Or maybe we should print that out as well to better align with the
pipeline?