### PR TITLE
Enable build on more platforms

### DIFF
--- a/sys/select_32.go
+++ b/sys/select_32.go
@@ -1,4 +1,4 @@
-// +build darwin 386,linux arm,linux netbsd openbsd
+// +build darwin 386,linux arm,linux mips,linux mipsle,linux
 
 // The type of FdSet.Bits is different on different platforms.
 // This file is for those where FdSet.Bits is []int32.

--- a/sys/select_64.go
+++ b/sys/select_64.go
@@ -1,4 +1,5 @@
-// +build amd64,dragonfly amd64,linux arm64,linux
+// +build linux
+// +build amd64 arm64 mips64 mips64le ppc64 ppc64le s390x
 
 // The type of FdSet.Bits is different on different platforms.
 // This file is for those where FdSet.Bits is []int64.

--- a/sys/select_u32.go
+++ b/sys/select_u32.go
@@ -1,7 +1,7 @@
-// +build arm,freebsd 386,freebsd
+// +build netbsd openbsd arm,freebsd 386,freebsd
 
 // The type of FdSet.Bits is different on different platforms.
-// This file is for FreeBSD where FdSet.Bits is actually X__fds_bits and it's []uint32.
+// This file is for those where FdSet.Bits is []uint32.
 
 package sys
 

--- a/sys/select_u64.go
+++ b/sys/select_u64.go
@@ -1,7 +1,7 @@
-// +build amd64,freebsd arm64,freebsd
+// +build dragonfly amd64,freebsd arm64,freebsd
 
 // The type of FdSet.Bits is different on different platforms.
-// This file is for FreeBSD where FdSet.Bits is actually X__fds_bits and it's []uint64.
+// This file is for those where FdSet.Bits is []int64.
 
 package sys
 

--- a/sys/termios_32.go
+++ b/sys/termios_32.go
@@ -1,4 +1,4 @@
-// +build 386,darwin dragonfly freebsd linux netbsd openbsd
+// +build 386,darwin arm,darwin dragonfly freebsd linux netbsd openbsd
 
 package sys
 

--- a/sys/termios_64.go
+++ b/sys/termios_64.go
@@ -1,4 +1,4 @@
-// +build amd64,darwin
+// +build amd64,darwin arm64,darwin
 
 package sys
 


### PR DESCRIPTION
Since we get rid of sqlite3, now we can easily build elvish on more platforms.

This commit is tested by the following script:

https://gist.github.com/zhsj/74489e93b60ec35261f9877f769b4b8c

Tests results are also attatched.

For darwin,{arm,arm64}, go cross build failed with:

```
# github.com/elves/elvish
warning: unable to find runtime/cgo.a
/usr/lib/go-1.8/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: unrecognized option '-pagezero_size'
/usr/bin/ld: use the --help option for usage information
collect2: error: ld returned 1 exit status
```
So these platforms are unknown whether it can be built or not.