### PR TITLE
Skipping entries leading by space when saving history

### DIFF
--- a/edit/history.go
+++ b/edit/history.go
@@ -2,6 +2,7 @@ package edit
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/elves/elvish/edit/history"
 	"github.com/elves/elvish/edit/ui"
@@ -90,6 +91,13 @@ func historyDefault(ed *Editor) {
 // Implementation.
 
 func (ed *Editor) appendHistory(line string) {
+	// TODO: should have a user variable to control the behavior
+	// Do not add command leading by space into history. This is
+	// useful for confidential operations.
+	if strings.HasPrefix(line, " ") {
+		return
+	}
+
 	if ed.daemon != nil && ed.historyFuser != nil {
 		ed.historyMutex.Lock()
 		ed.daemon.Waits().Add(1)


### PR DESCRIPTION
Although it is uncommon, sometimes people need to type confidential
stuff on command line, e.g. hash password by echoing it to a pipe.
Command lines starting with space will not be recorded into history
with this change.