### PR TITLE
[#873] fix json output of -compileonly

### DIFF
--- a/cliedit/highlight/highlight.go
+++ b/cliedit/highlight/highlight.go
@@ -26,7 +26,7 @@ func highlight(code string, dep Dep, lateCb func(styled.Text)) (styled.Text, []e
 
 	n, errParse := parse.AsChunk("[interactive]", code)
 	if errParse != nil {
-		for _, err := range errParse.(parse.MultiError).Entries {
+		for _, err := range errParse.(*parse.MultiError).Entries {
 			if err.Context.Begin != len(code) {
 				errors = append(errors, err)
 			}

--- a/edit/edcore/edit.go
+++ b/edit/edcore/edit.go
@@ -273,7 +273,7 @@ func atEnd(e error, n int) bool {
 	switch e := e.(type) {
 	case *eval.CompilationError:
 		return e.Context.Begin == n
-	case parse.MultiError:
+	case *parse.MultiError:
 		for _, entry := range e.Entries {
 			if entry.Context.Begin != n {
 				return false

--- a/parse/error.go
+++ b/parse/error.go
@@ -23,7 +23,7 @@ func (me *MultiError) add(msg string, ctx *diag.SourceRange) {
 }
 
 // Error returns a string representation of the error.
-func (me MultiError) Error() string {
+func (me *MultiError) Error() string {
 	switch len(me.Entries) {
 	case 0:
 		return "no parse error"
@@ -44,7 +44,7 @@ func (me MultiError) Error() string {
 }
 
 // PPrint pretty-prints the error.
-func (me MultiError) PPrint(indent string) string {
+func (me *MultiError) PPrint(indent string) string {
 	switch len(me.Entries) {
 	case 0:
 		return "no parse error"

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -279,7 +279,7 @@ func TestParseError(t *testing.T) {
 			t.Errorf("Parse(%q) returns no error", tc.src)
 			continue
 		}
-		posErr0 := err.(MultiError).Entries[0]
+		posErr0 := err.(*MultiError).Entries[0]
 		if posErr0.Context.Begin != tc.pos {
 			t.Errorf("Parse(%q) first error begins at %d, want %d. Errors are:%s\n", tc.src, posErr0.Context.Begin, tc.pos, err)
 		}

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -65,7 +65,7 @@ func (ps *parser) done() {
 // Assembles all parsing errors as one, or returns nil if there were no errors.
 func (ps *parser) assembleError() error {
 	if len(ps.errors.Entries) > 0 {
-		return ps.errors
+		return &ps.errors
 	}
 	return nil
 }


### PR DESCRIPTION
The [`errorToJSON()`](https://github.com/elves/elvish/blob/master/program/shell/errors_to_json.go#L31) method checks whether the error returned is a `*parse.MultiError`. However, rather than a pointer to a `MultiError`, an instance was being passed in. 

Updated the the instance methods of `MultiError` to take pointers as receivers to be in line with what was expected. This further required updating some other references.