### PR TITLE
Windows pathsep

### DIFF
--- a/pkg/edit/builtins.go
+++ b/pkg/edit/builtins.go
@@ -184,7 +184,7 @@ var bufferBuiltinsData = map[string]func(*cli.CodeBuffer){
 	"move-dot-right":            makeMove(moveDotRight),
 	"move-dot-left-word":        makeMove(moveDotLeftWord),
 	"move-dot-right-word":       makeMove(moveDotRightWord),
-	"move-dot-left-small-word":  makeMove(moveDotLeftWord),
+	"move-dot-left-small-word":  makeMove(moveDotLeftSmallWord),
 	"move-dot-right-small-word": makeMove(moveDotRightSmallWord),
 	"move-dot-left-alnum-word":  makeMove(moveDotLeftAlnumWord),
 	"move-dot-right-alnum-word": makeMove(moveDotRightAlnumWord),

--- a/pkg/edit/complete/complete_test.go
+++ b/pkg/edit/complete/complete_test.go
@@ -109,7 +109,7 @@ func TestComplete(t *testing.T) {
 		},
 	}
 
-	pathSep := parse.Quote(string(os.PathSeparator))
+	pathSep := parse.Quote("/")
 	allFileNameItems := []completion.Item{
 		fc("a.exe", " "), fc("d", pathSep), fc("non-exe", " "),
 	}
@@ -286,4 +286,4 @@ func fc(s, suffix string) completion.Item {
 
 func r(i, j int) diag.Ranging { return diag.Ranging{From: i, To: j} }
 
-func withPathSeparator(d string) string { return d + parse.Quote(string(os.PathSeparator)) }
+func withPathSeparator(d string) string { return d + parse.Quote("/") }

--- a/pkg/edit/complete/generators.go
+++ b/pkg/edit/complete/generators.go
@@ -116,7 +116,7 @@ func generateFileNames(seed string, onlyExecutable bool) ([]RawItem, error) {
 		}
 		// Only accept searchable directories and executable files if
 		// executableOnly is true.
-		if onlyExecutable && (info.Mode()&0111) == 0 {
+		if onlyExecutable && !util.IsExecutableFile(info) {
 			continue
 		}
 

--- a/pkg/edit/complete/generators.go
+++ b/pkg/edit/complete/generators.go
@@ -15,7 +15,7 @@ import (
 	"github.com/elves/elvish/pkg/util"
 )
 
-var quotedPathSeparator = parse.Quote(string(filepath.Separator))
+var quotedPathSeparator = parse.Quote("/")
 
 // GenerateFileNames returns filename candidates that are suitable for completing
 // the last argument. It can be used in Config.ArgGenerator.

--- a/pkg/edit/highlight.go
+++ b/pkg/edit/highlight.go
@@ -98,7 +98,7 @@ func hasFn(ns eval.Ns, name string) bool {
 
 func isDirOrExecutable(fname string) bool {
 	stat, err := os.Stat(fname)
-	return err == nil && (stat.IsDir() || stat.Mode()&0111 != 0)
+	return err == nil && (stat.IsDir() || util.IsExecutableFile(stat))
 }
 
 func hasExternalCommand(cmd string) bool {

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -236,7 +236,7 @@ func (ev *Evaler) SetLibDir(libDir string) {
 }
 
 func searchPaths() []string {
-	return strings.Split(os.Getenv("PATH"), ":")
+	return strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
 }
 
 // growPorts makes the size of ec.ports at least n, adding nil's if necessary.

--- a/pkg/eval/external_cmd.go
+++ b/pkg/eval/external_cmd.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"runtime"
 	"syscall"
 
 	"github.com/elves/elvish/pkg/eval/vals"
@@ -97,12 +96,6 @@ func (e ExternalCmd) Call(fm *Frame, argVals []interface{}, opts map[string]inte
 	return NewExternalCmdExit(e.Name, state.Sys().(syscall.WaitStatus), proc.Pid)
 }
 
-var osHasNoExecutableBit bool
-
-func init() {
-	osHasNoExecutableBit = runtime.GOOS == "windows"
-}
-
 // EachExternal calls f for each name that can resolve to an external
 // command.
 // TODO(xiaq): Windows support
@@ -111,7 +104,7 @@ func EachExternal(f func(string)) {
 		// XXX Ignore error
 		infos, _ := ioutil.ReadDir(dir)
 		for _, info := range infos {
-			if !info.IsDir() && (info.Mode()&0111 != 0 || osHasNoExecutableBit) {
+			if !info.IsDir() && util.IsExecutableFile(info) {
 				f(info.Name())
 			}
 		}

--- a/pkg/util/search.go
+++ b/pkg/util/search.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -20,5 +21,16 @@ func IsExecutable(path string) bool {
 		return false
 	}
 	fm := fi.Mode()
-	return !fm.IsDir() && (fm&0111 != 0)
+	return !fm.IsDir() && IsExecutableFile(fi)
+}
+
+var osHasNoExecutableBit bool
+
+func init() {
+	osHasNoExecutableBit = runtime.GOOS == "windows"
+}
+
+// IsExecutableFile returns true if the item denoted by info is executable on the runtime platform
+func IsExecutableFile(info os.FileInfo) bool {
+	return (info.Mode()&0111 != 0 || osHasNoExecutableBit)
 }


### PR DESCRIPTION
Relating to #897, in my daily use I have found that completing Windows paths with slashes is usually better than with escaped backslashes, even if not entirely correct. This is due to the slash being a character that needs not be escaped. Completion with a character that is only valid in quotes does not feel good in everyday usage, at least to me -- even if it works.

This PR fixes several completion uses I had when using Elvish on Windows 10 (as well as a typo in pkg/edit/builtins.go, for which I couldn't be bothered to open an extra PR). 

Let me know what you think!

Further enhancements could include the quoted string concatenation function mentioned in #897, and using it to complete backslashy paths as-is, but still use slashes as default for relative navigation, or making the behaviour configurable.