### PR TITLE
Document the exception data type and `cause` attr

### DIFF
--- a/website/ref/builtin.md
+++ b/website/ref/builtin.md
@@ -96,20 +96,34 @@ but when the current directory is empty, `count` will wait for inputs. Hence it
 is required to put the input in a list: `count [*]` unambiguously supplies input
 in the argument, even if there is no file.
 
-## Numerical Commands
+## Commands That Operate On Numbers
 
-Commands that operate on numbers are quite flexible about the format of the
-numbers. Integers can be specified as decimals (e.g. `233`) or hexadecimals
-(e.g. `0xE9`) and floating-point numbers can be specified using the scientific
-notation (e.g. `2.33e2`). These are different strings, but equal when considered
-as commands.
+Commands that operate on numbers are quite flexible about the
+format of those numbers. See the discussion of the [number data
+type](./language.html#number).
 
-Elvish has no special syntax or data type for numbers. Instead, they are just
-strings. For this reason, builtin commands for strings and numbers are
-completely separate. For instance, the numerical equality command is `==`, while
-the string equality command is `==s`. Another example is the `+` builtin, which
-only operates on numbers and does not function as a string concatenation
-commands.
+Because numbers are normally specified as strings, rather than as
+an explicit `float64` data type, some builtin commands have variants
+intended to operate on strings or numbers exclusively. For instance, the
+numerical equality command is `==`, while the string equality command is
+`==s`. Another example is the `+` builtin, which only operates on numbers
+and does not function as a string concatenation command. Consider these
+examples:
+
+```elvish-transcript
+~/projects/3rd-party/elvish> + x 1
+Exception: wrong type of 1'th argument: cannot parse as number: x
+[tty], line 1: + x 1
+~> + inf 1
+▶ (float64 +Inf)
+~> + -inf 1
+▶ (float64 -Inf)
+~> + -infinity 1
+▶ (float64 -Inf)
+~> + -infinityx 1
+Exception: wrong type of 1'th argument: cannot parse as number: -infinityx
+[tty], line 1: + -infinityx 1
+```
 
 ## Predicates
 

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -46,12 +46,14 @@ statements **executes** to produce side effects; an expression **evaluates** to
 some values. (The traditional terms for the two levels are "commands" and
 "words", but those terms are quite ambiguous.)
 
-# String
+# Data types
+
+## String
 
 The most common data structure in shells is the string. String literals can be
 quoted or unquoted (barewords).
 
-## Quoted
+### Quoted
 
 There are two types of quoted strings in Elvish, single-quoted strings and
 double-quoted strings.
@@ -72,7 +74,7 @@ effect, simply concatenate strings: instead of `"my name is $name"`, write
 `"my name is "$name`. Under the hood this is a
 [compound expression](#compound-expression-and-braced-lists).
 
-## Barewords
+### Barewords
 
 If a string only consists of bareword characters, it can be written without any
 quote; this is called a **bareword**. Examples are `a.txt`, `long-bareword`, and
@@ -102,27 +104,55 @@ metacharacters; use quoted strings instead. For instance, to echo a star, write
 in line continuations; their use elsewhere is reserved will cause a syntax
 error.
 
-## Notes
+### Notes
 
 The three syntaxes above all evaluate to strings, and they are interchangeable.
 For instance, `xyz`, `'xyz'` and `"xyz"` are different syntaxes for the same
-string, and they are always equivalent.
+string, and they are always equivalent with the exception of
+**escape sequences** as documented above.
 
-Elvish does have a dedicated `float64` number type, but it does not have a
-literal syntax; instead it needs to be constructed using a function call, as in
-`put (float64 42)`; the argument `42` is a string. For convenience, all Elvish
-functions that expect number arguments also accept strings that can be parsed as
-a number, so explicit number constructors are not needed often.
+## Number
 
+A `$number` argument can be a string in the following formats (they all
+express the same value):
 
-# List and Map
+* decimal notation (e.g., `10`),
+* hexadecimal notation (e.g., `0xA`),
+* octal notation (e.g., `0o12`),
+* binary notation (e.g., `0b1010`),
+* floating point notation (e.g., `10.0`), and
+* scientific notation (e.g., `1.0e1`).
 
-Lists and maps are the basic container types in Elvish.
+An explicit `float64` data type is created using this syntax: `(float64
+$number)`. For convenience, all Elvish functions that expect a numeric
+argument will accept a string that can be parsed as a number. They
+will automatically convert the string to a `float64`. Which means
+explicit `float64` constructors are almost never needed. This implicit
+conversion includes special values like infinity (`Inf`) and not-a-number
+(`NaN`). Note that the letter case of these special values doesn't matter
+so `inf`, `Inf`, and `INF` are equivalent.
+
+A `float64` data type can be converted to a string using `(to-string
+$number)`. The resulting string is guaranteed to result in the same
+value when converted back to a `float64`. Most of the time you won't
+need to perform this explicit conversion. Elvish will implicitly make
+the conversion when running external commands and many of the builtins
+(where the distinction is not important).
+
+See also the discussion of [Commands That Operate On
+Numbers](./builtin.html#commands-that-operate-on-numbers).
+
+## Exception
+
+Elvish has an exception data type, but it does not have a literal
+syntax for that type. See the discussion of [exception and flow
+commands](./language.html#exception-and-flow-commands) for more
+information about this data type.
 
 ## List
 
 Lists are surround by square brackets `[ ]`, with elements separated by
-whitespaces. Examples:
+whitespace. They are one of the basic container types in Elvish. Examples:
 
 ```elvish-transcript
 ~> put [lorem ipsum]
@@ -149,7 +179,8 @@ don't use them to separate elements:
 
 Maps are also surrounded by square brackets; a key/value pair is written
 `&key=value` (reminiscent to HTTP query parameters), and pairs are separated by
-whitespaces. Whitespaces are allowed after `=`, but not before `=`. Examples:
+whitespaces. Whitespaces are allowed after `=`, but not before `=`. They are
+one of the basic container types in Elvish. Examples:
 
 ```elvish-transcript
 ~> put [&foo=bar &lorem=ipsum]
@@ -1562,6 +1593,12 @@ fn f {
   }
 }
 ```
+
+**WARNING:** The exception data type currently supports a single attribute,
+`cause`, that can be used to extract an object describing the cause
+of the exception; e.g. `$e[cause]`.  This is not a string. This is an
+experimental feature. You should probably use `(to-string $e)` at this
+time in any production code.
 
 # Namespaces and Modules
 


### PR DESCRIPTION
This also explicitly documents `float64` as a data type, although that
is a byproduct of this change. I created this change because someone
asked on the project's Gitter channel how to extract useful info from an
exception object.

Related #208