### PR TITLE
Initial crude attempt at adding a built-in variable which returns the runtime OS

### DIFF
--- a/pkg/eval/builtin_ns.go
+++ b/pkg/eval/builtin_ns.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"strconv"
 	"syscall"
+        "runtime"
 
 	"github.com/elves/elvish/pkg/eval/vars"
 	"github.com/xiaq/persistent/vector"
@@ -87,6 +88,7 @@ var builtinNs = Ns{
 	"nil":   vars.NewReadOnly(nil),
 	"true":  vars.NewReadOnly(true),
 	"false": vars.NewReadOnly(false),
+        "os":    vars.NewReadOnly(runtime.GOOS),
 	"paths": &EnvList{envName: "PATH"},
 	"pwd":   PwdVariable{},
 	"args":  vars.NewReadOnly(vector.Empty),

--- a/pkg/eval/builtin_ns.go
+++ b/pkg/eval/builtin_ns.go
@@ -1,9 +1,9 @@
 package eval
 
 import (
+	"runtime"
 	"strconv"
 	"syscall"
-        "runtime"
 
 	"github.com/elves/elvish/pkg/eval/vars"
 	"github.com/xiaq/persistent/vector"
@@ -88,7 +88,7 @@ var builtinNs = Ns{
 	"nil":   vars.NewReadOnly(nil),
 	"true":  vars.NewReadOnly(true),
 	"false": vars.NewReadOnly(false),
-        "os":    vars.NewReadOnly(runtime.GOOS),
+	"os":    vars.NewReadOnly(runtime.GOOS),
 	"paths": &EnvList{envName: "PATH"},
 	"pwd":   PwdVariable{},
 	"args":  vars.NewReadOnly(vector.Empty),


### PR DESCRIPTION
**NOT FOR MERGE YET** - this is meant for discussion.

This originated from some discussion in Telegram about how it would be useful sometimes to easily identify the OS in which Elvish is running (e.g. to have functions which execute different commands depending on it).

Some quick exploration revealted that  this information is already available in the `runtime` module. This PR exposes this value as a new built-in variable `$os`.

Feedback of any kind welcome.
