### PR TITLE
Runtime fix for #402

### DIFF
--- a/program/clientcommon/runtime.go
+++ b/program/clientcommon/runtime.go
@@ -65,6 +65,14 @@ func InitRuntime(binpath, sockpath, dbpath string) *eval.Evaler {
 			version, err := cl.Version()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "warning: socket exists but not responding version RPC:", err)
+				fmt.Fprintln(os.Stderr, "warning: removing ", sockpath, " and restarting daemon !")
+				err3 := os.Remove(sockpath) // If the sock file exists , but doesn't have a daemon attached to it , remove it .
+				if err3 != nil {
+					fmt.Fprintln(os.Stderr, "warning: deletion of", sockpath, " failed! \n warning: remove it manually for the daemon to work correctly !", err3)
+				}
+				fmt.Fprintln(os.Stderr, "[!]attempting to restart daemon .")
+				InitRuntime(toSpawn.BinPath, toSpawn.SockPath, toSpawn.DbPath)
+				fmt.Fprintln(os.Stderr, "[!]daemon successfully restarted .")
 				// TODO(xiaq): Remove this when the SQLite-backed database
 				// becomes an unmemorable past (perhaps 6 months after the
 				// switch to boltdb).


### PR DESCRIPTION
This only fixes #402 at runtime level , meaning that in order to restart the daemon you have to start another instance of an elvish client .