### PR TITLE
add missing newline escape

### DIFF
--- a/_website/get/prelude.md
+++ b/_website/get/prelude.md
@@ -96,7 +96,7 @@ sudo wget -O /etc/apt/trusted.gpg.d/elvish \
   'https://sks-keyservers.net/pks/lookup?search=0xE9EA75D542E35A20&options=mr&op=get'
 sudo gpg --dearmor /etc/apt/trusted.gpg.d/elvish
 sudo rm /etc/apt/trusted.gpg.d/elvish
-echo 'deb http://ppa.launchpad.net/zhsj/elvish/ubuntu xenial main' |
+echo 'deb http://ppa.launchpad.net/zhsj/elvish/ubuntu xenial main' | \
   sudo tee /etc/apt/sources.list.d/elvish.list
 sudo apt-get update
 


### PR DESCRIPTION
install command for ubuntu/debian was incorrect on one command.