### PR TITLE
Expose histlist keybindings

### DIFF
--- a/edit/api.go
+++ b/edit/api.go
@@ -60,13 +60,14 @@ func installModules(modules map[string]eval.Namespace, ed *Editor) {
 	// Populate binding tables in the variable $binding.
 	// TODO Make binding specific to the Editor.
 	binding := &eval.Struct{
-		[]string{"insert", "command", "completion", "navigation", "history"},
+		[]string{"insert", "command", "completion", "navigation", "history", "histlist"},
 		[]eval.Variable{
 			eval.NewRoVariable(BindingTable{keyBindings[modeInsert]}),
 			eval.NewRoVariable(BindingTable{keyBindings[modeCommand]}),
 			eval.NewRoVariable(BindingTable{keyBindings[modeCompletion]}),
 			eval.NewRoVariable(BindingTable{keyBindings[modeNavigation]}),
 			eval.NewRoVariable(BindingTable{keyBindings[modeHistory]}),
+			eval.NewRoVariable(BindingTable{keyBindings[modeHistoryListing]}),
 		},
 	}
 	ns["binding"] = eval.NewRoVariable(binding)

--- a/eval/embedded-modules.go
+++ b/eval/embedded-modules.go
@@ -54,5 +54,14 @@ bind-mode navigation Alt-f  $le:nav:&trigger-filter
 
 bind-mode history Ctrl-N $le:history:&down-or-quit
 bind-mode history Ctrl-P $le:history:&up
+bind-mode history Ctrl-G $le:insert:&start
+
+bind-mode histlist Ctrl-N $le:histlist:&down
+bind-mode histlist Ctrl-P $le:histlist:&up
+bind-mode histlist Ctrl-G $le:insert:&start
+bind-mode histlist Alt-g $le:histlist:&toggle-case-sensitivity
+bind-mode histlist Alt-d $le:histlist:&toggle-dedup
+bind-mode histlist Ctrl-V $le:histlist:&page-down
+bind-mode histlist Alt-v $le:histlist:&page-up
 `,
 }

--- a/eval/readline-binding.elv
+++ b/eval/readline-binding.elv
@@ -46,3 +46,12 @@ bind-mode navigation Alt-f  $le:nav:&trigger-filter
 
 bind-mode history Ctrl-N $le:history:&down-or-quit
 bind-mode history Ctrl-P $le:history:&up
+bind-mode history Ctrl-G $le:insert:&start
+
+bind-mode histlist Ctrl-N $le:histlist:&down
+bind-mode histlist Ctrl-P $le:histlist:&up
+bind-mode histlist Ctrl-G $le:insert:&start
+bind-mode histlist Alt-g $le:histlist:&toggle-case-sensitivity
+bind-mode histlist Alt-d $le:histlist:&toggle-dedup
+bind-mode histlist Ctrl-V $le:histlist:&page-down
+bind-mode histlist Alt-v $le:histlist:&page-up


### PR DESCRIPTION
Enable keybindings for histlist to be changed by user from le:bindings
variable. Extend embedded:readline-binding with histlist as well.