### PR TITLE
Add `keys` function

### DIFF
--- a/eval/builtin_fn.go
+++ b/eval/builtin_fn.go
@@ -120,6 +120,9 @@ func init() {
 		{"wcswidth", wcswidth},
 		{"-override-wcwidth", overrideWcwidth},
 
+		// Map operations
+		{"keys", keys},
+
 		// String predicates
 		{"has-prefix", hasPrefix},
 		{"has-suffix", hasSuffix},
@@ -883,6 +886,20 @@ func overrideWcwidth(ec *EvalCtx, args []Value, opts map[string]Value) {
 	r, err := toRune(s)
 	maybeThrow(err)
 	util.OverrideWcwidth(r, w)
+}
+
+func keys(ec *EvalCtx, args []Value, opts map[string]Value) {
+	TakeNoOpt(opts)
+
+	var iter IterateKeyer
+	ScanArgs(args, &iter)
+
+	out := ec.ports[1].Chan
+
+	iter.IterateKey(func(v Value) bool {
+		out <- v
+		return true
+	})
 }
 
 func hasPrefix(ec *EvalCtx, args []Value, opts map[string]Value) {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -232,6 +232,9 @@ var evalTests = []struct {
 	{`has-prefix golang x`, bools(false), nomore},
 	{`has-suffix golang x`, bools(false), nomore},
 
+	{`keys [&]`, noout, nomore},
+	{`keys [&a=foo &b=bar] | each echo | sort | each put`, strs("a", "b"), nomore},
+
 	{`==s haha haha`, bools(true), nomore},
 	{`==s 10 10.0`, bools(false), nomore},
 	{`<s a b`, bools(true), nomore},


### PR DESCRIPTION
Yields the keys of a map value

See also #413. As @xiaq suggested there I now use `IterateKeyer` instead of `map` like I did in a previous cersion of this.

(I'm not too happy about the second test I added. Since the order of map keys are not guaranteed, I needed to sort the returned keys first with the `sort` utility.)