### PR TITLE
Support for arg-desc element in option maps to complete-getopt

### DIFF
--- a/edit/completion/compl_getopt.go
+++ b/edit/completion/compl_getopt.go
@@ -19,6 +19,7 @@ func complGetopt(fm *eval.Frame, elemsv, optsv, argsv interface{}) {
 		variadic bool
 	)
 	desc := make(map[*getopt.Option]string)
+	argdesc := make(map[*getopt.Option]string)
 	// Convert arguments.
 	err := vals.Iterate(elemsv, func(v interface{}) bool {
 		elem, ok := v.(string)
@@ -87,6 +88,9 @@ func complGetopt(fm *eval.Frame, elemsv, optsv, argsv interface{}) {
 		if s, ok := getStringField("desc"); ok {
 			desc[opt] = s
 		}
+		if s, ok := getStringField("arg-desc"); ok {
+			argdesc[opt] = s
+		}
 		opts = append(opts, opt)
 		return true
 	})
@@ -117,14 +121,22 @@ func complGetopt(fm *eval.Frame, elemsv, optsv, argsv interface{}) {
 	putShortOpt := func(opt *getopt.Option) {
 		c := &complexCandidate{stem: "-" + string(opt.Short)}
 		if d, ok := desc[opt]; ok {
-			c.displaySuffix = " (" + d + ")"
+			if e, ok := argdesc[opt]; ok {
+				c.displaySuffix = " " + e + " (" + d + ")"
+			} else {
+				c.displaySuffix = " (" + d + ")"
+			}
 		}
 		out <- c
 	}
 	putLongOpt := func(opt *getopt.Option) {
 		c := &complexCandidate{stem: "--" + opt.Long}
 		if d, ok := desc[opt]; ok {
-			c.displaySuffix = " (" + d + ")"
+			if e, ok := argdesc[opt]; ok {
+				c.displaySuffix = " " + e + " (" + d + ")"
+			} else {
+				c.displaySuffix = " (" + d + ")"
+			}
 		}
 		out <- c
 	}


### PR DESCRIPTION
If arg-desc is present, it gets added to the completion's display suffix, but outside the parenthesis. I.e.:

```
[&long=select &short=s &arg-desc="<type>" &desc="Select items"]
```

produces the following completion items:

```
▶ (edit:complex-candidate -s &code-suffix='' &display-suffix=' <type> (Select items)' &style='')
▶ (edit:complex-candidate --select &code-suffix='' &display-suffix=' <type> (Select items)' &style='')
```

I couldn't find any existing tests for complGetopt so I didn't know where to add tests for this - feel free to point me in the right direction.