### PR TITLE
Add cgo version IsATTY back

### DIFF
--- a/sys/isatty.go
+++ b/sys/isatty.go
@@ -1,3 +1,5 @@
+// +build !cgo
+
 package sys
 
 import (

--- a/sys/isatty_cgo.go
+++ b/sys/isatty_cgo.go
@@ -1,0 +1,12 @@
+// +build cgo
+
+package sys
+
+/*
+#include <unistd.h>
+*/
+import "C"
+
+func IsATTY(fd int) bool {
+	return C.isatty(C.int(fd)) != 0
+}


### PR DESCRIPTION
At ppc64le, mattn/go-isatty failed to work. So add the cgo's
version back and let people choose if they need cgo.

On ppc64le, mattn/go-isatty.IsTerminal call

`syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)`

but this sycall returns `inappropriate ioctl for device` if the fd is 0,
which should be a tty.

Signed-off-by: Shengjing Zhu <i@zhsj.me>