### PR TITLE
Replace re:replace with replaces in epm

### DIFF
--- a/eval/bundled/epm.elv.go
+++ b/eval/bundled/epm.elv.go
@@ -278,7 +278,7 @@ fn query [pkg]{
 # List installed packages
 fn installed {
   put $-lib-dir/*[nomatch-ok] | each [dir]{
-    dom = (re:replace &literal $-lib-dir/ '' $dir)
+    dom = (replaces $-lib-dir/ '' $dir)
     cfg = (-domain-config $dom)
     # Only list domains for which we know the config, so that the user
     # can have his own non-package directories under ~/.elvish/lib


### PR DESCRIPTION
By using `replaces` it doesn't attempt to interpret \U as regex escape sequence. The \U comes from `C:\Users` which is like `/home` on Linux. 

This closes #755