### PR TITLE
Appends pathSeparator to dir name

### DIFF
--- a/pkg/edit/complete/complete_test.go
+++ b/pkg/edit/complete/complete_test.go
@@ -109,9 +109,8 @@ func TestComplete(t *testing.T) {
 		},
 	}
 
-	pathSep := parse.Quote(string(os.PathSeparator))
 	allFileNameItems := []completion.Item{
-		fc("a.exe", " "), fc("d", pathSep), fc("non-exe", " "),
+		fc("a.exe", " "), fc("d" + string(os.PathSeparator), ""), fc("non-exe", " "),
 	}
 
 	allCommandItems := []completion.Item{
@@ -244,7 +243,7 @@ func TestComplete(t *testing.T) {
 			panic(err)
 		}
 		allLocalCommandItems := []completion.Item{
-			fc("./a.exe", " "), fc("./d", "/"), fc("./d2", "/"),
+			fc("./a.exe", " "), fc("./d/", ""), fc("./d2/", ""),
 		}
 		tt.Test(t, tt.Fn("Complete", Complete), tt.Table{
 			// Filename completion treats symlink to directories as directories.
@@ -252,7 +251,7 @@ func TestComplete(t *testing.T) {
 			Args(cb("p > d"), cfg).Rets(
 				&Result{
 					Name: "redir", Replace: r(4, 5),
-					Items: []completion.Item{fc("d", "/"), fc("d2", "/")}},
+					Items: []completion.Item{fc("d/", ""), fc("d2/", "")}},
 				nil,
 			),
 
@@ -280,10 +279,8 @@ func cb(s string) CodeBuffer { return CodeBuffer{s, len(s)} }
 func c(s string) completion.Item { return completion.Item{ToShow: s, ToInsert: s} }
 
 func fc(s, suffix string) completion.Item {
-	return completion.Item{ToShow: s, ToInsert: s + suffix,
+	return completion.Item{ToShow: s, ToInsert: parse.Quote(s) + suffix,
 		ShowStyle: ui.StyleFromSGR(lscolors.GetColorist().GetStyle(s))}
 }
 
 func r(i, j int) diag.Ranging { return diag.Ranging{From: i, To: j} }
-
-func withPathSeparator(d string) string { return d + parse.Quote(string(os.PathSeparator)) }

--- a/pkg/edit/complete/generators.go
+++ b/pkg/edit/complete/generators.go
@@ -10,12 +10,11 @@ import (
 	"github.com/elves/elvish/pkg/cli/lscolors"
 	"github.com/elves/elvish/pkg/eval"
 	"github.com/elves/elvish/pkg/eval/vals"
-	"github.com/elves/elvish/pkg/parse"
 	"github.com/elves/elvish/pkg/ui"
 	"github.com/elves/elvish/pkg/util"
 )
 
-var quotedPathSeparator = parse.Quote(string(filepath.Separator))
+var pathSeparator = string(filepath.Separator)
 
 // GenerateFileNames returns filename candidates that are suitable for completing
 // the last argument. It can be used in Config.ArgGenerator.
@@ -123,19 +122,24 @@ func generateFileNames(seed string, onlyExecutable bool) ([]RawItem, error) {
 		// Full filename for source and getStyle.
 		full := dir + name
 
+		// Will be set to an empty space for non-directories
 		suffix := " "
+
 		if info.IsDir() {
-			suffix = quotedPathSeparator
+			full += pathSeparator
+			suffix = ""
 		} else if info.Mode()&os.ModeSymlink != 0 {
 			stat, err := os.Stat(full)
 			if err == nil && stat.IsDir() {
 				// Symlink to directory.
-				suffix = quotedPathSeparator
+				full += pathSeparator
+				suffix = ""
 			}
 		}
 
 		items = append(items, ComplexItem{
-			Stem: full, CodeSuffix: suffix,
+			Stem:         full,
+			CodeSuffix:   suffix,
 			DisplayStyle: ui.StyleFromSGR(lsColor.GetStyle(full)),
 		})
 	}


### PR DESCRIPTION
> * The old quotedPathSeparator was renamed to pathSeparator
> * pathSeparator is not put inside quotes before it is used
> * Instead of using the pathSeparator in quotes a suffix, it is appended
>   to the full directory name and afterwords wrapped into quotes iff
>   necessary

Not quite sure that is what you intended, but it seems to work for me just fine :)

Looking forward to a small code review from you.