### PR TITLE
Fix a few typos and misspellings

### DIFF
--- a/_website/learn/cookbook.md
+++ b/_website/learn/cookbook.md
@@ -206,7 +206,7 @@ If you come from other shells, hopefully the following recipes will get you star
     newline; while in bash or zsh, it creates a file whose name contains a
     backslash followed by `n`.
 
-*   Elementary floating-point arithmetics as well as comparisons are builtin,
+*   Elementary floating-point arithmetic as well as comparisons are builtin,
     with a prefix syntax:
 
     ```elvish-transcript

--- a/_website/ref/builtin.md
+++ b/_website/ref/builtin.md
@@ -144,7 +144,7 @@ sections. Their known problem is also discussed.
 / $dividend $divisor...
 ```
 
-Basic arithmetic operations of adding, substraction, multiplication and
+Basic arithmetic operations of adding, subtraction, multiplication and
 division respectively.
 
 All of them can take multiple arguments:
@@ -308,7 +308,7 @@ bar
 assoc $container $k $v
 ```
 
-Output a slighly modified version of `$container`, such that its value at `$k`
+Output a slightly modified version of `$container`, such that its value at `$k`
 is `$v`. Applies to both lists and to maps.
 
 When `$container` is a list, `$k` may be a negative index. However, slice is
@@ -1066,8 +1066,8 @@ Example (your output will differ):
 ▶ 14
 ```
 
-This command is intended for homogenous processing of possibly unbound data.
-If you need to do a fixed number of heterogenous things in parallel, use
+This command is intended for homogeneous processing of possibly unbound data.
+If you need to do a fixed number of heterogeneous things in parallel, use
 `run-parallel`.
 
 $cf each run-parallel
@@ -1374,8 +1374,8 @@ run-parallel {
 }
 ```
 
-This command is intended for doing a fixed number of heterogenous things in
-parallel. If you need homogenous parallel processing of possibly unbound data,
+This command is intended for doing a fixed number of heterogeneous things in
+parallel. If you need homogeneous parallel processing of possibly unbound data,
 use `peach` instead.
 
 $cf peach

--- a/_website/ref/language.md
+++ b/_website/ref/language.md
@@ -1595,7 +1595,7 @@ following modules:
 
 ## User-Defined Modules
 
-You can define your own modules with Elvishscript but putting them under
+You can define your own modules with Elvishscript by putting them under
 `~/.elvish/lib` and giving them a `.elv` extension. For instance, to define a
 module named `a`, store it in `~/.elvish/lib/a.elv`:
 
@@ -1619,7 +1619,7 @@ f from mod a
 The argument to `use` is called the **usespec** and will be explained in more
 details below. In the simplest case, it is simply the module name.
 
-Modules are evaluated in a seprate scope. That means that functions and
+Modules are evaluated in a separate scope. That means that functions and
 variables defined in the module does not pollute the default namespace, and
 vice versa. For instance, if you define `ls` as a wrapper function in
 `rc.elv`:


### PR DESCRIPTION
Correcting a handful of typos and spelling mistakes in the webpage documentation. 