### PR TITLE
Add user-defined 'matcher' interface

### DIFF
--- a/edit/candidate.go
+++ b/edit/candidate.go
@@ -81,15 +81,3 @@ func outputComplexCandidate(ec *eval.EvalCtx,
 
 	ec.OutputChan() <- c
 }
-
-func cookCandidates(raws []rawCandidate, pattern string,
-	match func(string, string) bool, q parse.PrimaryType) []*candidate {
-
-	var cooked []*candidate
-	for _, raw := range raws {
-		if match(raw.text(), pattern) {
-			cooked = append(cooked, raw.cook(q))
-		}
-	}
-	return cooked
-}

--- a/edit/completion.go
+++ b/edit/completion.go
@@ -215,9 +215,11 @@ func startCompletionInner(ed *Editor, acceptPrefix bool) {
 					break
 				}
 			}
-			if prefix != "" && prefix != ed.line[complSpec.begin:complSpec.end] {
+
+			if prefix != "" && len(prefix) > complSpec.end-complSpec.begin {
 				ed.line = ed.line[:complSpec.begin] + prefix + ed.line[complSpec.end:]
 				ed.dot = complSpec.begin + len(prefix)
+
 				return
 			}
 		}

--- a/edit/matcher.go
+++ b/edit/matcher.go
@@ -1,24 +1,80 @@
 package edit
 
 import (
+	"errors"
+	"os"
 	"strings"
 
 	"github.com/elves/elvish/eval"
-	"github.com/elves/elvish/util"
+	"github.com/elves/elvish/parse"
 )
 
-var _ = registerVariable("-use-subseq-matcher", func() eval.Variable {
-	return eval.NewPtrVariableWithValidator(eval.Bool(false), eval.ShouldBeBool)
+var (
+	errIncorrectNumOfResults = errors.New("matcher must return a bool for each candidate")
+	errMatcherMustBeFn       = errors.New("matcher must be a function")
+)
+
+var prefixMatcher = eval.BuiltinFn{"prefixMatcher", func(ec *eval.EvalCtx,
+	args []eval.Value, opts map[string]eval.Value) {
+	out := ec.OutputChan()
+	var pattern eval.String
+	var candidates eval.List
+	eval.ScanArgs(args, &pattern, &candidates)
+
+	candidates.Iterate(func(cand eval.Value) bool {
+		candidate := eval.ToString(cand)
+
+		out <- eval.Bool(strings.HasPrefix(candidate, string(pattern)))
+		return true
+	})
+}}
+
+var _ = registerVariable("-matcher", func() eval.Variable {
+	m := map[eval.Value]eval.Value{
+		eval.String("index"):    eval.CallableValue(&prefixMatcher),
+		eval.String("redirect"): eval.CallableValue(&prefixMatcher),
+		eval.String("argument"): eval.CallableValue(&prefixMatcher),
+		eval.String("variable"): eval.CallableValue(&prefixMatcher),
+		eval.String("command"):  eval.CallableValue(&prefixMatcher),
+	}
+	return eval.NewPtrVariableWithValidator(eval.NewMap(m), eval.ShouldBeMap)
 })
 
-func (ed *Editor) useSubseqMatcher() bool {
-	return bool(ed.variables["-use-subseq-matcher"].Get().(eval.Bool).Bool())
-}
+func (ed *Editor) filterAndCookCandidates(ev *eval.Evaler, completer string, pattern string,
+	cands []rawCandidate, q parse.PrimaryType) ([]*candidate, error) {
 
-func (ed *Editor) matcher() func(string, string) bool {
-	if ed.useSubseqMatcher() {
-		return util.HasSubseq
-	} else {
-		return strings.HasPrefix
+	var filtered []*candidate
+	matcher := ed.variables["-matcher"].Get().(eval.Map).IndexOne(eval.String(completer))
+	m, ok := matcher.(eval.CallableValue)
+	if !ok {
+		return nil, errMatcherMustBeFn
 	}
+
+	ports := []*eval.Port{
+		eval.DevNullClosedChan, {File: os.Stdout}, {File: os.Stderr}}
+	ec := eval.NewTopEvalCtx(ev, "[editor matcher]", "", ports)
+
+	var candValues []eval.Value
+	patternValue := eval.String(pattern)
+
+	for _, cand := range cands {
+		candValues = append(candValues, eval.String(cand.text()))
+	}
+
+	args := []eval.Value{
+		patternValue,
+		eval.NewList(candValues...),
+	}
+	values, err := ec.PCaptureOutput(m, args, eval.NoOpts)
+	if err != nil {
+		return nil, err
+	} else if len(values) != len(candValues) {
+		return nil, errIncorrectNumOfResults
+	}
+	for i, value := range values {
+		if eval.ToBool(value) {
+			filtered = append(filtered, cands[i].cook(q))
+		}
+	}
+	return filtered, nil
 }

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -465,6 +465,16 @@ func linesToChan(r io.Reader, ch chan<- Value) {
 	}
 }
 
+// InputChan returns a channel from which input can be read.
+func (ec *EvalCtx) InputChan() chan Value {
+	return ec.ports[0].Chan
+}
+
+// InputFile returns a file from which input can be read.
+func (ec *EvalCtx) InputFile() *os.File {
+	return ec.ports[0].File
+}
+
 // OutputChan returns a channel onto which output can be written.
 func (ec *EvalCtx) OutputChan() chan<- Value {
 	return ec.ports[1].Chan


### PR DESCRIPTION
This PR adds a user-defined 'matcher' interface. Generally, the idea is to implement a user-defined map of functions that are used as the filters for commands, arguments, variables, redirects, and indexes. Currently, there are two 'global' matchers, the default 'prefix matcher' and the 'subsequence matcher' that can be activated by setting `-use-subseq-matcher`. 

With this patch, you can, for example, allow case-independent completion for variables by setting:
    
    edit:-matcher[variable] = [pattern]{ each [cand]{
        put (re:match '(?i)^'$pattern $cand)
      }
    }
Note that the matcher is passed the pattern it match against as an argument. Completions can be read from the input stream. It must return a bool for each completion, indicating whether it is an acceptable match for `pattern`.

This interface is somewhat less intuitive than the callback being per-candidate, but has much better performance (especially for the builtin matcher). This PR should close #433, #228, and possibly #396 