### PR TITLE
Add support for -norc flag

### DIFF
--- a/program/program.go
+++ b/program/program.go
@@ -34,7 +34,7 @@ type flagSet struct {
 
 	Help, Version, BuildInfo, JSON bool
 
-	CodeInArg, CompileOnly, norc bool
+	CodeInArg, CompileOnly, NoRc bool
 
 	Web  bool
 	Port int
@@ -63,7 +63,7 @@ func newFlagSet() *flagSet {
 
 	f.BoolVar(&f.CodeInArg, "c", false, "take first argument as code to execute")
 	f.BoolVar(&f.CompileOnly, "compileonly", false, "Parse/Compile but do not execute")
-	f.BoolVar(&f.norc, "norc", false, "run elvish without invoking rc.elv")
+	f.BoolVar(&f.NoRc, "norc", false, "run elvish without invoking rc.elv")
 
 	f.BoolVar(&f.Web, "web", false, "run backend of web interface")
 	f.IntVar(&f.Port, "port", defaultWebPort, "the port of the web backend")
@@ -155,6 +155,6 @@ func FindProgram(flag *flagSet) Program {
 		}
 		return web.New(flag.Bin, flag.Sock, flag.DB, flag.Port)
 	default:
-		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly, flag.norc)
+		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly, flag.NoRc)
 	}
 }

--- a/program/program.go
+++ b/program/program.go
@@ -34,7 +34,7 @@ type flagSet struct {
 
 	Help, Version, BuildInfo, JSON bool
 
-	CodeInArg, CompileOnly bool
+	CodeInArg, CompileOnly, norc bool
 
 	Web  bool
 	Port int
@@ -63,6 +63,7 @@ func newFlagSet() *flagSet {
 
 	f.BoolVar(&f.CodeInArg, "c", false, "take first argument as code to execute")
 	f.BoolVar(&f.CompileOnly, "compileonly", false, "Parse/Compile but do not execute")
+	f.BoolVar(&f.norc, "norc", false, "run elvish without invoking rc.elv")
 
 	f.BoolVar(&f.Web, "web", false, "run backend of web interface")
 	f.IntVar(&f.Port, "port", defaultWebPort, "the port of the web backend")
@@ -154,6 +155,6 @@ func FindProgram(flag *flagSet) Program {
 		}
 		return web.New(flag.Bin, flag.Sock, flag.DB, flag.Port)
 	default:
-		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly)
+		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly, flag.norc)
 	}
 }

--- a/program/shell/interact.go
+++ b/program/shell/interact.go
@@ -29,7 +29,7 @@ func interact(ev *eval.Evaler, dataDir string, norc bool) {
 	defer ed.Close()
 
 	// Source rc.elv.
-	if norc == false && dataDir != "" {
+	if !norc && dataDir != "" {
 		err := sourceRC(ev, dataDir)
 		if err != nil {
 			util.PprintError(err)

--- a/program/shell/interact.go
+++ b/program/shell/interact.go
@@ -16,7 +16,7 @@ import (
 	"github.com/elves/elvish/util"
 )
 
-func interact(ev *eval.Evaler, dataDir string) {
+func interact(ev *eval.Evaler, dataDir string, norc bool) {
 	// Build Editor.
 	var ed editor
 	if sys.IsATTY(os.Stdin) {
@@ -29,7 +29,7 @@ func interact(ev *eval.Evaler, dataDir string) {
 	defer ed.Close()
 
 	// Source rc.elv.
-	if dataDir != "" {
+	if norc == false && dataDir != "" {
 		err := sourceRC(ev, dataDir)
 		if err != nil {
 			util.PprintError(err)

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -24,7 +24,7 @@ type Shell struct {
 	NoRc        bool
 }
 
-func New(binpath, sockpath, dbpath string, cmd, compileonly bool, norc bool) *Shell {
+func New(binpath, sockpath, dbpath string, cmd, compileonly, norc bool) *Shell {
 	return &Shell{binpath, sockpath, dbpath, cmd, compileonly, norc}
 }
 

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -21,7 +21,7 @@ type Shell struct {
 	DbPath      string
 	Cmd         bool
 	CompileOnly bool
-	norc        bool
+	NoRc        bool
 }
 
 func New(binpath, sockpath, dbpath string, cmd, compileonly bool, norc bool) *Shell {
@@ -45,7 +45,7 @@ func (sh *Shell) Main(args []string) int {
 			return 2
 		}
 	} else {
-		interact(ev, dataDir, sh.norc)
+		interact(ev, dataDir, sh.NoRc)
 	}
 
 	return 0

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -21,14 +21,15 @@ type Shell struct {
 	DbPath      string
 	Cmd         bool
 	CompileOnly bool
+	norc        bool
 }
 
-func New(binpath, sockpath, dbpath string, cmd, compileonly bool) *Shell {
-	return &Shell{binpath, sockpath, dbpath, cmd, compileonly}
+func New(binpath, sockpath, dbpath string, cmd, compileonly bool, norc bool) *Shell {
+	return &Shell{binpath, sockpath, dbpath, cmd, compileonly, norc}
 }
 
 // Main runs Elvish using the default terminal interface. It blocks until Elvish
-// quites, and returns the exit code.
+// quits, and returns the exit code.
 func (sh *Shell) Main(args []string) int {
 	defer rescue()
 
@@ -44,7 +45,7 @@ func (sh *Shell) Main(args []string) int {
 			return 2
 		}
 	} else {
-		interact(ev, dataDir)
+		interact(ev, dataDir, sh.norc)
 	}
 
 	return 0


### PR DESCRIPTION
Basically what it says in the title, adding support for a `-norc` flag to the Elvish shell.  Intended to be used for debugging/troubleshooting, or really anything that requires testing against a "stock" instance of Elvish without any customization that would normally be in a user's `rc.elv` file.