### PR TITLE
Add variable to track number of background jobs

### DIFF
--- a/eval/compile_op.go
+++ b/eval/compile_op.go
@@ -75,6 +75,7 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 		fm = fm.fork("background job" + op.source)
 		fm.intCh = nil
 		fm.background = true
+		fm.Evaler.numBgJobs++
 
 		if fm.Editor != nil {
 			// TODO: Redirect output in interactive mode so that the line
@@ -135,6 +136,7 @@ func (op *pipelineOp) Invoke(fm *Frame) error {
 		// Background job, wait for form termination asynchronously.
 		go func() {
 			wg.Wait()
+			fm.Evaler.numBgJobs--
 			msg := "job " + op.source + " finished"
 			err := ComposeExceptionsFromPipeline(errors)
 			if err != nil {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -36,6 +36,7 @@ const (
 const (
 	defaultValuePrefix        = "▶ "
 	defaultNotifyBgJobSuccess = true
+	defaultNumBgJobs          = 0
 	initIndent                = vals.NoPretty
 )
 
@@ -45,6 +46,7 @@ type Evaler struct {
 	evalerScopes
 	valuePrefix        string
 	notifyBgJobSuccess bool
+	numBgJobs          int
 	beforeChdir        []func(string)
 	afterChdir         []func(string)
 	DaemonClient       *daemon.Client
@@ -68,6 +70,7 @@ func NewEvaler() *Evaler {
 	ev := &Evaler{
 		valuePrefix:        defaultValuePrefix,
 		notifyBgJobSuccess: defaultNotifyBgJobSuccess,
+		numBgJobs:          defaultNumBgJobs,
 		evalerScopes: evalerScopes{
 			Global:  make(Ns),
 			Builtin: builtin,
@@ -90,6 +93,7 @@ func NewEvaler() *Evaler {
 
 	builtin["value-out-indicator"] = vars.FromPtr(&ev.valuePrefix)
 	builtin["notify-bg-job-success"] = vars.FromPtr(&ev.notifyBgJobSuccess)
+	builtin["num-bg-jobs"] = vars.FromPtr(&ev.numBgJobs)
 	builtin["pwd"] = PwdVariable{ev}
 
 	return ev


### PR DESCRIPTION
Pretty much what it says in the subject, added in a variable to track the number of background jobs.  The most obvious use for something like this is to create a prompt notification about background jobs but it could potentially have other uses as well, such as warning the user if they try to exit the shell with jobs still running in the background.