### PR TITLE
support completion with variable

### DIFF
--- a/edit/highlight/emitter.go
+++ b/edit/highlight/emitter.go
@@ -83,7 +83,7 @@ func (e *Emitter) form(n *parse.Form) {
 }
 
 func (e *Emitter) formHead(n *parse.Compound) {
-	simple, head, err := nodeutil.SimpleCompound(n, nil)
+	simple, head, err := nodeutil.SimpleCompound(n, nil, nil)
 	st := ui.Styles{}
 	if simple {
 		if e.GoodFormHead(head) {

--- a/edit/nodeutil/nodeutil.go
+++ b/edit/nodeutil/nodeutil.go
@@ -4,11 +4,14 @@ package nodeutil
 import (
 	"strings"
 
+	"github.com/elves/elvish/eval"
 	"github.com/elves/elvish/parse"
 	"github.com/elves/elvish/util"
 )
 
-func SimpleCompound(cn *parse.Compound, upto *parse.Indexing) (bool, string, error) {
+var logger = util.GetLogger("[nodeutil] ")
+
+func SimpleCompound(cn *parse.Compound, upto *parse.Indexing, ev *eval.Evaler) (bool, string, error) {
 	tilde := false
 	head := ""
 	for _, in := range cn.Indexings {
@@ -20,6 +23,16 @@ func SimpleCompound(cn *parse.Compound, upto *parse.Indexing) (bool, string, err
 			tilde = true
 		case parse.Bareword, parse.SingleQuoted, parse.DoubleQuoted:
 			head += in.Head.Value
+		case parse.Variable:
+			if ev == nil {
+				return false, "", nil
+			}
+			v := PurelyEvalPrimary(in.Head, ev)
+			if s, ok := v.(eval.String); ok {
+				head += string(s)
+			} else {
+				return false, "", nil
+			}
 		default:
 			return false, "", nil
 		}
@@ -41,4 +54,24 @@ func SimpleCompound(cn *parse.Compound, upto *parse.Indexing) (bool, string, err
 		head = home + head[i:]
 	}
 	return true, head, nil
+}
+
+// PurelyEvalPrimary evaluates a primary node without causing any side effects.
+// If this cannot be done, it returns nil.
+//
+// Currently, only string literals and variables with no @ can be evaluated.
+func PurelyEvalPrimary(pn *parse.Primary, ev *eval.Evaler) eval.Value {
+	switch pn.Type {
+	case parse.Bareword, parse.SingleQuoted, parse.DoubleQuoted:
+		return eval.String(pn.Value)
+	case parse.Variable:
+		explode, ns, name := eval.ParseVariable(pn.Value)
+		if explode {
+			return nil
+		}
+		ec := eval.NewTopEvalCtx(ev, "[pure eval]", "", nil)
+		variable := ec.ResolveVar(ns, name)
+		return variable.Get()
+	}
+	return nil
 }


### PR DESCRIPTION
`ls $E:GOROOT/<tab>` should work now.

Signed-off-by: Tw <tw19881113@gmail.com>