### PR TITLE
Add information for installing on FreeBSD

### DIFF
--- a/_website/get/prelude.md
+++ b/_website/get/prelude.md
@@ -115,6 +115,24 @@ brew install elvish
 brew install --HEAD elvish
 ```
 
+## FreeBSD
+
+Elvish is available in the FreeBSD ports tree and as a prebuilt package. Both
+methods will install the latest release:
+
+### Install With pkg:
+
+```elvish
+pkg install elvish
+```
+
+### Build From Ports:
+
+```elvish
+cd /usr/ports/shells/elvish
+make install
+```
+
 ## OpenBSD
 
 Elvish is available in the official OpenBSD package repository. This will


### PR DESCRIPTION
Added information for installing Elvish with `pkg` command (FreeBSD
package manager) and building Elvish from FreeBSD ports tree.

Signed-off-by: Adam Jimerson <vendion@gmail.com>