### PR TITLE
Handle ^H on backspace (again)

### DIFF
--- a/edit/insert.go
+++ b/edit/insert.go
@@ -72,8 +72,8 @@ func init() {
 		{'W', ui.Ctrl}:    "kill-word-left",
 		{ui.Backspace, 0}: "kill-rune-left",
 		// Some terminal send ^H on backspace
-		// ui.Key{'H', ui.Ctrl}: "kill-rune-left",
-		{ui.Delete, 0}: "kill-rune-right",
+		ui.Key{'H', ui.Ctrl}: "kill-rune-left",
+		{ui.Delete, 0}:       "kill-rune-right",
 		// Inserting.
 		{'.', ui.Alt}:      "insert-last-word",
 		{ui.Enter, ui.Alt}: "insert-key",


### PR DESCRIPTION
It seems that this line got commented out somewhere in refactoring process.
Refixes https://github.com/elves/elvish/issues/55. This seems to conflict with https://github.com/elves/elvish/issues/339 but I don't see any reason why this code could  be deliberately commented out. :man_shrugging: 

Sidenote: my term is `st`.