### PR TITLE
Add eval.ScanIntoOpts and minor changes to narrow mode

### DIFF
--- a/edit/narrow.go
+++ b/edit/narrow.go
@@ -111,6 +111,10 @@ func (l *narrow) CursorOnModeLine() bool {
 }
 
 func (l *narrow) List(maxHeight int) renderer {
+	if l.opts.MaxLines > 0 && l.opts.MaxLines < maxHeight {
+		maxHeight = l.opts.MaxLines
+	}
+
 	if l.filtered == nil {
 		l.refresh()
 	}
@@ -347,6 +351,7 @@ type narrowOptions struct {
 	IgnoreDuplication bool     `name:"ignore-duplication"`
 	IgnoreCase        bool     `name:"ignore-case"`
 	KeepBottom        bool     `name:"keep-bottom"`
+	MaxLines          int      `name:"max-lines"`
 	Modeline          string   `name:"modeline"`
 
 	bindingMap map[ui.Key]eval.CallableValue

--- a/edit/narrow.go
+++ b/edit/narrow.go
@@ -39,21 +39,6 @@ var _ = registerBuiltins(modeNarrow, map[string]func(*Editor){
 
 func init() {
 	registerBindings(modeNarrow, modeNarrow, nil)
-	// registerBindings(modeNarrow, modeNarrow, map[ui.Key]string{
-	// 	ui.Key{ui.Up, 0}:         "up",
-	// 	ui.Key{ui.PageUp, 0}:     "page-up",
-	// 	ui.Key{ui.Down, 0}:       "down",
-	// 	ui.Key{ui.PageDown, 0}:   "page-down",
-	// 	ui.Key{ui.Tab, 0}:        "down-cycle",
-	// 	ui.Key{ui.Tab, ui.Shift}: "up-cycle",
-	// 	ui.Key{ui.Backspace, 0}:  "backspace",
-	// 	ui.Key{ui.Enter, 0}:      "accept-close",
-	// 	ui.Key{ui.Enter, ui.Alt}: "accept",
-	// 	ui.Default:               "default",
-	// 	ui.Key{'[', ui.Ctrl}:     "insert:start",
-	// 	ui.Key{'G', ui.Ctrl}:     "toggle-ignore-case",
-	// 	ui.Key{'D', ui.Ctrl}:     "toggle-ignore-duplication",
-	// })
 }
 
 // narrow implements a listing mode that supports the notion of selecting an


### PR DESCRIPTION
eval.ScanIntoOpts is similar to eval.ScanOpts, instead of specifying
each option separately, it accepts an option struct and parse the
options according the struct internally.

Options organized as a group in a struct is more readable and could be
extend in the future if the calling function requires many.