### PR TITLE
Implement $platform:is-unix and is-windows

### DIFF
--- a/pkg/eval/platform/platform.go
+++ b/pkg/eval/platform/platform.go
@@ -23,7 +23,21 @@ import (
 // [`GOOS`](https://pkg.go.dev/runtime?tab=doc#pkg-constants) constant.
 // This is read-only.
 
+//elvdoc:var is-unix
+//
+// Whether or not the platform is UNIX-like. This includes Linux, macOS
+// (Darwin), FreeBSD, NetBSD, and OpenBSD. This can be used to decide, for
+// example, if the `unix` module is usable.
+// This is read-only.
+
+//elvdoc:var is-windows
+//
+// Whether or not the platform is Microsoft Windows.
+// This is read-only.
+
 var Ns = eval.Ns{
-	"arch": vars.NewReadOnly(runtime.GOARCH),
-	"os":   vars.NewReadOnly(runtime.GOOS),
+	"arch":       vars.NewReadOnly(runtime.GOARCH),
+	"os":         vars.NewReadOnly(runtime.GOOS),
+	"is-unix":    vars.NewReadOnly(isUnix),
+	"is-windows": vars.NewReadOnly(isWindows),
 }

--- a/pkg/eval/platform/platform_test.go
+++ b/pkg/eval/platform/platform_test.go
@@ -14,5 +14,8 @@ func TestPlatform(t *testing.T) {
 	eval.TestWithSetup(t, setup,
 		That(`put $platform:arch`).Puts(runtime.GOARCH),
 		That(`put $platform:os`).Puts(runtime.GOOS),
+		That(`put $platform:is-windows`).Puts(runtime.GOOS == "windows"),
+		That(`put $platform:is-unix`).Puts(
+			runtime.GOOS != "windows" && runtime.GOOS != "plan9" && runtime.GOOS != "js"),
 	)
 }

--- a/pkg/eval/platform/unix.go
+++ b/pkg/eval/platform/unix.go
@@ -1,0 +1,8 @@
+// +build !windows,!plan9,!js
+
+package platform
+
+const (
+	isUnix    = true
+	isWindows = false
+)

--- a/pkg/eval/platform/windows.go
+++ b/pkg/eval/platform/windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package platform
+
+const (
+	isUnix    = false
+	isWindows = true
+)


### PR DESCRIPTION
This will facilitate elvish scripts determining whether it is safe to
`use unix` or `use windows`. The implementation of the `unix` module is
out for review in a separate commit. The `windows` module is likely to
be implemented in the near future.