### PR TITLE
eval: move restore functionality into assignmentOp

### DIFF
--- a/eval/boilerplate.go
+++ b/eval/boilerplate.go
@@ -41,15 +41,15 @@ func (cp *compiler) formOps(ns []*parse.Form) []effectOp {
 	return ops
 }
 
-func (cp *compiler) assignmentOp(n *parse.Assignment) effectOp {
+func (cp *compiler) assignmentOp(n *parse.Assignment, temporary bool) effectOp {
 	cp.compiling(n)
-	return effectOp{cp.assignment(n), n.Range().From, n.Range().To}
+	return effectOp{cp.assignment(n, temporary), n.Range().From, n.Range().To}
 }
 
-func (cp *compiler) assignmentOps(ns []*parse.Assignment) []effectOp {
+func (cp *compiler) assignmentOps(ns []*parse.Assignment, temporary bool) []effectOp {
 	ops := make([]effectOp, len(ns))
 	for i, n := range ns {
-		ops[i] = cp.assignmentOp(n)
+		ops[i] = cp.assignmentOp(n, temporary)
 	}
 	return ops
 }

--- a/eval/compile_lvalue_test.go
+++ b/eval/compile_lvalue_test.go
@@ -8,5 +8,10 @@ func TestAssignment(t *testing.T) {
 		That("x = [a]; x[0] = b; put $x[0]").Puts("b"),
 		That("x = a; { x = b }; put $x").Puts("b"),
 		That("x = [a]; { x[0] = b }; put $x[0]").Puts("b"),
+		// temporary variable
+		That("x=ok put $x").Puts("ok"),
+		That("x=ok put $x; put $x").Puts("ok").Errors(), // variable does not exist
+		// closure
+		That("f=[m]{ put $m } { $f ok }").Puts("ok"),
 	)
 }

--- a/eval/ns.go
+++ b/eval/ns.go
@@ -107,6 +107,10 @@ func (ns Ns) AddBuiltinFns(nsName string, fns map[string]interface{}) Ns {
 	return ns
 }
 
+func (ns Ns) Del(name string) {
+	delete(ns, name)
+}
+
 func addrOf(a interface{}) uintptr {
 	return reflect.ValueOf(a).Pointer()
 }

--- a/eval/op.go
+++ b/eval/op.go
@@ -26,7 +26,7 @@ func (op effectOp) exec(fm *Frame) error {
 	return op.body.invoke(fm)
 }
 
-// An operation on an Frame that produce Value's.
+// An operation on an Frame that produce Values.
 type valuesOp struct {
 	body       valuesOpBody
 	begin, end int
@@ -43,7 +43,7 @@ func (op valuesOp) exec(fm *Frame) ([]interface{}, error) {
 	return op.body.invoke(fm)
 }
 
-// An operation on a Frame that produce Variable's.
+// An operation on a Frame that produce Variables.
 type lvaluesOp struct {
 	body       lvaluesOpBody
 	begin, end int


### PR DESCRIPTION
This change makes assignmentOp mutable only on temporary assignment,
otherwise the outer Op needs to know how to deal with it.
Theoretically, lvaluesOp should tell which variable is new, but it
requires more changes to the underlying structures.

This fixes #532.