### PR TITLE
Don't crash when git update fails

### DIFF
--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -111,7 +111,12 @@ fn tilde-expand [p]{
     &upgrade= [pkg dom-cfg]{
       dest = (dest $pkg)
       -info "Updating "$pkg
-      git -C $dest pull
+      is-ok = ?(out = [(git -C $dest pull)])
+      if $is-ok {
+        -info (joins "\n" $out)
+      } else {
+        -error "Something failed, please check error above and retry."
+      }
     }
   ]
 

--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -111,11 +111,10 @@ fn tilde-expand [p]{
     &upgrade= [pkg dom-cfg]{
       dest = (dest $pkg)
       -info "Updating "$pkg
-      is-ok = ?(out = [(git -C $dest pull)])
-      if $is-ok {
-        -info (joins "\n" $out)
-      } else {
-        -error "Something failed, please check error above and retry."
+      try {
+        git -C $dest pull
+      } except _ {
+          -error "Something failed, please check error above and retry."
       }
     }
   ]


### PR DESCRIPTION
When git update fails for any reason (i.e. not a git repo, unstaged changes, etc.), catch the exception and print an error, but don't crash.

Fixes #626