### PR TITLE
fix overflows on req arg in ioctl

### DIFF
--- a/sys/ioctl.go
+++ b/sys/ioctl.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Ioctl wraps the ioctl syscall.
-func Ioctl(fd int, req int, arg uintptr) error {
+func Ioctl(fd int, req uintptr, arg uintptr) error {
 	_, _, e := unix.Syscall(
-		unix.SYS_IOCTL, uintptr(fd), uintptr(req), arg)
+		unix.SYS_IOCTL, uintptr(fd), req, arg)
 	if e != 0 {
 		return os.NewSyscallError("ioctl", e)
 	}


### PR DESCRIPTION
https://buildd.debian.org/status/fetch.php?pkg=elvish&arch=mips&ver=0.11~rc1%2Bds1-1&stamp=1516051895&raw=0

```
# github.com/elves/elvish/sys
src/github.com/elves/elvish/sys/tc.go:21:14: constant 2147775606 overflows int
```