### PR TITLE
Enforce ICRNL on readline

### DIFF
--- a/edit/editor.go
+++ b/edit/editor.go
@@ -210,6 +210,10 @@ func setupTerminal(file *os.File) (*sys.Termios, error) {
 	term.SetVMin(1)
 	term.SetVTime(0)
 
+	// Enforcing crnl translation on readline. Assuming user won't set
+	// inlcr or -onlcr, otherwise we have to hardcode all of them here.
+	term.SetICRNL(true)
+
 	err = term.ApplyToFd(fd)
 	if err != nil {
 		return nil, fmt.Errorf("can't set up terminal attribute: %s", err)

--- a/sys/termios.go
+++ b/sys/termios.go
@@ -66,6 +66,11 @@ func (term *Termios) SetEcho(v bool) {
 	setFlag(&term.Lflag, unix.ECHO, v)
 }
 
+// SetICRNL sets the CRNL iflag bit
+func (term *Termios) SetICRNL(v bool) {
+	setFlag(&term.Iflag, unix.ICRNL, v)
+}
+
 // FlushInput discards data written to a file descriptor but not read.
 func FlushInput(fd int) error {
 	return ioctlu(uintptr(fd), flushIOCTL, uintptr(unix.TCIFLUSH))


### PR DESCRIPTION
Make readline resilient to tty changes by enforcing icrnl when it
starts.

fix #399