### PR TITLE
Namespace db paths incase $HOME is the same for multiple users

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -59,7 +59,7 @@ func InitRuntime(binpath, sockpath, dbpath string) (*eval.Evaler, string) {
 		fmt.Fprintln(os.Stderr, "warning: cannot create data directory ~/.elvish")
 	} else {
 		if dbpath == "" {
-			dbpath = filepath.Join(dataDir, "db")
+			dbpath = filepath.Join(dataDir, fmt.Sprintf("%d-db",os.Getuid()))
 		}
 	}
 


### PR DESCRIPTION
On my ubuntu machine, the $HOME is the same for `root` as well as the `ubuntu` user. When I switch to another user from `ubuntu` 

```sh
$ whoami
ubuntu
$ sudo -s
Cannot connect to daemon: unexpected RPC error on socket /tmp/elvish-0/sock: timeout
Daemon-related functions will likely not work.
Failed to initialize command history; disabled.
$ whoami
root
```

I looked into the codebase, and the issue was because of a timeout while trying to open the database. The database for the `root` user pointed to the database for the `ubuntu` user because of the default configuration of my ubuntu server installation. Both users had the same home_dir. Boltdb tries to acquire a lock on the existing dbfile, so that only one writer/reader can access it any time. It waits in-definitely in this case leading to the timeout.

By namespacing the db path to the uid, we sidestep this issue for multiple users sharing the same home dir. 

Tested.