### PR TITLE
Various epm updates

### DIFF
--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -55,7 +55,7 @@ fn dest [pkg]{
 }
 
 fn is-installed [pkg]{
-  put ?(test -e (dest $pkg))
+  put (or (and ?(test -e (dest $pkg)) $true) $false)
 }
 
 fn -package-domain [pkg]{

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -228,15 +228,18 @@ fn metadata [pkg]{
 # Print out information about a package
 fn query [pkg]{
   data = (metadata $pkg)
-  echo (edit:styled "Package "$pkg cyan)
-  echo (edit:styled "Source:" blue) (-package-method $pkg) (-package-op $pkg src)
-  if (is-installed $pkg) {
-    echo (edit:styled "Installed at "(dest $pkg) green)
+  special-keys = [name method installed src dst]
+  echo (edit:styled "Package "$data[name] cyan)
+  if $data[installed] {
+    echo (edit:styled "Installed at "$data[dst] green)
   } else {
     echo (edit:styled "Not installed" red)
   }
+  echo (edit:styled "Source:" blue) $data[method] $data[src]
   keys $data | each [key]{
-    echo (edit:styled $key":" blue) $data[$key]
+    if (not (has-value $special-keys $key)) {
+      echo (edit:styled (first-upper $key)":" blue) $data[$key]
+    }
   }
 }
 

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -273,6 +273,9 @@ fn installed {
   }
 }
 
+# epm:list is an alias for epm:installed
+fn list { installed }
+
 # Install and upgrade are method-specific, so we call the
 # corresponding functions using -package-op
 fn install [&silent-if-installed=$false @pkgs]{

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -295,8 +295,15 @@ fn install [&silent-if-installed=$false @pkgs]{
       if (has-key $metadata dependencies) {
         deps = $metadata[dependencies]
         -info "Installing dependencies: "(joins " " $deps)
-        install $@deps
-        # TODO: what to do if install of dependencies fails? Uninstall everything?
+        # If the installation of dependencies fails, uninstall the
+        # target package (leave any already-installed dependencies in
+        # place)
+        try {
+          install $@deps
+        } except e {
+          -error "Dependency installation failed. Uninstalling "$pkg", please check the errors above and try again."
+          -uninstall-package $pkg
+        }
       }
     }
   }

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -279,6 +279,10 @@ fn list { installed }
 # Install and upgrade are method-specific, so we call the
 # corresponding functions using -package-op
 fn install [&silent-if-installed=$false @pkgs]{
+  if (eq $pkgs []) {
+    -error "You must specify at least one package."
+    return
+  }
   for pkg $pkgs {
     if (is-installed $pkg) {
       if (not $silent-if-installed) {
@@ -315,7 +319,7 @@ fn upgrade [@pkgs]{
 # Uninstall is the same for everyone, just remove the directory
 fn uninstall [@pkgs]{
   if (eq $pkgs []) {
-    -error 'Must specify at least one package.'
+    -error 'You must specify at least one package.'
     return
   }
   for pkg $pkgs {

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -55,7 +55,7 @@ fn dest [pkg]{
 }
 
 fn is-installed [pkg]{
-  put (or (and ?(test -e (dest $pkg)) $true) $false)
+  bool ?(test -e (dest $pkg))
 }
 
 fn -package-domain [pkg]{
@@ -218,9 +218,9 @@ fn metadata [pkg]{
     &installed= (is-installed $pkg)
   ]
   # Merge with package-specified attributes, if any
-  mdataf = (-package-metadata-file $pkg)
-  if (and (is-installed $pkg) ?(test -f $mdataf)) {
-    res = (merge (cat $mdataf | from-json) $res)
+  file = (-package-metadata-file $pkg)
+  if (and (is-installed $pkg) ?(test -f $file)) {
+    res = (merge (cat $file | from-json) $res)
   }
   put $res
 }

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -238,7 +238,11 @@ fn query [pkg]{
   echo (edit:styled "Source:" blue) $data[method] $data[src]
   keys $data | each [key]{
     if (not (has-value $special-keys $key)) {
-      echo (edit:styled (first-upper $key)":" blue) $data[$key]
+      val = $data[$key]
+      if (eq (kind-of $val) list) {
+        val = (joins ", " $val)
+      }
+      echo (edit:styled (first-upper $key)":" blue) $val
     }
   }
 }

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -283,6 +283,14 @@ fn install [&silent-if-installed=$false @pkgs]{
       }
     } else {
       -package-op $pkg install
+      # Check if there are any dependencies to install
+      metadata = (metadata $pkg)
+      if (has-key $metadata dependencies) {
+        deps = $metadata[dependencies]
+        -info "Installing dependencies: "(joins " " $deps)
+        install $@deps
+        # TODO: what to do if install of dependencies fails? Uninstall everything?
+      }
     }
   }
 }


### PR DESCRIPTION
Various epm improvements, including:

- Force output of `is-installed` to `$true` or `$false`, just for cleanliness
- The `metadata` function now returns not only package-provided metadata (if any) but also some base attributes such as package name, install status, source and destination (if installed), and install method.
- The `query` function uses the improved `metadata` function, and prettified output.
- Rudimentary dependency management:   If an installed package has a metadata file, and if the metadata has a    `dependencies` key, then it is expected to be a list of strings    indicating packages that must also be installed.    There is still no error handling for this. If the    installation of dependencies fails, should we just uninstall everything?    Feedback welcome.
