### PR TITLE
Send SIGHUP to process group when SIGHUP is received

### DIFF
--- a/edit/editor.go
+++ b/edit/editor.go
@@ -4,6 +4,7 @@ package edit
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"syscall"
@@ -372,6 +373,8 @@ MainLoop:
 		case sig := <-ed.sigs:
 			// TODO(xiaq): Maybe support customizable handling of signals
 			switch sig {
+			case syscall.SIGHUP:
+				return "", io.EOF
 			case syscall.SIGINT:
 				// Start over
 				ed.editorState = editorState{

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -199,6 +199,10 @@ func handleSignals() {
 	go func() {
 		for sig := range sigs {
 			logger.Println("signal", sig)
+			if sig == syscall.SIGHUP {
+				syscall.Kill(0, syscall.SIGHUP)
+				os.Exit(0)
+			}
 			if sig == syscall.SIGQUIT || sig == syscall.SIGUSR1 {
 				fmt.Print(sys.DumpStack())
 			}


### PR DESCRIPTION
> If the process is a controlling process, the SIGHUP signal shall be sent to each process in the foreground process group of the controlling terminal belonging to the calling process.

The solution works but I don't think this is the right one. I'll put it here in case there are comments. I will look at what other shell do tomorrow.