### PR TITLE
eval: add query commands to store module

### DIFF
--- a/eval/store/store.go
+++ b/eval/store/store.go
@@ -7,7 +7,9 @@ import (
 
 func Ns(s storedefs.Store) eval.Ns {
 	return eval.NewNs().AddGoFns("store:", map[string]interface{}{
-		"del-dir": s.DelDir,
-		"del-cmd": s.DelCmd,
+		"cmds":     s.Cmds,
+		"next-cmd": s.NextCmd,
+		"del-cmd":  s.DelCmd,
+		"del-dir":  s.DelDir,
 	})
 }


### PR DESCRIPTION
This change adds two query commands for querying command history from
underlying store. With the index from the previous result, one could
use "del-cmd" to delete it then.