### PR TITLE
pkg/eval: Add commands append and concat

### DIFF
--- a/pkg/cli/lscolors/feature_string.go
+++ b/pkg/cli/lscolors/feature_string.go
@@ -4,6 +4,30 @@ package lscolors
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[featureInvalid-0]
+	_ = x[featureOrphanedSymlink-1]
+	_ = x[featureSymlink-2]
+	_ = x[featureMultiHardLink-3]
+	_ = x[featureNamedPipe-4]
+	_ = x[featureSocket-5]
+	_ = x[featureDoor-6]
+	_ = x[featureBlockDevice-7]
+	_ = x[featureCharDevice-8]
+	_ = x[featureWorldWritableStickyDirectory-9]
+	_ = x[featureWorldWritableDirectory-10]
+	_ = x[featureStickyDirectory-11]
+	_ = x[featureDirectory-12]
+	_ = x[featureCapability-13]
+	_ = x[featureSetuid-14]
+	_ = x[featureSetgid-15]
+	_ = x[featureExecutable-16]
+	_ = x[featureRegular-17]
+}
+
 const _feature_name = "featureInvalidfeatureOrphanedSymlinkfeatureSymlinkfeatureMultiHardLinkfeatureNamedPipefeatureSocketfeatureDoorfeatureBlockDevicefeatureCharDevicefeatureWorldWritableStickyDirectoryfeatureWorldWritableDirectoryfeatureStickyDirectoryfeatureDirectoryfeatureCapabilityfeatureSetuidfeatureSetgidfeatureExecutablefeatureRegular"
 
 var _feature_index = [...]uint16{0, 14, 36, 50, 70, 86, 99, 110, 128, 145, 180, 209, 231, 247, 264, 277, 290, 307, 321}

--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -28,9 +28,11 @@ func init() {
 		"has-key":   hasKey,
 		"has-value": hasValue,
 
-		"take":  take,
-		"drop":  drop,
-		"count": count,
+		"take":   take,
+		"drop":   drop,
+		"count":  count,
+		"append": appendElvish,
+		"concat": concat,
 
 		"keys": keys,
 	})
@@ -192,6 +194,18 @@ func count(fm *Frame, args ...interface{}) (int, error) {
 		return 0, errors.New("want 0 or 1 argument")
 	}
 	return n, nil
+}
+
+func appendElvish(list vals.List, value interface{}) vals.List {
+	return list.Cons(value)
+}
+
+func concat(list vals.List, list2 vals.List) vals.List {
+	newList := list
+	for it := list2.Iterator(); it.HasElem(); it.Next() {
+		newList = newList.Cons(it.Elem())
+	}
+	return newList
 }
 
 func keys(fm *Frame, v interface{}) error {

--- a/pkg/eval/builtin_fn_container_test.go
+++ b/pkg/eval/builtin_fn_container_test.go
@@ -40,6 +40,9 @@ func TestBuiltinFnContainer(t *testing.T) {
 		That(`count [(range 100)]`).Puts("100"),
 		That(`count 1 2 3`).ThrowsAny(),
 
+		That(`explode (append [1 2] 3)`).Puts("1", "2", "3"),
+		That(`explode (concat [1 2] [3 4])`).Puts("1", "2", "3", "4"),
+
 		That(`keys [&]`).DoesNothing(),
 		That(`keys [&a=foo]`).Puts("a"),
 		// Windows does not have an external sort command. Disabled until we have a

--- a/pkg/getopt/string.go
+++ b/pkg/getopt/string.go
@@ -4,6 +4,15 @@ package getopt
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[DoubleDashTerminatesOptions-1]
+	_ = x[FirstArgTerminatesOptions-2]
+	_ = x[LongOnly-4]
+}
+
 const (
 	_Config_name_0 = "DoubleDashTerminatesOptionsFirstArgTerminatesOptions"
 	_Config_name_1 = "LongOnly"
@@ -24,6 +33,14 @@ func (i Config) String() string {
 		return "Config(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 }
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[NoArgument-0]
+	_ = x[RequiredArgument-1]
+	_ = x[OptionalArgument-2]
+}
 
 const _HasArg_name = "NoArgumentRequiredArgumentOptionalArgument"
 
@@ -34,6 +51,18 @@ func (i HasArg) String() string {
 		return "HasArg(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _HasArg_name[_HasArg_index[i]:_HasArg_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[NewOptionOrArgument-0]
+	_ = x[NewOption-1]
+	_ = x[NewLongOption-2]
+	_ = x[LongOption-3]
+	_ = x[ChainShortOption-4]
+	_ = x[OptionArgument-5]
+	_ = x[Argument-6]
 }
 
 const _ContextType_name = "NewOptionOrArgumentNewOptionNewLongOptionLongOptionChainShortOptionOptionArgumentArgument"

--- a/pkg/parse/string.go
+++ b/pkg/parse/string.go
@@ -4,6 +4,25 @@ package parse
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[BadPrimary-0]
+	_ = x[Bareword-1]
+	_ = x[SingleQuoted-2]
+	_ = x[DoubleQuoted-3]
+	_ = x[Variable-4]
+	_ = x[Wildcard-5]
+	_ = x[Tilde-6]
+	_ = x[ExceptionCapture-7]
+	_ = x[OutputCapture-8]
+	_ = x[List-9]
+	_ = x[Lambda-10]
+	_ = x[Map-11]
+	_ = x[Braced-12]
+}
+
 const _PrimaryType_name = "BadPrimaryBarewordSingleQuotedDoubleQuotedVariableWildcardTildeExceptionCaptureOutputCaptureListLambdaMapBraced"
 
 var _PrimaryType_index = [...]uint8{0, 10, 18, 30, 42, 50, 58, 63, 79, 92, 96, 102, 105, 111}
@@ -13,6 +32,16 @@ func (i PrimaryType) String() string {
 		return "PrimaryType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _PrimaryType_name[_PrimaryType_index[i]:_PrimaryType_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[BadRedirMode-0]
+	_ = x[Read-1]
+	_ = x[Write-2]
+	_ = x[ReadWrite-3]
+	_ = x[Append-4]
 }
 
 const _RedirMode_name = "BadRedirModeReadWriteReadWriteAppend"
@@ -24,6 +53,16 @@ func (i RedirMode) String() string {
 		return "RedirMode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _RedirMode_name[_RedirMode_index[i]:_RedirMode_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[NormalExpr-0]
+	_ = x[CmdExpr-1]
+	_ = x[LHSExpr-2]
+	_ = x[BracedElemExpr-3]
+	_ = x[strictExpr-4]
 }
 
 const _ExprCtx_name = "NormalExprCmdExprLHSExprBracedElemExprstrictExpr"


### PR DESCRIPTION
This adds two basic functions for working with lists. Elvish already allows both operations by special syntax, but it's often useful to have them as functions.