### PR TITLE
edit: allow to customize stale prompt

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -25,8 +25,11 @@ import (
 	"github.com/xiaq/persistent/hashmap"
 )
 
-var lastPromptContent []*ui.Styled
-var logger = util.GetLogger("[edit] ")
+var (
+	lastPromptContent  []*ui.Styled
+	lastRpromptContent []*ui.Styled
+	logger             = util.GetLogger("[edit] ")
+)
 
 // editor implements the line editor.
 type editor struct {
@@ -408,9 +411,10 @@ MainLoop:
 			select {
 			case ed.rpromptContent = <-rpromptCh:
 				logger.Println("rprompt fetched")
+				lastRpromptContent = ed.rpromptContent
 			case <-rpromptTimeout:
 				logger.Println("stale rprompt")
-				//ed.rpromptContent = promptUpdater.StalePromptTransformed(ed)
+				ed.rpromptContent = rpromptUpdater.StalePromptTransformed(ed, lastRpromptContent)
 			}
 		}
 		fresh = false
@@ -431,6 +435,7 @@ MainLoop:
 			goto refresh
 		case ed.rpromptContent = <-rpromptCh:
 			logger.Println("rprompt fetched late")
+			lastRpromptContent = ed.rpromptContent
 			goto refresh
 		case m := <-isExternalCh:
 			ed.isExternal = m

--- a/edit/prompt/prompt.go
+++ b/edit/prompt/prompt.go
@@ -19,9 +19,10 @@ var logger = util.GetLogger("[edit/prompt] ")
 
 // Config holds the config for the prompt
 type Config struct {
-	Prompt               eval.Callable
-	Rprompt              eval.Callable
-	StalePromptTransform eval.Callable
+	Prompt                eval.Callable
+	Rprompt               eval.Callable
+	StalePromptTransform  eval.Callable
+	StaleRpromptTransform eval.Callable
 
 	RpromptPersistent bool
 	PromptsMaxWait    float64

--- a/edit/prompt/prompt.go
+++ b/edit/prompt/prompt.go
@@ -17,9 +17,11 @@ import (
 
 var logger = util.GetLogger("[edit/prompt] ")
 
+// Config holds the config for the prompt
 type Config struct {
-	Prompt  eval.Callable
-	Rprompt eval.Callable
+	Prompt               eval.Callable
+	Rprompt              eval.Callable
+	StalePromptTransform eval.Callable
 
 	RpromptPersistent bool
 	PromptsMaxWait    float64
@@ -34,8 +36,8 @@ type Editor interface {
 // maxSeconds is the maximum number of seconds time.Duration can represent.
 const maxSeconds = float64(math.MaxInt64 / time.Second)
 
-// PromptInit returns an initial value for $edit:prompt.
-func PromptInit() eval.Callable {
+// DefaultPromptInit returns an initial value for $edit:prompt.
+func DefaultPromptInit() eval.Callable {
 	user, err := user.Current()
 	isRoot := err == nil && user.Uid == "0"
 
@@ -51,8 +53,8 @@ func PromptInit() eval.Callable {
 	return eval.NewBuiltinFn("default prompt", prompt)
 }
 
-// RpromptInit returns an initial value for $edit:rprompt.
-func RpromptInit() eval.Callable {
+// DefaultRpromptInit returns an initial value for $edit:rprompt.
+func DefaultRpromptInit() eval.Callable {
 	username := "???"
 	user, err := user.Current()
 	if err == nil {
@@ -71,7 +73,19 @@ func RpromptInit() eval.Callable {
 	return eval.NewBuiltinFn("default rprompt", rprompt)
 }
 
-// MakeMaxWait makes a channel that sends the current time after
+// StalePromptTransformInit returns an initial value for $edit:-stale-prompt-transform
+func StalePromptTransformInit() eval.Callable {
+	stalePromptTransform := func(fm *eval.Frame) {
+		out := fm.OutputChan()
+		fm.IterateInputs(func(i interface{}) {
+			out <- i
+		})
+	}
+
+	return eval.NewBuiltinFn("default stale prompt transform", stalePromptTransform)
+}
+
+// MakeMaxWaitChan makes a channel that sends the current time after
 // $edit:-prompts-max-wait seconds if the time fits in a time.Duration value, or
 // nil otherwise.
 func (cfg *Config) MakeMaxWaitChan() <-chan time.Time {
@@ -90,6 +104,11 @@ func callPrompt(ed Editor, fn eval.Callable) []*ui.Styled {
 		{}, // Will be replaced when capturing output
 		{File: os.Stderr},
 	}
+
+	return callAndGetStyled(ed, fn, ports)
+}
+
+func callAndGetStyled(ed Editor, fn eval.Callable, ports []*eval.Port) []*ui.Styled {
 	var (
 		styleds      []*ui.Styled
 		styledsMutex sync.Mutex
@@ -133,17 +152,49 @@ func callPrompt(ed Editor, fn eval.Callable) []*ui.Styled {
 	return styleds
 }
 
-// Updater manages the update of a prompt.
-type Updater struct {
-	promptFn eval.Callable
-	Staled   []*ui.Styled
+// callTransformer calls a Fn, assuming that it is a prompt transformer. It calls the Fn with no
+// arguments and input, and converts its outputs to styled objects.
+func callTransformer(ed Editor, fn eval.Callable, currentPrompt []*ui.Styled) []*ui.Styled {
+	input := make(chan interface{})
+	stopInputWriter := make(chan struct{})
+
+	ports := []*eval.Port{
+		{Chan: input, File: eval.DevNull},
+		{}, // Will be replaced when capturing output
+		{File: os.Stderr},
+	}
+	go func() {
+		defer close(input)
+		for _, char := range currentPrompt {
+			select {
+			case input <- char:
+			case <-stopInputWriter:
+				return
+			}
+		}
+	}()
+	defer close(stopInputWriter)
+
+	return callAndGetStyled(ed, fn, ports)
 }
 
-var staledPrompt = &ui.Styled{"?", ui.Styles{"inverse"}}
+// Updater manages the update of a prompt.
+type Updater struct {
+	promptFn         eval.Callable
+	staleTransformFn eval.Callable
+}
 
 // NewUpdater creates a new Updater.
-func NewUpdater(promptFn eval.Callable) *Updater {
-	return &Updater{promptFn, []*ui.Styled{staledPrompt}}
+func NewUpdater(promptFn eval.Callable, staleTransformFn eval.Callable) *Updater {
+	return &Updater{
+		promptFn:         promptFn,
+		staleTransformFn: staleTransformFn,
+	}
+}
+
+// StalePromptTransformed returns the prompt transformed
+func (pu *Updater) StalePromptTransformed(ed Editor, currentPrompt []*ui.Styled) []*ui.Styled {
+	return callTransformer(ed, pu.staleTransformFn, currentPrompt)
 }
 
 // Update updates the prompt, returning a channel onto which the result will be
@@ -152,9 +203,6 @@ func (pu *Updater) Update(ed Editor) <-chan []*ui.Styled {
 	ch := make(chan []*ui.Styled)
 	go func() {
 		result := callPrompt(ed, pu.promptFn)
-		pu.Staled = make([]*ui.Styled, len(result)+1)
-		pu.Staled[0] = staledPrompt
-		copy(pu.Staled[1:], result)
 		ch <- result
 	}()
 	return ch

--- a/edit/prompt_config.go
+++ b/edit/prompt_config.go
@@ -20,5 +20,7 @@ func init() {
 		ns["-prompts-max-wait"] = vars.NewFromPtr(&ed.PromptsMaxWait)
 		ed.StalePromptTransform = prompt.StalePromptTransformInit()
 		ns["-stale-prompt-transform"] = vars.NewFromPtr(&ed.StalePromptTransform)
+		ed.StaleRpromptTransform = prompt.StalePromptTransformInit()
+		ns["-stale-rprompt-transform"] = vars.NewFromPtr(&ed.StaleRpromptTransform)
 	})
 }

--- a/edit/prompt_config.go
+++ b/edit/prompt_config.go
@@ -10,13 +10,15 @@ import (
 
 func init() {
 	atEditorInit(func(ed *editor, ns eval.Ns) {
-		ed.Prompt = prompt.PromptInit()
+		ed.Prompt = prompt.DefaultPromptInit()
 		ns["prompt"] = vars.NewFromPtr(&ed.Prompt)
-		ed.Rprompt = prompt.RpromptInit()
+		ed.Rprompt = prompt.DefaultRpromptInit()
 		ns["rprompt"] = vars.NewFromPtr(&ed.Rprompt)
 		ed.RpromptPersistent = false
 		ns["rprompt-persistent"] = vars.NewFromPtr(&ed.RpromptPersistent)
 		ed.PromptsMaxWait = math.Inf(1)
 		ns["-prompts-max-wait"] = vars.NewFromPtr(&ed.PromptsMaxWait)
+		ed.StalePromptTransform = prompt.StalePromptTransformInit()
+		ns["-stale-prompt-transform"] = vars.NewFromPtr(&ed.StalePromptTransform)
 	})
 }


### PR DESCRIPTION
The following patch allows to transform the stale prompt by setting a function like this:

```edit:stale-prompt-transform = { each [x]{ edit:styled $x[text] "gray" } }```

By default it displays the previous prompt
