### PR TITLE
Throw error when builtin source failed

### DIFF
--- a/eval/builtin_fn.go
+++ b/eval/builtin_fn.go
@@ -626,7 +626,7 @@ func source(ec *EvalCtx, args []Value, opts map[string]Value) {
 	ScanArgs(args, &fname)
 	ScanOpts(opts)
 
-	ec.Source(string(fname))
+	maybeThrow(ec.Source(string(fname)))
 }
 
 // each takes a single closure and applies it to all input values.


### PR DESCRIPTION
Explicitly warn user of failure when error occur.