### PR TITLE
Return offline storage error when fuser is nil

### DIFF
--- a/edit/histlist.go
+++ b/edit/histlist.go
@@ -124,6 +124,9 @@ func getCmds(ed *editor) ([]string, error) {
 	if ed.daemon == nil {
 		return nil, errStoreOffline
 	}
+	if ed.hist.fuser == nil {
+		return nil, errStoreOffline
+	}
 	return ed.hist.fuser.AllCmds()
 }
 


### PR DESCRIPTION
This check avoids panic when `fuser` struct gets `nil` due to history backend failure.
```golang
runtime error: invalid memory address or nil pointer dereference
...
github.com/elves/elvish/edit/history.(*Fuser).AllCmds(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/elves/elvish/edit/history/fuser.go:45 +0x65
github.com/elves/elvish/edit.getCmds(0xc420110600, 0x1, 0x20, 0xc4202422c4, 0x1, 0x4628c2)
        /go/src/github.com/elves/elvish/edit/histlist.go:127 +0x43
github.com/elves/elvish/edit.histlistStart(0xc420110600)
        /go/src/github.com/elves/elvish/edit/histlist.go:114 +0x2f
github.com/elves/elvish/edit.initHistlist.func1()
        /go/src/github.com/elves/elvish/edit/histlist.go:37 +0x2a
reflect.Value.call(0x85d180, 0xc420148a40, 0x13, 0x918f77, 0x4, 0x0, 0x0, 0x0, 0x0, 0x85d180, ...)
...
```