### PR TITLE
Highlight and complete builtin like other namespaces

### DIFF
--- a/edit/completers.go
+++ b/edit/completers.go
@@ -155,7 +155,7 @@ func hasProperPrefix(s, p string) bool {
 func iterateVariables(ev *eval.Evaler, ns string, f func(string)) {
 	switch ns {
 	case "":
-		for varname := range ev.Builtin {
+		for varname := range ev.Builtin() {
 			f(varname)
 		}
 		for varname := range ev.Global {

--- a/edit/highlight.go
+++ b/edit/highlight.go
@@ -29,7 +29,7 @@ func goodFormHead(head string, ed *Editor) bool {
 		if !explode {
 			switch ns {
 			case "":
-				if ev.Builtin[eval.FnPrefix+name] != nil || ev.Global[eval.FnPrefix+name] != nil {
+				if ev.Builtin()[eval.FnPrefix+name] != nil || ev.Global[eval.FnPrefix+name] != nil {
 					return true
 				}
 			case "e":


### PR DESCRIPTION
Currently, builtin functions can be accessed in the shell like `builtin:cd`. However, these functions won't be highlighted correctly, and the builtin namespace is not used in completions (so `built<tab>` will not complete to `builtin:`). With this PR, the builtin namespace is treated like other namespaces for the purposes of completion and highlighting.