### PR TITLE
Suppress Background Notification

### DIFF
--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -141,7 +141,7 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 			if err != nil {
 				msg += ", errors = " + err.Error()
 			}
-			if suppressBackground.Get() != "true" {
+			if suppressBackground.Get() != "true" || err != nil {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -137,11 +137,10 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 			wg.Wait()
 			msg := "job " + op.source + " finished"
 			err := ComposeExceptionsFromPipeline(errors)
-			suppressBackground := vars.FromPtr(fm.Evaler.suppressBackground)
 			if err != nil {
 				msg += ", errors = " + err.Error()
 			}
-			if suppressBackground.Get() != true || err != nil {
+			if fm.Evaler.notifyBgJobSuccess != true || err != nil {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -140,7 +140,7 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 			if err != nil {
 				msg += ", errors = " + err.Error()
 			}
-			if fm.Evaler.notifyBgJobSuccess != true || err != nil {
+			if fm.Evaler.notifyBgJobSuccess || err != nil {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -141,7 +141,7 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 			if err != nil {
 				msg += ", errors = " + err.Error()
 			}
-			if suppressBackground.Get() != "true" || err != nil {
+			if suppressBackground.Get() != true || err != nil {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {

--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -137,13 +137,16 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 			wg.Wait()
 			msg := "job " + op.source + " finished"
 			err := ComposeExceptionsFromPipeline(errors)
+			suppressBackground := vars.FromPtr(fm.Evaler.suppressBackground)
 			if err != nil {
 				msg += ", errors = " + err.Error()
 			}
-			if fm.Editor != nil {
-				fm.Editor.Notify("%s", msg)
-			} else {
-				fm.ports[2].File.WriteString(msg + "\n")
+			if suppressBackground.Get() != "true" {
+				if fm.Editor != nil {
+					fm.Editor.Notify("%s", msg)
+				} else {
+					fm.ports[2].File.WriteString(msg + "\n")
+				}
 			}
 		}()
 		return nil

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -36,6 +36,7 @@ const (
 const (
 	defaultValuePrefix = "▶ "
 	initIndent         = vals.NoPretty
+	defaultSuppressBackground = "false"
 )
 
 // Evaler is used to evaluate elvish sources. It maintains runtime context
@@ -43,6 +44,7 @@ const (
 type Evaler struct {
 	evalerScopes
 	valuePrefix  string
+	suppressBackground string
 	beforeChdir  []func(string)
 	afterChdir   []func(string)
 	DaemonClient *daemon.Client
@@ -65,6 +67,7 @@ func NewEvaler() *Evaler {
 
 	ev := &Evaler{
 		valuePrefix: defaultValuePrefix,
+		suppressBackground: defaultSuppressBackground,
 		evalerScopes: evalerScopes{
 			Global:  make(Ns),
 			Builtin: builtin,
@@ -86,6 +89,7 @@ func NewEvaler() *Evaler {
 	builtin["after-chdir"] = vars.FromPtr(&afterChdirElvish)
 
 	builtin["value-out-indicator"] = vars.FromPtr(&ev.valuePrefix)
+	builtin["suppress-background"] = vars.FromPtr(&ev.suppressBackground)
 	builtin["pwd"] = PwdVariable{ev}
 
 	return ev

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -36,7 +36,7 @@ const (
 const (
 	defaultValuePrefix = "▶ "
 	initIndent         = vals.NoPretty
-	defaultSuppressBackground = "false"
+	defaultSuppressBackground = false
 )
 
 // Evaler is used to evaluate elvish sources. It maintains runtime context
@@ -44,7 +44,7 @@ const (
 type Evaler struct {
 	evalerScopes
 	valuePrefix  string
-	suppressBackground string
+	suppressBackground bool
 	beforeChdir  []func(string)
 	afterChdir   []func(string)
 	DaemonClient *daemon.Client

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -35,7 +35,7 @@ const (
 
 const (
 	defaultValuePrefix        = "▶ "
-	defaultNotifyBgJobSuccess = false
+	defaultNotifyBgJobSuccess = true
 	initIndent                = vals.NoPretty
 )
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -35,8 +35,8 @@ const (
 
 const (
 	defaultValuePrefix        = "▶ "
+	defaultNotifyBgJobSuccess = false
 	initIndent                = vals.NoPretty
-	defaultSuppressBackground = false
 )
 
 // Evaler is used to evaluate elvish sources. It maintains runtime context
@@ -44,7 +44,7 @@ const (
 type Evaler struct {
 	evalerScopes
 	valuePrefix        string
-	suppressBackground bool
+	notifyBgJobSuccess bool
 	beforeChdir        []func(string)
 	afterChdir         []func(string)
 	DaemonClient       *daemon.Client
@@ -67,7 +67,7 @@ func NewEvaler() *Evaler {
 
 	ev := &Evaler{
 		valuePrefix:        defaultValuePrefix,
-		suppressBackground: defaultSuppressBackground,
+		notifyBgJobSuccess: defaultNotifyBgJobSuccess,
 		evalerScopes: evalerScopes{
 			Global:  make(Ns),
 			Builtin: builtin,
@@ -89,7 +89,7 @@ func NewEvaler() *Evaler {
 	builtin["after-chdir"] = vars.FromPtr(&afterChdirElvish)
 
 	builtin["value-out-indicator"] = vars.FromPtr(&ev.valuePrefix)
-	builtin["suppress-background"] = vars.FromPtr(&ev.suppressBackground)
+	builtin["notify-bg-job-success"] = vars.FromPtr(&ev.notifyBgJobSuccess)
 	builtin["pwd"] = PwdVariable{ev}
 
 	return ev

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -34,8 +34,8 @@ const (
 )
 
 const (
-	defaultValuePrefix = "▶ "
-	initIndent         = vals.NoPretty
+	defaultValuePrefix        = "▶ "
+	initIndent                = vals.NoPretty
 	defaultSuppressBackground = false
 )
 
@@ -43,12 +43,12 @@ const (
 // shared among all evalCtx instances.
 type Evaler struct {
 	evalerScopes
-	valuePrefix  string
+	valuePrefix        string
 	suppressBackground bool
-	beforeChdir  []func(string)
-	afterChdir   []func(string)
-	DaemonClient *daemon.Client
-	modules      map[string]Ns
+	beforeChdir        []func(string)
+	afterChdir         []func(string)
+	DaemonClient       *daemon.Client
+	modules            map[string]Ns
 	// bundled modules
 	bundled map[string]string
 	Editor  Editor
@@ -66,7 +66,7 @@ func NewEvaler() *Evaler {
 	builtin := builtinNs.Clone()
 
 	ev := &Evaler{
-		valuePrefix: defaultValuePrefix,
+		valuePrefix:        defaultValuePrefix,
 		suppressBackground: defaultSuppressBackground,
 		evalerScopes: evalerScopes{
 			Global:  make(Ns),


### PR DESCRIPTION
Fixes #683 

Allow the suppression of the `job ... finished` message after a background process finishes.  Message suppression is controlled by the new builtin variable `suppress-background`.  A value of "true" will suppress any background notification messages.  Errors are always printed regardless of how `suppress-background` is set.