### PR TITLE
Add a builtin function "builtin"

### DIFF
--- a/eval/validator.go
+++ b/eval/validator.go
@@ -3,10 +3,11 @@ package eval
 import "errors"
 
 var (
-	errShouldBeList = errors.New("should be list")
-	errShouldBeMap  = errors.New("should be map")
-	errShouldBeFn   = errors.New("should be function")
-	errShouldBeBool = errors.New("should be bool")
+	errShouldBeList   = errors.New("should be list")
+	errShouldBeMap    = errors.New("should be map")
+	errShouldBeFn     = errors.New("should be function")
+	errShouldBeBool   = errors.New("should be bool")
+	errShouldBeString = errors.New("should be string")
 )
 
 func ShouldBeList(v Value) error {
@@ -33,6 +34,13 @@ func ShouldBeFn(v Value) error {
 func ShouldBeBool(v Value) error {
 	if _, ok := v.(Bool); !ok {
 		return errShouldBeBool
+	}
+	return nil
+}
+
+func ShouldBeString(v Value) error {
+	if _, ok := v.(String); !ok {
+		return errShouldBeString
 	}
 	return nil
 }


### PR DESCRIPTION
To prevent being stuck into deadloop when shadowing builtin functions,
elvish needs to be told explicitly. The function calls its arguments
in turn except shows all the builtins when no argument is given.