### PR TITLE
fix crash on variable completion

### DIFF
--- a/edit/completers.go
+++ b/edit/completers.go
@@ -385,7 +385,7 @@ func findRedirContext(n parse.Node) (int, int, string, parse.PrimaryType) {
 // the actual completion work to a suitable completer.
 func complArg(n parse.Node, ev *eval.Evaler) (*complSpec, error) {
 	begin, end, current, q, form := findArgContext(n)
-	if begin == -1 {
+	if begin == -1 || form.Head == nil {
 		return nil, errCompletionUnapplicable
 	}
 


### PR DESCRIPTION
Completion on variable like `m =<tab>` will crash:

```
runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
github.com/elves/elvish/sys.DumpStack(0xc4201310a0, 0x1)
        /home/tw/golib/src/github.com/elves/elvish/sys/dumpstack.go:7 +0xa7
github.com/elves/elvish/shell.rescue()
        /home/tw/golib/src/github.com/elves/elvish/shell/shell.go:68 +0xd2
panic(0x936000, 0xe46060)
        /home/tw/goroot/src/runtime/panic.go:489 +0x25a
github.com/elves/elvish/edit/nodeutil.SimpleCompound(0x0, 0x0, 0x432486, 0x9e2608, 0x3, 0xc4201be360, 0xc4201ba680)
        /home/tw/golib/src/github.com/elves/elvish/edit/nodeutil/nodeutil.go:14 +0x2c
github.com/elves/elvish/edit.simpleCompound(0x0, 0x0, 0x3, 0x3, 0x0, 0x0, 0x1)
        /home/tw/golib/src/github.com/elves/elvish/edit/nodeutil.go:30 +0x35
github.com/elves/elvish/edit.complArg(0xe60620, 0xc420136500, 0xc42014c1e0, 0x1, 0xe576e0, 0xc4201380f0)
        /home/tw/golib/src/github.com/elves/elvish/edit/completers.go:394 +0xbe
github.com/elves/elvish/edit.complete(0xe60620, 0xc420136500, 0xc42014c1e0, 0xe60620, 0xc420136500, 0x4, 0x4, 0x120454000)
        /home/tw/golib/src/github.com/elves/elvish/edit/completers.go:86 +0x8f
github.com/elves/elvish/edit.startCompletionInner(0xc4200978c0, 0xc420131601)
        /home/tw/golib/src/github.com/elves/elvish/edit/completion.go:192 +0xa1
github.com/elves/elvish/edit.complSmartStart(0xc4200978c0)
        /home/tw/golib/src/github.com/elves/elvish/edit/completion.go:85 +0x30
github.com/elves/elvish/edit.(*Editor).CallFn(0xc4200978c0, 0xe5d4e0, 0xc42013e0e0, 0x0, 0x0, 0x0)
        /home/tw/golib/src/github.com/elves/elvish/edit/api.go:146 +0x5d7
github.com/elves/elvish/edit.(*Editor).ReadLine(0xc4200978c0, 0x0, 0x0, 0x0, 0x0)
        /home/tw/golib/src/github.com/elves/elvish/edit/editor.go:448 +0x8a8
github.com/elves/elvish/shell.interact.func1(0x94d880, 0xc420248240, 0x17, 0x9c1501)
        /home/tw/golib/src/github.com/elves/elvish/shell/shell.go:128 +0x2a
github.com/elves/elvish/shell.interact(0xc42014c1e0, 0xc420134d50)
        /home/tw/golib/src/github.com/elves/elvish/shell/shell.go:139 +0x148
github.com/elves/elvish/shell.(*Shell).Run(0xc420131f18, 0xc4200101a0, 0x0, 0x0, 0x0)
        /home/tw/golib/src/github.com/elves/elvish/shell/shell.go:57 +0x191
main.main()
        /home/tw/golib/src/github.com/elves/elvish/main.go:143 +0x477
```