### PR TITLE
pkg/edit: Introduce before-add-cmd hook

### DIFF
--- a/pkg/edit/config_api.go
+++ b/pkg/edit/config_api.go
@@ -49,6 +49,16 @@ func initAfterReadline(appSpec *cli.AppSpec, ev *eval.Evaler, ns eval.Ns) {
 	})
 }
 
+//elvdoc:var add-cmd-filters
+//
+// List of filters to run before adding a command to history.
+//
+// A filter is a function that takes a command as argument and outputs
+// a boolean value. If any of the filters outputs `$false`, the
+// command is not saved to history, and the rest of the filters are
+// not run. The default value of this list contains a filter which
+// ignores command starts with space.
+
 func callHooks(ev *eval.Evaler, name string, hook vals.List, args ...interface{}) {
 	i := -1
 	for it := hook.Iterator(); it.HasElem(); it.Next() {
@@ -68,6 +78,44 @@ func callHooks(ev *eval.Evaler, name string, hook vals.List, args ...interface{}
 		fm := eval.NewTopFrame(ev, parse.Source{Name: name}, ports)
 		fn.Call(fm, args, eval.NoOpts)
 	}
+}
+
+func callFilters(ev *eval.Evaler, name string, filters vals.List, args ...interface{}) bool {
+	i := -1
+	for it := filters.Iterator(); it.HasElem(); it.Next() {
+		i++
+		name := fmt.Sprintf("%s[%d]", name, i)
+		fn, ok := it.Elem().(eval.Callable)
+		if !ok {
+			// TODO(xiaq): This is not testable as it depends on stderr.
+			// Make it testable.
+			diag.Complainf(os.Stderr, "%s not function", name)
+			continue
+		}
+		// TODO(xiaq): This should use stdPorts, but stdPorts is currently
+		// unexported from eval.
+		ports := []*eval.Port{
+			eval.DevNullClosedChan, {File: os.Stdout}, {File: os.Stderr}}
+		fm := eval.NewTopFrame(ev, parse.Source{Name: name}, ports)
+		out, err := fm.CaptureOutput(func(fm *eval.Frame) error { return fn.Call(fm, args, eval.NoOpts) })
+		if err != nil {
+			diag.Complainf(os.Stderr, "%s return error", name)
+			continue
+		}
+		if len(out) != 1 {
+			diag.Complainf(os.Stderr, "filter %s should only return $true or $false", name)
+			continue
+		}
+		p, ok := out[0].(bool)
+		if !ok {
+			diag.Complainf(os.Stderr, "filter %s should return bool", name)
+			continue
+		}
+		if !p {
+			return false
+		}
+	}
+	return true
 }
 
 func newIntVar(i int) vars.PtrVar            { return vars.FromPtr(&i) }

--- a/pkg/edit/editor_test.go
+++ b/pkg/edit/editor_test.go
@@ -27,14 +27,95 @@ func TestEditor_DoesNotAddEmptyCommandToHistory(t *testing.T) {
 	testCommands(t, f.Store /* no commands */)
 }
 
-func TestEditor_DoesCommandWithLeadingSpaceToHistory(t *testing.T) {
-	f := setup()
+func TestEditor_TestAddCmdFilters(t *testing.T) {
+	cases := []struct {
+		name        string
+		rc          string
+		input       string
+		wantHistory []string
+	}{
+		// TODO: Enable the following two tests once error output can
+		// be tested.
+		// {
+		// 	name:        "non callable item",
+		// 	rc:          "edit:add-cmd-filters = [$false]",
+		// 	input:       "echo\n",
+		// 	wantHistory: []string{"echo"},
+		// },
+		// {
+		// 	name:        "callback outputs nothing",
+		// 	rc:          "edit:add-cmd-filters = [[_]{}]",
+		// 	input:       "echo\n",
+		// 	wantHistory: []string{"echo"},
+		// },
+		{
+			name:        "callback outputs true",
+			rc:          "edit:add-cmd-filters = [[_]{ put $true }]",
+			input:       "echo\n",
+			wantHistory: []string{"echo"},
+		},
+		{
+			name:        "callback outputs false",
+			rc:          "edit:add-cmd-filters = [[_]{ put $false }]",
+			input:       "echo\n",
+			wantHistory: nil,
+		},
+		{
+			name:        "false-true chain",
+			rc:          "edit:add-cmd-filters = [[_]{ put $false } [_]{ put $true }]",
+			input:       "echo\n",
+			wantHistory: nil,
+		},
+		{
+			name:        "true-false chain",
+			rc:          "edit:add-cmd-filters = [[_]{ put $true } [_]{ put $false }]",
+			input:       "echo\n",
+			wantHistory: nil,
+		},
+		{
+			name:        "positive",
+			rc:          "edit:add-cmd-filters = [[cmd]{ ==s $cmd echo }]",
+			input:       "echo\n",
+			wantHistory: []string{"echo"},
+		},
+		{
+			name:        "negative",
+			rc:          "edit:add-cmd-filters = [[cmd]{ ==s $cmd echo }]",
+			input:       "echo x\n",
+			wantHistory: nil,
+		},
+		{
+			name:        "default value",
+			rc:          "",
+			input:       " echo\n",
+			wantHistory: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := setup(rc(c.rc))
+			defer f.Cleanup()
+
+			feedInput(f.TTYCtrl, c.input)
+			f.Wait()
+
+			testCommands(t, f.Store, c.wantHistory...)
+		})
+	}
+}
+
+func TestEditor_AddCmdFiltersHasShortCircuit(t *testing.T) {
+	f := setup(rc(
+		`called = $false`,
+		`@edit:add-cmd-filters = [_]{ put $false } [_]{ called = $true; put $true }`,
+	))
 	defer f.Cleanup()
 
-	feedInput(f.TTYCtrl, " echo\n")
+	feedInput(f.TTYCtrl, "echo\n")
 	f.Wait()
-
-	testCommands(t, f.Store /* no commands */)
+	testCommands(t, f.Store)
+	testGlobal(t, f.Evaler, "called", false)
 }
 
 func testCommands(t *testing.T, store store.Store, wantCmds ...string) {


### PR DESCRIPTION
edit:before-add-cmd hook let its functions check the command about to save
and output a stirng. If the string is non-empty, it will be passed to
the next function in the hook chain as input and finally saved to db;
otherwise the command will be ignored.

Edit: this variable has been renamed to `edit:add-cmd-filters` as suggested by @xiaq. A `filter` is a bit different than a `hook`, it outputs a boolean value to indicate whether the argument to it passed the the check or not. 