### PR TITLE
Add poller interface for read and write event

### DIFF
--- a/sys/poller.go
+++ b/sys/poller.go
@@ -1,0 +1,57 @@
+// +build !windows
+
+package sys
+
+import "syscall"
+
+type Poller struct {
+	rdset *FdSet
+	wdset *FdSet
+	maxfd int
+	rfds  []int
+	wfds  []int
+}
+
+func max(a, b int) int {
+	if a < b {
+		return b
+	}
+	return a
+}
+
+func (poller *Poller) Init(rfds []uintptr, wfds []uintptr) error {
+	poller.rdset = NewFdSet()
+	poller.wdset = NewFdSet()
+	poller.maxfd = -1
+	for _, rfd := range rfds {
+		poller.rfds = append(poller.rfds, int(rfd))
+		poller.maxfd = max(poller.maxfd, int(rfd))
+	}
+	for _, wfd := range wfds {
+		poller.wfds = append(poller.wfds, int(wfd))
+		poller.maxfd = max(poller.maxfd, int(wfd))
+	}
+	return nil
+}
+
+func (poller *Poller) Poll(timeout *syscall.Timeval) (*[]uintptr, *[]uintptr, error) {
+	poller.rdset.Set(poller.rfds...)
+	poller.wdset.Set(poller.wfds...)
+	err := Select(poller.maxfd+1, poller.rdset, poller.wdset, nil, timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	rfds := []uintptr{}
+	wfds := []uintptr{}
+	for _, rfd := range poller.rfds {
+		if poller.rdset.IsSet(rfd) {
+			rfds = append(rfds, uintptr(rfd))
+		}
+	}
+	for _, wfd := range poller.wfds {
+		if poller.rdset.IsSet(wfd) {
+			wfds = append(wfds, uintptr(wfd))
+		}
+	}
+	return &rfds, &wfds, nil
+}

--- a/sys/poller_test.go
+++ b/sys/poller_test.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+package sys
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestPoller(t *testing.T) {
+	var p1, p2 [2]int
+	mustNil(syscall.Pipe(p1[:]))
+	mustNil(syscall.Pipe(p2[:]))
+	poller := Poller{}
+	poller.Init([]uintptr{uintptr(p1[0]), uintptr(p2[0])}, []uintptr{})
+	go func() {
+		syscall.Write(p1[1], []byte("to p1"))
+		syscall.Write(p2[1], []byte("to p2"))
+		syscall.Close(p1[1])
+		syscall.Close(p2[1])
+	}()
+	_, _, e := poller.Poll(nil)
+	if e != nil {
+		t.Errorf("Poll(nil) => %v, want <nil>", e)
+	}
+	syscall.Close(p1[0])
+	syscall.Close(p2[0])
+}

--- a/sys/poller_windows.go
+++ b/sys/poller_windows.go
@@ -1,0 +1,103 @@
+// +build windows
+
+package sys
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	INFINITE uint32 = 0xFFFFFFFF
+)
+
+const (
+	MAXIMUM_WAIT_OBJECTS int = 64
+)
+
+const (
+	WAIT_OBJECT_0    uint32 = 0
+	WAIT_ABANDONED_0 uint32 = 0x00000080
+	WAIT_TIMEOUT     uint32 = 0x00000102
+	WAIT_FAILED      uint32 = 0xFFFFFFFF
+)
+
+var (
+	kernel32, _               = syscall.LoadLibrary("kernel32.dll")
+	waitForMultipleObjects, _ = syscall.GetProcAddress(kernel32, "WaitForMultipleObjects")
+)
+
+func boolToUint32(b bool) uint32 {
+	if b {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+// DWORD WINAPI WaitForMultipleObjects(
+//   _In_       DWORD  nCount,
+//   _In_ const HANDLE *lpsyscall.Handles,
+//   _In_       BOOL   bWaitAll,
+//   _In_       DWORD  dwMilliseconds
+// );
+func WaitForMultipleObjects(handles *[]syscall.Handle, waitAll bool, milliseconds uint32) (handle syscall.Handle, err error) {
+	count := uint32(len(*handles))
+	r1, _, e1 := syscall.Syscall6(waitForMultipleObjects, 4, uintptr(count), uintptr(unsafe.Pointer(handles)), uintptr(boolToUint32(waitAll)), uintptr(milliseconds), 0, 0)
+	if e1 != 0 {
+		return syscall.Handle(syscall.InvalidHandle), e1
+	}
+	ret := uint32(r1)
+	if WAIT_OBJECT_0 <= ret && ret <= WAIT_OBJECT_0+count-1 {
+		return syscall.Handle((*handles)[ret-WAIT_OBJECT_0]), nil
+	}
+	return syscall.Handle(syscall.InvalidHandle), errors.New("timeout")
+}
+
+type Poller struct {
+	rfds []syscall.Handle
+	wfds []syscall.Handle
+}
+
+// TODO better option is IOCP
+func (poller *Poller) Init(rfds []uintptr, wfds []uintptr) error {
+	for _, rfd := range rfds {
+		poller.rfds = append(poller.rfds, syscall.Handle(rfd))
+	}
+	for _, wfd := range wfds {
+		poller.wfds = append(poller.wfds, syscall.Handle(wfd))
+	}
+	return nil
+}
+
+// WaitForMultipleObjects is O(n) and limited by MAXIMUM_WAIT_OBJECTS
+func (poller *Poller) Poll(timeout *syscall.Timeval) (*[]uintptr, *[]uintptr, error) {
+	var milliseconds uint32
+	if timeout == nil || uint64(timeout.Sec*1000+timeout.Usec/1000) > uint64(INFINITE) {
+		milliseconds = INFINITE
+	} else {
+		milliseconds = uint32(timeout.Sec*1000 + timeout.Usec/1000)
+	}
+	handles := append(poller.rfds, poller.wfds...)
+	handle, err := WaitForMultipleObjects(&handles, false, milliseconds)
+	if err != nil {
+		return nil, nil, err
+	}
+	// this method is not truely trust, fd may be in both set
+	rfds := []uintptr{}
+	wfds := []uintptr{}
+	for _, rfd := range poller.rfds {
+		if rfd == handle {
+			rfds = append(rfds, uintptr(handle))
+			break
+		}
+	}
+	for _, wfd := range poller.wfds {
+		if wfd == handle {
+			wfds = append(wfds, uintptr(handle))
+			break
+		}
+	}
+	return &rfds, &wfds, nil
+}

--- a/sys/select.go
+++ b/sys/select.go
@@ -1,4 +1,4 @@
-// +build !freebsd
+// +build !freebsd,!windows
 
 package sys
 

--- a/sys/select_test.go
+++ b/sys/select_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package sys
 
 import (


### PR DESCRIPTION
we can replace WaitForMultipleObjects with IOCP easily if it is
also suitable for console input event.

It is an early attempt to porting to windows resolving IO multiplexing on input events(Refer to #168). There are many tasks left though.