### PR TITLE
Fix and cleanup.

### DIFF
--- a/edit/registry.go
+++ b/edit/registry.go
@@ -19,7 +19,9 @@ var builtinMaps = map[string]map[string]*BuiltinFn{}
 // variable initializations to make sure every subnamespace is registered before
 // makeBindings is ever called.
 func registerBuiltins(module string, impls map[string]func(*Editor)) struct{} {
-	builtinMaps[module] = make(map[string]*BuiltinFn)
+	if _, ok := builtinMaps[module]; !ok {
+		builtinMaps[module] = make(map[string]*BuiltinFn)
+	}
 	for name, impl := range impls {
 		var fullName string
 		if module == "" {
@@ -50,7 +52,9 @@ func registerBindings(
 	mt ModeType, defaultMod string,
 	bindingData map[ui.Key]string) struct{} {
 
-	bindings := map[ui.Key]eval.CallableValue{}
+	if _, ok := keyBindings[mt]; !ok {
+		keyBindings[mt] = map[ui.Key]eval.CallableValue{}
+	}
 	for key, fullName := range bindingData {
 		// break fullName into mod and name.
 		var mod, name string
@@ -62,7 +66,7 @@ func registerBindings(
 		}
 		if m, ok := builtinMaps[mod]; ok {
 			if builtin, ok := m[name]; ok {
-				bindings[key] = builtin
+				keyBindings[mt][key] = builtin
 			} else {
 				fmt.Fprintln(os.Stderr, "Internal warning: no such builtin", name, "in mod", mod)
 			}
@@ -70,7 +74,6 @@ func registerBindings(
 			fmt.Fprintln(os.Stderr, "Internal warning: no such mod:", mod)
 		}
 	}
-	keyBindings[mt] = bindings
 	return struct{}{}
 }
 

--- a/eval/readline-binding.elv
+++ b/eval/readline-binding.elv
@@ -62,8 +62,8 @@ bind-mode loc Ctrl-V $le:loc:&page-down
 bind-mode loc Alt-v $le:loc:&page-up
 bind-mode loc Ctrl-G $le:insert:&start
 
-bind-mode bang Ctrl-N $le:bang:&down
-bind-mode bang Ctrl-P $le:bang:&up
-bind-mode bang Ctrl-V $le:bang:&page-down
-bind-mode bang Alt-v $le:bang:&page-up
-bind-mode bang Ctrl-G $le:insert:&start
+bind-mode lastcmd Ctrl-N $le:lastcmd:&down
+bind-mode lastcmd Ctrl-P $le:lastcmd:&up
+bind-mode lastcmd Ctrl-V $le:lastcmd:&page-down
+bind-mode lastcmd Alt-v  $le:lastcmd:&page-up
+bind-mode lastcmd Ctrl-G $le:insert:&start


### PR DESCRIPTION
Add a PoC mode called "narrow", which tries to be a generic purpose list selection mode that can be easily extended.

Also includes fixup for "bang" to "lastcmd" renaming and register merging.
