### PR TITLE
Fix bug when capturing output without trailing newline

### DIFF
--- a/eval/compile_value.go
+++ b/eval/compile_value.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -364,14 +363,15 @@ func pcaptureOutput(ec *EvalCtx, op Op) ([]Value, error) {
 	go func() {
 		for {
 			line, err := bufferedPipeRead.ReadString('\n')
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				// TODO report error
-				log.Println(err)
+			if line != "" {
+				ch <- String(strings.TrimSuffix(line, "\n"))
+			}
+			if err != nil {
+				if err != io.EOF {
+					logger.Println("error on reading:", err)
+				}
 				break
 			}
-			ch <- String(line[:len(line)-1])
 		}
 		bytesCollected <- true
 	}()

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -125,6 +125,7 @@ var evalTests = []struct {
 
 	// Output capture
 	{"put (put lorem ipsum)", strs("lorem", "ipsum"), nomore},
+	{"put (print \"lorem\nipsum\")", strs("lorem", "ipsum"), nomore},
 
 	// Exception capture
 	{"bool ?(nop); bool ?(e:false)", bools(true, false), nomore},


### PR DESCRIPTION
Currently, running `put (print "a\nb")` will return only `a`. The last line of output is lost if there is no trailing newline. This is not caught in existing tests because they generally use `echo`.