### PR TITLE
File-based epm implementation

### DIFF
--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -119,14 +119,21 @@ fn -package-without-domain [pkg]{
   ]
 ]
 
+# Return the filename of the domain config file for the given domain
+# (regardless of whether it exists)
 fn -domain-config-file [dom]{
   put $-lib-dir/$dom/epm-domain.cfg
 }
 
+# Return the filename of the metadata file for the given package
+# (regardless of whether it exists)
 fn -package-metadata-file [pkg]{
   put (dest $pkg)/metadata.json
 }
 
+# Read the domain config file for a given domain. If the file does not
+# exist but we have a built-in definition, then we create the file
+# with the default.
 fn -read-domain-config [dom]{
   cfgfile = (-domain-config-file $dom)
   # Only read config if it hasn't been loaded already
@@ -180,6 +187,7 @@ fn -package-op [pkg what]{
   }
 }
 
+# Read and parse the package metadata, if it exists
 fn metadata [pkg]{
   res = [&]
   mdata = (-package-metadata-file $pkg)
@@ -189,6 +197,7 @@ fn metadata [pkg]{
   put $res
 }
 
+# Print out information about a package
 fn query [pkg]{
   data = (metadata $pkg)
   echo (edit:styled "Package "$pkg cyan)
@@ -203,6 +212,7 @@ fn query [pkg]{
   }
 }
 
+# Uninstall a single package by removing its directory
 fn -uninstall-package [pkg]{
   if (not (is-installed $pkg)) {
     -error "Package "$pkg" is not installed."
@@ -213,6 +223,10 @@ fn -uninstall-package [pkg]{
   rm -rf $dest
 }
 
+######################################################################
+# Main user-facing functions
+
+# List installed packages
 fn installed {
   e:ls $-lib-dir | each [dom]{
     if ?(test -f (-domain-config-file $dom)) {
@@ -225,8 +239,8 @@ fn installed {
   }
 }
 
-######################################################################
-
+# Install and upgrade are method-specific, so we call the
+# corresponding functions using -package-op
 fn install [&silent-if-installed=$false @pkgs]{
   for pkg $pkgs {
     if (is-installed $pkg) {
@@ -253,6 +267,7 @@ fn upgrade [@pkgs]{
   }
 }
 
+# Uninstall is the same for everyone, just remove the directory
 fn uninstall [@pkgs]{
   if (eq $pkgs []) {
     fail 'Must specify at least one package.'

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -1,111 +1,206 @@
 package bundled
 
-const epmElv = `
+const epmElv = `# Verbosity configuration
+debug-mode = $false
+
+# Configuration for common domains
+-default-domain-config = [
+  &"github.com"= [
+    &method= git
+    &protocol= https
+    &levels= 2
+  ]
+]
+
+# Internal configuration
 -data-dir = ~/.elvish
--installed = $-data-dir/epm-installed
+-lib-dir = $-data-dir/lib
+
+# Runtime state - records get copied from -default-domain-config
+# as needed
+-domain-config = [&]
+
+# Utility functions
+fn -debug [text]{
+  if $debug-mode {
+    print (edit:styled '=> ' blue)
+    echo $text
+  }
+}
 
 fn -info [text]{
-    print (edit:styled '=> ' green)
-    echo $text
+  print (edit:styled '=> ' green)
+  echo $text
+}
+
+fn -warn [text]{
+  print (edit:styled '=> ' yellow)
+  echo $text
 }
 
 fn -error [text]{
-    print (edit:styled '=> ' red)
-    echo $text
+  print (edit:styled '=> ' red)
+  echo $text
 }
 
-fn add-installed [@pkgs]{
-    if (eq $pkgs []) {
-        -error 'Must specify at least one package.'
+fn dest [pkg]{
+  put $-lib-dir/$pkg
+}
+
+fn is-installed [pkg]{
+  put ?(test -e (dest $pkg))
+}
+
+fn -package-domain [pkg]{
+  splits / $pkg | take 1
+}
+
+fn -package-without-domain [pkg]{
+  joins / [(splits / $pkg | drop 1)]
+}
+
+# Known method handlers. Each entry is indexed by method name (the
+# value of the "method" key in the domain configs), and must contain
+# two keys: install and upgrade, each one must be a closure that
+# received two arguments: package name and the domain config entry
+-method-handler = [
+  &git= [
+    &install= [pkg dom-cfg]{
+      dest = (dest $pkg)
+      -info "Installing "$pkg
+      mkdir -p $dest
+      git clone $dom-cfg[protocol]"://"$pkg $dest
+    }
+
+    &upgrade= [pkg dom-cfg]{
+      dest = (dest $pkg)
+      -info "Updating "$pkg
+      git -C $dest pull
+    }
+  ]
+
+  &rsync= [
+    &install= [pkg dom-cfg]{
+      dest = (dest $pkg)
+      pkgd = (-package-without-domain $pkg)
+      -info "Installing "$pkg
+      rsync -av $dom-cfg[location]/$pkgd/ $dest
+    }
+
+    &upgrade= [pkg dom-cfg]{
+      dest = (dest $pkg)
+      pkgd = (-package-without-domain $pkg)
+      if (not (is-installed $pkg)) {
+        -error "Package "$pkg" is not installed."
         return
+      }
+      -info "Updating "$pkg
+      rsync -av $dom-cfg[location]/$pkgd/ $dest
     }
-    for pkg $pkgs {
-        echo $pkg >> $-installed
-    }
+  ]
+]
+
+fn -domain-config-file [dom]{
+  put $-lib-dir/$dom/epm-domain.cfg
 }
 
-fn -get-url [pkg]{
-    put https://$pkg
+fn -read-domain-config [dom]{
+  cfgfile = (-domain-config-file $dom)
+  # Only read config if it hasn't been loaded already
+  if (not (has-key $-domain-config $dom)) {
+    if ?(test -f $cfgfile) {
+      # If the config file exists, read it...
+      -domain-config[$dom] = (cat $cfgfile | from-json)
+      -debug "Read domain config for "$dom": "(to-string $-domain-config[$dom])
+    } else {
+      # ...otherwise check if we have a default config for the domain, and save it
+      if (has-key $-default-domain-config $dom) {
+        -domain-config[$dom] = $-default-domain-config[$dom]
+        -debug "No existing config for "$dom", using the default: "(to-string $-domain-config[$dom])
+        mkdir -p (dirname $cfgfile)
+        put $-domain-config[$dom] | to-json > $cfgfile
+      } else {
+        fail "No existing config for "$dom" and no default available. Please create config file "(tilde-abbr $cfgfile)" by hand"
+      }
+    }
+  }
 }
 
-fn -install-one [pkg]{
-    dest = $-data-dir/lib/$pkg
-    if ?(test -e $dest) {
-        -error 'Package '$pkg' already exists locally.'
-        return
+# Invoke package operations defined in $-method-handler above
+fn -package-op [pkg what]{
+  dom = (-package-domain $pkg)
+  -read-domain-config $dom
+  if (has-key $-domain-config $dom) {
+    cfg = $-domain-config[$dom]
+    method = $cfg[method]
+    if (has-key $-method-handler $method) {
+      if (has-key $-method-handler[$method] $what) {
+        $-method-handler[$method][$what] $pkg $cfg
+      } else {
+        fail "No handler for '"$what"' defined in method '"$method"'"
+      }
+    } else {
+      fail "No handler defined for method '"$method"', specified in in config file "(-domain-config-file $dom)
     }
-    -info 'Installing '$pkg
-    mkdir -p $dest
-    git clone (-get-url $pkg) $dest
-    add-installed $pkg
+  }
 }
 
-fn install [@pkgs]{
-    if (eq $pkgs []) {
-        -error 'Must specify at least one package.'
-        return
-    }
-    for pkg $pkgs {
-        -install-one $pkg
-    }
+fn -uninstall-package [pkg]{
+  if (not (is-installed $pkg)) {
+    -error "Package "$pkg" is not installed."
+    return
+  }
+  dest = (dest $pkg)
+  -info "Removing package "$pkg
+  rm -rf $dest
 }
 
 fn installed {
-    if ?(test -f $-installed) {
-        cat $-installed
+  e:ls $-lib-dir | each [dom]{
+    if ?(test -f (-domain-config-file $dom)) {
+      -read-domain-config $dom
+      lvl = $-domain-config[$dom][levels]
+      find $-lib-dir/$dom -type d -depth $lvl | each [pkg]{
+        replaces $-lib-dir/ "" $pkg
+      }
     }
+  }
 }
 
-fn -upgrade-one [pkg]{
-    dest = $-data-dir/lib/$pkg
-    if (not ?(test -d $dest)) {
-        -error 'Package '$pkg' not installed locally.'
-        return
+######################################################################
+
+fn install [&silent-if-installed=$false @pkgs]{
+  for pkg $pkgs {
+    if (is-installed $pkg) {
+      if (not $silent-if-installed) {
+        -info "Package "$pkg" is already installed."
+      }
+    } else {
+      -package-op $pkg install
     }
-    -info 'Upgrading package '$pkg
-    git -C $dest pull
+  }
 }
 
 fn upgrade [@pkgs]{
-    if (eq $pkgs []) {
-        pkgs = [(installed)]
-        -info 'Upgrading all installed packages'
+  if (eq $pkgs []) {
+    pkgs = [(installed)]
+    -info 'Upgrading all installed packages'
+  }
+  for pkg $pkgs {
+    if (not (is-installed $pkg)) {
+      -error "Package "$pkg" is not installed."
+    } else { 
+      -package-op $pkg upgrade
     }
-    for pkg $pkgs {
-        -upgrade-one $pkg
-    }
-}
-
-fn -uninstall-one [pkg]{
-    installed-pkgs = [(installed)]
-    if (not (has-value $installed-pkgs $pkg)) {
-        -error 'Package '$pkg' is not registered as installed.'
-        return
-    }
-    dest = $-data-dir/lib/$pkg
-    if (not ?(test -d $dest)) {
-        -error 'Package '$pkg' does not exist locally.'
-        return
-    }
-    -info 'Removing package '$pkg
-    rm -rf $dest
-    # issue #486
-    {
-        for installed $installed-pkgs {
-            if (not-eq $installed $pkg) {
-                echo $installed
-            }
-        }
-    } > $-installed
+  }
 }
 
 fn uninstall [@pkgs]{
-    if (eq $pkgs []) {
-        -error 'Must specify at least one package.'
-        return
-    }
-    for pkg $pkgs {
-        -uninstall-one $pkg
-    }
-}
-`
+  if (eq $pkgs []) {
+    fail 'Must specify at least one package.'
+    return
+  }
+  for pkg $pkgs {
+    -uninstall-package $pkg
+  }
+}`

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -10,6 +10,16 @@ debug-mode = $false
     &protocol= https
     &levels= 2
   ]
+  &"bitbucket.org"= [
+    &method= git
+    &protocol= https
+    &levels= 2
+  ]
+  &"gitlab.com"= [
+    &method= git
+    &protocol= https
+    &levels= 2
+  ]
 ]
 
 # Internal configuration

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -168,6 +168,19 @@ fn metadata [pkg]{
   put $res
 }
 
+fn query [pkg]{
+  data = (metadata $pkg)
+  echo (edit:styled "Package "$pkg cyan)
+  if (is-installed $pkg) {
+    echo (edit:styled "Installed at "(dest $pkg) green)
+  } else {
+    echo (edit:styled "Not installed" red)
+  }
+  keys $data | each [key]{
+    echo (edit:styled $key":" blue) $data[$key]
+  }
+}
+
 fn -uninstall-package [pkg]{
   if (not (is-installed $pkg)) {
     -error "Package "$pkg" is not installed."

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -189,10 +189,10 @@ fn -package-op [pkg what]{
       if (has-key $-method-handler[$method] $what) {
         $-method-handler[$method][$what] $pkg $cfg
       } else {
-        fail "No handler for '"$what"' defined in method '"$method"'"
+        fail "Unknown operation '"$what"' for package "$pkg
       }
     } else {
-      fail "No handler defined for method '"$method"', specified in in config file "(-domain-config-file $dom)
+      fail "Unknown method '"$method"', specified in in config file "(-domain-config-file $dom)
     }
   } else {
     -error "No config for domain '"$dom"'."

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -72,7 +72,7 @@ fn -package-without-domain [pkg]{
 # received two arguments: package name and the domain config entry
 #
 # - Method 'git' requires the key 'protocol' in the domain config,
-#   which has to be `http` or `https`
+#   which has to be 'http' or 'https'
 # - Method 'rsync' requires the key 'location' in the domain config,
 #   which has to contain the directory where the domain files are
 #   stored. It can be any source location understood by the rsync
@@ -147,7 +147,7 @@ fn -write-domain-config [dom]{
 # Returns the domain config file for a given domain. If the file does not
 # exist but we have a built-in definition, then we return the
 # default. Otherwise we return $false, so the result can always be
-# checked with `if`.
+# checked with 'if'.
 fn -domain-config [dom]{
   cfgfile = (-domain-config-file $dom)
   cfg = $false

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -114,6 +114,10 @@ fn -domain-config-file [dom]{
   put $-lib-dir/$dom/epm-domain.cfg
 }
 
+fn -package-metadata-file [pkg]{
+  put (dest $pkg)/metadata.json
+}
+
 fn -read-domain-config [dom]{
   cfgfile = (-domain-config-file $dom)
   # Only read config if it hasn't been loaded already
@@ -153,6 +157,15 @@ fn -package-op [pkg what]{
       fail "No handler defined for method '"$method"', specified in in config file "(-domain-config-file $dom)
     }
   }
+}
+
+fn metadata [pkg]{
+  res = [&]
+  mdata = (-package-metadata-file $pkg)
+  if (and (is-installed $pkg) ?(test -f $mdata)) {
+    res = (cat $mdata | from-json)
+  }
+  put $res
 }
 
 fn -uninstall-package [pkg]{


### PR DESCRIPTION
Reimplementation of epm to be fully file-based, with per-domain configuration for different package installation methods. The scheme is described in https://github.com/elves/elvish/pull/547#issuecomment-354560975. In short:

- Packages are specified as `domain/package`. For example, `github.com/zzamboni/modules.elv`
- Packages are stored under `~/.elvish/lib` under their full path. For example, `~/.elvish/lib/github.com/zzamboni/modules.elv/`
- Each domain has a configuration file stored in `~/.elvish/lib/<domain>/epm-domain.cfg`. Currently epm has built-in domain configuration for the `github.com`, `gitlab.com` and `bitbucket.org` domains. This file is a JSON file which contains the following fields:

  - `method` specifies the method used to transfer the module files. Currently supported are `git` and `rsync`.
  - `levels` specifies how many directories under the domain directory are packages located. For example, the github.com domain has `levels` set to 2, which means the packages are directories stored 2 levels under `~/.elvish/lib/github.com`.
  - Other fields may be specified, depending on the method. For example, method `git` needs `protocol` (e.g. `https` or `git`) and method `rsync` needs `location` (the location from which to rsync the files).

For domains with built-in configuration (github.com, gitlab.com and bitbucket.org at the moment), the `epm-domain.cfg` file is created automatically the first time a package from that domain is installed. For others, you have to create the file by hand. For example, to have a "dev" domain which installs packages specified as `dev/foo` from `~/devel/foo`, you must create file `~/.elvish/lib/dev/epm-domain.cfg` containing the following:

```json
{
   "method" : "rsync",
   "location" : "/Users/taazadi1/Personal/devel/elvish/dev",
   "levels" : "1"
}
```