### PR TITLE
Fix crash in re:find with some patterns

### DIFF
--- a/eval/re/re.go
+++ b/eval/re/re.go
@@ -67,8 +67,14 @@ func find(ec *eval.EvalCtx, args []eval.Value, opts map[string]eval.Value) {
 		groups := vector.Empty
 		for i := 0; i < len(match); i += 2 {
 			start, end := match[i], match[i+1]
+			var text eval.Variable
+			if start < 0 || end < 0 {
+				text = eval.NewRoVariable(eval.String(""))
+			} else {
+				text = eval.NewRoVariable(argSource[start:end])
+			}
 			groups = groups.Cons(&eval.Struct{submatchFields, []eval.Variable{
-				eval.NewRoVariable(argSource[start:end]),
+				text,
 				eval.NewRoVariable(eval.String(strconv.Itoa(start))),
 				eval.NewRoVariable(eval.String(strconv.Itoa(end))),
 			}})


### PR DESCRIPTION
Currently `re:find` will crash with some (uncommon) regexs. For example:

    put (re:find 'A(B)*' 'A')

This happens because `FindAllSubmatchIndex` can return negative values which are then used to index in to the text. Now, `re:find` just lets the submatch text="" in such cases.