### PR TITLE
Fix `%` not to crash when divisor is 0

### DIFF
--- a/eval/builtin_fn_num.go
+++ b/eval/builtin_fn_num.go
@@ -139,7 +139,7 @@ func divide(fm *Frame, prod float64, nums ...float64) {
 	out <- vals.FromGo(prod)
 }
 
-func mod(fm *Frame, a, b int) (int, error) {
+func mod(a, b int) (int, error) {
 	if b == 0 {
 		return 0, ErrArgs
 	}

--- a/eval/builtin_fn_num.go
+++ b/eval/builtin_fn_num.go
@@ -28,7 +28,7 @@ func init() {
 		"*": times,
 		"/": slash,
 		"^": math.Pow,
-		"%": func(a, b int) int { return a % b },
+		"%": mod,
 
 		// Random
 		"rand":    rand.Float64,
@@ -137,6 +137,13 @@ func divide(fm *Frame, prod float64, nums ...float64) {
 		prod /= f
 	}
 	out <- vals.FromGo(prod)
+}
+
+func mod(fm *Frame, a, b int) (int, error) {
+	if b == 0 {
+		return 0, ErrArgs
+	}
+	return a % b, nil
 }
 
 func randint(low, high int) (int, error) {

--- a/eval/builtin_fn_num_test.go
+++ b/eval/builtin_fn_num_test.go
@@ -32,5 +32,6 @@ func TestBuiltinFnNum(t *testing.T) {
 		That("/ 1 0").Puts(math.Inf(1)),
 		That("^ 16 2").Puts(256.0),
 		That("% 23 7").Puts("2"),
+		That("% 1 0").Errors(),
 	)
 }


### PR DESCRIPTION
Executing `% 1 0` on elvish cause runtime error and elvish crash.
As one solution, I implemented mod function which returns ErrArgs if divisor is 0.