### PR TITLE
Changed default shortcut for location mode to Ctrl-/

### DIFF
--- a/edit/insert.go
+++ b/edit/insert.go
@@ -91,7 +91,7 @@ func init() {
 		{'N', ui.Ctrl}: "navigation:start",
 		{'R', ui.Ctrl}: "histlist:start",
 		{'1', ui.Alt}:  "lastcmd:start",
-		{'L', ui.Ctrl}: "location:start",
+		{'/', ui.Ctrl}: "location:start",
 		{'V', ui.Ctrl}: "insert-raw",
 
 		ui.Default: "insert:default",


### PR DESCRIPTION
The previous default was Ctrl-L, which is commonly used for
clearing the terminal. As discussed with xiaq, Ctrl-/ is a
nice alternative which doesn't clash with any existing user
expectations.