### PR TITLE
edit/completion: add sorter

### DIFF
--- a/edit/completion/candidate.go
+++ b/edit/completion/candidate.go
@@ -3,7 +3,6 @@ package completion
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/elves/elvish/edit/ui"
 	"github.com/elves/elvish/eval"
@@ -22,12 +21,6 @@ type rawCandidate interface {
 	text() string
 	cook(q parse.PrimaryType) *candidate
 }
-
-type rawCandidates []rawCandidate
-
-func (cs rawCandidates) Len() int           { return len(cs) }
-func (cs rawCandidates) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
-func (cs rawCandidates) Less(i, j int) bool { return cs[i].text() < cs[j].text() }
 
 // plainCandidate is a minimal implementation of rawCandidate.
 type plainCandidate string
@@ -153,6 +146,5 @@ func filterRawCandidates(ev *eval.Evaler, matcher eval.Callable, seed string, ch
 			filtered = append(filtered, collected[i])
 		}
 	}
-	sort.Sort(rawCandidates(filtered))
 	return filtered, nil
 }

--- a/edit/completion/completion_mode.go
+++ b/edit/completion/completion_mode.go
@@ -22,6 +22,7 @@ import (
 type completion struct {
 	binding      eddefs.BindingMap
 	matcher      hashmap.Map
+	sorter       hashmap.Map
 	argCompleter hashmap.Map
 	completionState
 }
@@ -43,6 +44,7 @@ func Init(ed eddefs.Editor, ns eval.Ns) {
 	c := &completion{
 		binding:      eddefs.EmptyBindingMap,
 		matcher:      vals.MakeMapFromKV("", matchPrefix),
+		sorter:       vals.EmptyMap,
 		argCompleter: makeArgCompleter(),
 	}
 
@@ -50,6 +52,7 @@ func Init(ed eddefs.Editor, ns eval.Ns) {
 		eval.Ns{
 			"binding":       vars.FromPtr(&c.binding),
 			"matcher":       vars.FromPtr(&c.matcher),
+			"sorter":        vars.FromPtr(&c.sorter),
 			"arg-completer": vars.FromPtr(&c.argCompleter),
 		}.AddBuiltinFns("edit:completion:", map[string]interface{}{
 			"start":          func() { c.start(ed, false) },
@@ -211,7 +214,7 @@ func (c *completion) start(ed eddefs.Editor, acceptSingleton bool) {
 	}
 
 	completer, complSpec, err := complete(
-		node, &complEnv{ed.Evaler(), c.matcher, c.argCompleter})
+		node, &complEnv{ed.Evaler(), c.matcher, c.sorter, c.argCompleter})
 
 	if err != nil {
 		ed.AddTip("%v", err)

--- a/edit/completion/sorter.go
+++ b/edit/completion/sorter.go
@@ -1,0 +1,66 @@
+package completion
+
+import (
+	"errors"
+	"os"
+	"sort"
+
+	"github.com/elves/elvish/eval"
+	"github.com/elves/elvish/eval/vals"
+	"github.com/xiaq/persistent/hashmap"
+)
+
+var (
+	errSorterMustBeFn = errors.New("sorter must be a function")
+)
+
+type rawCandidates []rawCandidate
+
+func (cs rawCandidates) Len() int           { return len(cs) }
+func (cs rawCandidates) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
+func (cs rawCandidates) Less(i, j int) bool { return cs[i].text() < cs[j].text() }
+
+func lookupSorter(m hashmap.Map, name string) (eval.Callable, bool) {
+	key := name
+	if !hashmap.HasKey(m, key) {
+		// Use fallback sorter
+		if !hashmap.HasKey(m, "") {
+			return nil, false
+		}
+		key = ""
+	}
+	value, _ := m.Index(key)
+	sorter, ok := value.(eval.Callable)
+	return sorter, ok
+}
+
+func sortRawCandidates(ev *eval.Evaler, customSorter eval.Callable, seed string, rs []rawCandidate) ([]rawCandidate, error) {
+	// default sorter
+	if customSorter == nil {
+		sort.Sort(rawCandidates(rs))
+		return rs, nil
+	}
+
+	ports := []*eval.Port{
+		eval.DevNullClosedChan,
+		{}, // Will be replaced when capturing output
+		{File: os.Stderr},
+	}
+	ec := eval.NewTopFrame(ev, eval.NewInternalSource("[editor sorter]"), ports)
+	sort.SliceStable(rs, func(i, j int) bool {
+		args := []interface{}{seed, rs[i].text(), rs[j].text()}
+		rets, err := ec.CaptureOutput(customSorter, args, eval.NoOpts)
+		if err != nil {
+			logger.Printf("sorter: %v", err)
+			return false
+		}
+		// just return one bool
+		if n := len(rets); n != 1 {
+			logger.Printf("sorter: return value count %d != 1", n)
+			return false
+		}
+		return vals.Bool(rets[0])
+	})
+
+	return rs, nil
+}

--- a/edit/completion/sorter_test.go
+++ b/edit/completion/sorter_test.go
@@ -1,0 +1,73 @@
+package completion
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/elves/elvish/eval"
+	"github.com/elves/elvish/eval/vals"
+)
+
+func TestSortRawCandidates(t *testing.T) {
+	ev := eval.NewEvaler()
+	defer ev.Close()
+
+	fakeDirSort := eval.NewBuiltinFn("test:fakeDirSort",
+		func(fm *eval.Frame, opts eval.RawOptions, seed, a, b string) {
+			out := fm.OutputChan()
+			da, db := strings.HasSuffix(a, "/"), strings.HasSuffix(b, "/")
+			isBefore := false
+
+			switch {
+			case da && !db:
+				isBefore = true
+			case !da && db:
+				isBefore = false
+			default:
+				pa := strings.HasPrefix(a, seed)
+				if pa {
+					isBefore = true
+				} else {
+					isBefore = false
+				}
+			}
+			out <- vals.Bool(isBefore)
+		})
+
+	for name, test := range map[string]struct {
+		src    []string
+		sorter eval.Callable
+		seed   string
+		want   []string
+	}{
+		"default": {
+			src:  []string{"z", "y", "x"},
+			want: []string{"x", "y", "z"},
+		},
+		"fakeDirSort": {
+			sorter: fakeDirSort,
+			seed:   "Y",
+			src:    []string{"x", "z/", "y", "Y/"},
+			want:   []string{"Y/", "z/", "x", "y"},
+		},
+	} {
+		inputs := make([]rawCandidate, len(test.src))
+		for i, s := range test.src {
+			inputs[i] = plainCandidate(s)
+		}
+
+		result, err := sortRawCandidates(ev, test.sorter, test.seed, inputs)
+		if err != nil {
+			t.Errorf("test %s: got unexpected error %v", name, err)
+		}
+
+		got := make([]string, len(result))
+		for i, r := range result {
+			got[i] = r.text()
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("test %s: got unexpected result: %v, want %v", name, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Just got inspiration from sort package, user can setup a comparion function (like the `Less` method in sort),
and its definition is: `func isBefore (seed, a, b string) bool`, its result determines whether candidate `a` should be placed before candidate `b`. 

For issue #580 , a simple directory first sorter would be: `[seed a b]{ put ?(test -d $a) }`,  you can also create any sophisticated sorter for sure.

BTW, now custom sort is a little slow, I will try to figure out the potention reason and improve it.

Thanks.