### PR TITLE
added a has-key and has-value builtin to test the existence of an element.

### DIFF
--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -292,6 +292,17 @@ var evalTests = []struct {
 	{`ord a`, strs("0x61"), nomore},
 	{`base 16 42 233`, strs("2a", "e9"), nomore},
 	{`wcswidth 你好`, strs("4"), nomore},
+	{`has-key [foo bar] 0`, bools(true), nomore},
+	{`has-key [foo bar] 0:1`, bools(true), nomore},
+	{`has-key [foo bar] 0:20`, bools(false), nomore},
+	{`has-key [&lorem=ipsum &foo=bar] lorem`, bools(true), nomore},
+	{`has-key [&lorem=ipsum &foo=bar] loremwsq`, bools(false), nomore},
+	{`has-value [&lorem=ipsum &foo=bar] lorem`, bools(false), nomore},
+	{`has-value [&lorem=ipsum &foo=bar] bar`, bools(true), nomore},
+	{`has-value [foo bar] bar`, bools(true), nomore},
+	{`has-value [foo bar] badehose`, bools(false), nomore},
+	{`has-value "foo" o`, bools(true), nomore},
+	{`has-value "foo" d`, bools(false), nomore},
 }
 
 func strs(ss ...string) []Value {


### PR DESCRIPTION
This works with maps and every iterable type.

```
~/go/src/github.com/elves/elvish> contains [1 2 "3"] 2
▶ $true
~/go/src/github.com/elves/elvish> contains [1 2 "3"] 5
▶ $false
~/go/src/github.com/elves/elvish> contains [&foo=bar &lorem=ipsum] "lorem"
▶ $true
~/go/src/github.com/elves/elvish> contains "hallo" "o"
▶ $true

```

@xiaq what do you think?

fixes #407 #398