### PR TITLE
[#760] Support JSON output in -compileonly

### DIFF
--- a/program/program.go
+++ b/program/program.go
@@ -159,6 +159,6 @@ func FindProgram(flag *flagSet) Program {
 		}
 		return web.New(flag.Bin, flag.Sock, flag.DB, flag.Port)
 	default:
-		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly, flag.NoRc, flag.NewEdit)
+		return shell.New(flag.Bin, flag.Sock, flag.DB, flag.CodeInArg, flag.CompileOnly, flag.NoRc, flag.NewEdit, flag.JSON)
 	}
 }

--- a/program/shell/errors_to_json.go
+++ b/program/shell/errors_to_json.go
@@ -40,7 +40,7 @@ func errorToJSON(err error) []byte {
 	}
 	jsonError, errMarshal := json.Marshal(e)
 	if errMarshal != nil {
-		return []byte(`[{"message":"Unable to convert the errors to JSON format"}]`)
+		return []byte(`[{"message":"Unable to convert the errors to JSON"}]`)
 	}
 	return jsonError
 }

--- a/program/shell/errors_to_json.go
+++ b/program/shell/errors_to_json.go
@@ -1,0 +1,47 @@
+package shell
+
+import (
+	"encoding/json"
+
+	"github.com/elves/elvish/eval"
+	"github.com/elves/elvish/parse"
+)
+
+// ErrorInJSON is the data structure for self-defined error
+type ErrorInJSON struct {
+	FileName string `json:"fileName"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Message  string `json:"message"`
+}
+
+// SimplifiedErrorInJSON is the data structure for errors which contain limited info
+type SimplifiedErrorInJSON struct {
+	Message string `json:"message"`
+}
+
+// ErrorToJSON converts the error into JSON format
+func ErrorToJSON(err error) string {
+	var e interface{}
+	switch err := err.(type) {
+	case *eval.CompilationError:
+		e = []interface{}{ErrorInJSON{err.Context.Name, err.Context.Begin, err.Context.End, err.Message}}
+	case *parse.MultiError:
+		e = processMultiError(err)
+	default:
+		e = []interface{}{SimplifiedErrorInJSON{err.Error()}}
+	}
+	jsonError, er := json.Marshal(e)
+	if er != nil {
+		return `[{"message":"Unable to convert the errors to JSON format"}]`
+	}
+	return string(jsonError)
+}
+
+func processMultiError(e *parse.MultiError) []ErrorInJSON {
+	var errArr []ErrorInJSON
+	for _, v := range e.Entries {
+		errArr = append(errArr, ErrorInJSON{v.Context.Name, v.Context.Begin, v.Context.End, v.Message})
+	}
+	return errArr
+}

--- a/program/shell/errors_to_json.go
+++ b/program/shell/errors_to_json.go
@@ -20,8 +20,8 @@ type simpleErrorInJSON struct {
 	Message string `json:"message"`
 }
 
-// ErrorToJSON converts the error into JSON format.
-func ErrorToJSON(err error) []byte {
+// Converts the error into JSON.
+func errorToJSON(err error) []byte {
 	var e interface{}
 	switch err := err.(type) {
 	case *eval.CompilationError:
@@ -38,8 +38,8 @@ func ErrorToJSON(err error) []byte {
 	default:
 		e = []interface{}{simpleErrorInJSON{err.Error()}}
 	}
-	jsonError, er := json.Marshal(e)
-	if er != nil {
+	jsonError, errMarshal := json.Marshal(e)
+	if errMarshal != nil {
 		return []byte(`[{"message":"Unable to convert the errors to JSON format"}]`)
 	}
 	return jsonError

--- a/program/shell/errors_to_json_test.go
+++ b/program/shell/errors_to_json_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestErrorsToJSON(t *testing.T) {
-	tt.Test(t, tt.Fn("ErrorToJSON", ErrorToJSON), tt.Table{
+	tt.Test(t, tt.Fn("errorToJSON", errorToJSON), tt.Table{
 		tt.Args(&eval.CompilationError{
 			Message: "ERR",
 			Context: diag.SourceRange{Name: "file", Begin: 5, End: 7}},

--- a/program/shell/errors_to_json_test.go
+++ b/program/shell/errors_to_json_test.go
@@ -7,41 +7,28 @@ import (
 	"github.com/elves/elvish/diag"
 	"github.com/elves/elvish/eval"
 	"github.com/elves/elvish/parse"
+	"github.com/elves/elvish/tt"
 )
 
-var errorsJSONTests = []struct {
-	in   error
-	want string
-}{
-	{
-		&eval.CompilationError{
+func TestErrorsToJSON(t *testing.T) {
+	tt.Test(t, tt.Fn("ErrorToJSON", ErrorToJSON), tt.Table{
+		tt.Args(&eval.CompilationError{
 			Message: "ERR",
 			Context: diag.SourceRange{Name: "file", Begin: 5, End: 7}},
-		`[{"fileName":"file","start":5,"end":7,"message":"ERR"}]`,
-	},
-	{
-		&parse.MultiError{Entries: []*parse.Error{
+		).Rets(
+			[]byte(`[{"fileName":"file","start":5,"end":7,"message":"ERR"}]`),
+		),
+		tt.Args(&parse.MultiError{Entries: []*parse.Error{
 			{
 				Message: "ERR1",
 				Context: diag.SourceRange{Name: "file1", Begin: 5, End: 7}},
 			{
 				Message: "ERR2",
 				Context: diag.SourceRange{Name: "file2", Begin: 15, End: 16}},
-		}},
-		`[{"fileName":"file1","start":5,"end":7,"message":"ERR1"},` +
-			`{"fileName":"file2","start":15,"end":16,"message":"ERR2"}]`,
-	},
-	{
-		errors.New("ERR"),
-		`[{"message":"ERR"}]`,
-	},
-}
-
-func TestErrorsToJSON(t *testing.T) {
-	for i, test := range errorsJSONTests {
-		s := ErrorToJSON(test.in)
-		if s != test.want {
-			t.Errorf("test #%d (error = %s, json = %s) failed", i, test.in, s)
-		}
-	}
+		}}).Rets(
+			[]byte(`[{"fileName":"file1","start":5,"end":7,"message":"ERR1"},` +
+				`{"fileName":"file2","start":15,"end":16,"message":"ERR2"}]`),
+		),
+		tt.Args(errors.New("ERR")).Rets([]byte(`[{"message":"ERR"}]`)),
+	})
 }

--- a/program/shell/errors_to_json_test.go
+++ b/program/shell/errors_to_json_test.go
@@ -1,0 +1,31 @@
+package shell
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elves/elvish/diag"
+	"github.com/elves/elvish/eval"
+	"github.com/elves/elvish/parse"
+)
+
+var errorsJSONTests = []struct {
+	in   error
+	want string
+}{
+	{&eval.CompilationError{Message: "This is a test error", Context: diag.SourceRange{Name: "CompileError", Source: "compile", Begin: 5, End: 7}}, `[{"fileName":"CompileError","start":5,"end":7,"message":"This is a test error"}]`},
+	{&parse.MultiError{Entries: []*parse.Error{
+		{Message: "This is a test error", Context: diag.SourceRange{Name: "ParseError", Source: "parse", Begin: 5, End: 7}},
+		{Message: "This is a test error", Context: diag.SourceRange{Name: "ParseError", Source: "parse", Begin: 15, End: 16}},
+	}}, `[{"fileName":"ParseError","start":5,"end":7,"message":"This is a test error"},{"fileName":"ParseError","start":15,"end":16,"message":"This is a test error"}]`},
+	{errors.New("This is a test error"), `[{"message":"This is a test error"}]`},
+}
+
+func TestErrorsToJSON(t *testing.T) {
+	for i, test := range errorsJSONTests {
+		s := ErrorToJSON(test.in)
+		if s != test.want {
+			t.Errorf("test #%d (error = %s, json = %s) failed", i, test.in, s)
+		}
+	}
+}

--- a/program/shell/errors_to_json_test.go
+++ b/program/shell/errors_to_json_test.go
@@ -13,12 +13,28 @@ var errorsJSONTests = []struct {
 	in   error
 	want string
 }{
-	{&eval.CompilationError{Message: "This is a test error", Context: diag.SourceRange{Name: "CompileError", Source: "compile", Begin: 5, End: 7}}, `[{"fileName":"CompileError","start":5,"end":7,"message":"This is a test error"}]`},
-	{&parse.MultiError{Entries: []*parse.Error{
-		{Message: "This is a test error", Context: diag.SourceRange{Name: "ParseError", Source: "parse", Begin: 5, End: 7}},
-		{Message: "This is a test error", Context: diag.SourceRange{Name: "ParseError", Source: "parse", Begin: 15, End: 16}},
-	}}, `[{"fileName":"ParseError","start":5,"end":7,"message":"This is a test error"},{"fileName":"ParseError","start":15,"end":16,"message":"This is a test error"}]`},
-	{errors.New("This is a test error"), `[{"message":"This is a test error"}]`},
+	{
+		&eval.CompilationError{
+			Message: "ERR",
+			Context: diag.SourceRange{Name: "file", Begin: 5, End: 7}},
+		`[{"fileName":"file","start":5,"end":7,"message":"ERR"}]`,
+	},
+	{
+		&parse.MultiError{Entries: []*parse.Error{
+			{
+				Message: "ERR1",
+				Context: diag.SourceRange{Name: "file1", Begin: 5, End: 7}},
+			{
+				Message: "ERR2",
+				Context: diag.SourceRange{Name: "file2", Begin: 15, End: 16}},
+		}},
+		`[{"fileName":"file1","start":5,"end":7,"message":"ERR1"},` +
+			`{"fileName":"file2","start":15,"end":16,"message":"ERR2"}]`,
+	},
+	{
+		errors.New("ERR"),
+		`[{"message":"ERR"}]`,
+	},
 }
 
 func TestErrorsToJSON(t *testing.T) {

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -49,7 +49,7 @@ func (sh *Shell) Main(args []string) int {
 		err := script(ev, args, sh.Cmd, sh.CompileOnly)
 		if err != nil {
 			if sh.CompileOnly && sh.JSON {
-				fmt.Println(ErrorToJSON(err))
+				fmt.Printf("%s\n", ErrorToJSON(err))
 			} else {
 				diag.PPrintError(err)
 			}

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -25,10 +25,11 @@ type Shell struct {
 	CompileOnly bool
 	NoRc        bool
 	NewEdit     bool
+	JSON        bool
 }
 
-func New(binpath, sockpath, dbpath string, cmd, compileonly, norc, newEdit bool) *Shell {
-	return &Shell{binpath, sockpath, dbpath, cmd, compileonly, norc, newEdit}
+func New(binpath, sockpath, dbpath string, cmd, compileonly, norc, newEdit, json bool) *Shell {
+	return &Shell{binpath, sockpath, dbpath, cmd, compileonly, norc, newEdit, json}
 }
 
 // Main runs Elvish using the default terminal interface. It blocks until Elvish
@@ -47,7 +48,11 @@ func (sh *Shell) Main(args []string) int {
 	if len(args) > 0 {
 		err := script(ev, args, sh.Cmd, sh.CompileOnly)
 		if err != nil {
-			diag.PPrintError(err)
+			if sh.CompileOnly && sh.JSON {
+				fmt.Println(ErrorToJSON(err))
+			} else {
+				diag.PPrintError(err)
+			}
 			return 2
 		}
 	} else {

--- a/program/shell/shell.go
+++ b/program/shell/shell.go
@@ -49,7 +49,7 @@ func (sh *Shell) Main(args []string) int {
 		err := script(ev, args, sh.Cmd, sh.CompileOnly)
 		if err != nil {
 			if sh.CompileOnly && sh.JSON {
-				fmt.Printf("%s\n", ErrorToJSON(err))
+				fmt.Printf("%s\n", errorToJSON(err))
 			} else {
 				diag.PPrintError(err)
 			}


### PR DESCRIPTION
Added the support for `-json` flag and transform the errors into array JSON format.