### PR TITLE
Add -version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ PKG_BASE := github.com/elves/elvish
 PKGS := $(shell go list ./... | grep -v /vendor/)
 PKG_COVERS := $(shell go list ./... | grep -v '^$(PKG_BASE)/vendor/' | grep -v '^$(PKG_BASE)$$' | sed "s|^$(PKG_BASE)/|cover/|" | sed 's/$$/.cover/')
 COVER_MODE := set
+VERSION := $(shell git describe --tags --always)
 
 FIRST_GOPATH=$(shell go env GOPATH | cut -d: -f1)
 
 default: get test
 
 get:
-	go get .
+	go get -ldflags "-X main.Version=$(VERSION)" .
 
 generate:
 	go generate ./...

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ import (
 	"github.com/elves/elvish/web"
 )
 
+var Version = "unknown"
+
 // defaultPort is the default port on which the web interface runs. The number
 // is chosen because it resembles "elvi".
 const defaultWebPort = 3171
@@ -38,7 +40,8 @@ var logger = util.GetLogger("[main] ")
 
 var (
 	// Flags handled in this package, or common to shell and daemon.
-	help = flag.Bool("help", false, "show usage help and quit")
+	help        = flag.Bool("help", false, "show usage help and quit")
+	showVersion = flag.Bool("version", false, "show version and quit")
 
 	logpath     = flag.String("log", "", "a file to write debug log to")
 	cpuprofile  = flag.String("cpuprofile", "", "write cpu profile to file")
@@ -78,6 +81,12 @@ func main() {
 		usage()
 		return
 	}
+
+	if *showVersion {
+		fmt.Println(Version)
+		return
+	}
+
 	if *isdaemon && len(args) > 0 {
 		// The daemon takes no argument.
 		usage()


### PR DESCRIPTION
People install with go get, will show version unknown
But if they install from prebuilt, make get, they will
known their version

Closes: #279

Signed-off-by: Shengjing Zhu <i@zhsj.me>