### PR TITLE
Add OpenBSD package instructions to download page.

### DIFF
--- a/_website/download/prelude.md
+++ b/_website/download/prelude.md
@@ -254,3 +254,12 @@ brew install elvish
 # Or install HEAD:
 brew install --HEAD elvish
 ```
+
+## OpenBSD
+
+Elvish is available in the official OpenBSD package repository. It will
+install the latest release:
+
+```elvish
+doas pkg_add elvish
+```


### PR DESCRIPTION
Hi!

I'm an OpenBSD developer; I committed a package for Elvish a few weeks ago:
https://marc.info/?l=openbsd-ports-cvs&m=153599043204210&w=2

This PR adds the OpenBSD package install instructions to the download page of the website.

Thanks!