### PR TITLE
Use XDG runtime directory on Unix when present

### DIFF
--- a/pkg/program/shell/run_dir_unix.go
+++ b/pkg/program/shell/run_dir_unix.go
@@ -15,12 +15,13 @@ var (
 	errBadPermission = errors.New("bad permission")
 )
 
-// getSecureRunDir stats elvish-$uid under the default temp dir, creating it if
-// it doesn't yet exist, and return the directory name if it has the correct
-// owner and permission.
+// getSecureRunDir stats elvish under the directory defined by the
+// XDG_RUNTIME_DIR environment variable, creating it if it doesn't yet exist,
+// and return the directory name if it has the correct owner and permission.
+// If XDG_RUNTIME_DIR is not set it falls back to elvish-$uid under the default
+// temp dir.
 func getSecureRunDir() (string, error) {
-	uid := os.Getuid()
-	runDir := filepath.Join(os.TempDir(), fmt.Sprintf("elvish-%d", uid))
+	runDir := getRunDirPath()
 	err := os.MkdirAll(runDir, 0700)
 	if err != nil {
 		return "", fmt.Errorf("mkdir: %v", err)
@@ -31,7 +32,19 @@ func getSecureRunDir() (string, error) {
 		return "", err
 	}
 
-	return runDir, checkExclusiveAccess(info, uid)
+	return runDir, checkExclusiveAccess(info, os.Getuid())
+}
+
+// getRunDirPath returns a path that's used by Elvish to store runtime files.
+// This path will be either XDG_RUNTIME_DIR/elvish when the XDG_RUNTIME_DIR
+// environment variable is set, or TMPDIR/elvish-$uid otherwise.
+func getRunDirPath() string {
+	if os.Getenv("XDG_RUNTIME_DIR") != "" {
+		return filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "elvish")
+	}
+
+	uid := os.Getuid()
+	return filepath.Join(os.TempDir(), fmt.Sprintf("elvish-%d", uid))
 }
 
 func checkExclusiveAccess(info os.FileInfo, uid int) error {

--- a/pkg/program/shell/run_dir_unix_test.go
+++ b/pkg/program/shell/run_dir_unix_test.go
@@ -1,0 +1,112 @@
+// +build !windows,!plan9
+
+package shell
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/elves/elvish/pkg/util"
+)
+
+func TestGetSecureRunDir(t *testing.T) {
+	xdgRuntimeDir, xdgCleanup := util.TestDir()
+	defer xdgCleanup()
+
+	tmpDir, tmpCleanup := util.TestDir()
+	defer tmpCleanup()
+
+	uid := os.Getuid()
+
+	tests := []struct {
+		name          string
+		xdgRuntimeDir string
+		tmpdir        string
+		want          string
+	}{
+		{
+			name:          "prefer XDG_RUNTIME_DIR over TMPDIR",
+			xdgRuntimeDir: xdgRuntimeDir,
+			tmpdir:        tmpDir,
+			want:          filepath.Join(xdgRuntimeDir, "elvish"),
+		},
+		{
+			name:          "use XDG_RUNTIME_DIR when TMPDIR is not set",
+			xdgRuntimeDir: xdgRuntimeDir,
+			tmpdir:        "",
+			want:          filepath.Join(xdgRuntimeDir, "elvish"),
+		},
+		{
+			name:          "fallback to TMPDIR when XDG_RUNTIME_DIR is not set",
+			xdgRuntimeDir: "",
+			tmpdir:        tmpDir,
+			want:          filepath.Join(tmpDir, fmt.Sprintf("elvish-%d", uid)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Helper()
+
+			envOverrides := map[string]string{
+				"XDG_RUNTIME_DIR": test.xdgRuntimeDir,
+				"TMPDIR":          test.tmpdir,
+			}
+
+			restore := withTempEnvs(envOverrides)
+			defer restore()
+
+			runDir, err := getSecureRunDir()
+			if err != nil {
+				t.Errorf("Could not get secure run dir: %v", err)
+			}
+
+			wantRunDir := test.want
+			if runDir != wantRunDir {
+				t.Errorf("Got run dir %v, want %v", runDir, wantRunDir)
+			}
+
+			info, err := os.Stat(runDir)
+			if err != nil {
+				t.Errorf("Could not stat run dir: %v", err)
+			}
+
+			stat := info.Sys().(*syscall.Stat_t)
+			if int(stat.Uid) != uid {
+				t.Errorf("Invalid run dir owner")
+			}
+			if stat.Mode&077 != 0 {
+				t.Errorf("Invalid run dir permissions")
+			}
+		})
+	}
+}
+
+// TODO: Move to the util package and add tests
+func withTempEnvs(envOverrides map[string]string) func() {
+	valuesToRestore := map[string]string{}
+
+	for key, value := range envOverrides {
+		original, exists := os.LookupEnv(key)
+
+		os.Setenv(key, value)
+
+		if exists {
+			valuesToRestore[key] = original
+		}
+	}
+
+	return func() {
+		for key := range envOverrides {
+			value, exists := valuesToRestore[key]
+			if exists {
+				os.Setenv(key, value)
+			} else {
+				os.Unsetenv(key)
+			}
+		}
+	}
+}

--- a/pkg/program/shell/run_dir_unix_test.go
+++ b/pkg/program/shell/run_dir_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"syscall"
 	"testing"
 
@@ -80,6 +81,83 @@ func TestGetSecureRunDir(t *testing.T) {
 			}
 			if stat.Mode&077 != 0 {
 				t.Errorf("Invalid run dir permissions")
+			}
+		})
+	}
+}
+
+func TestGetSecureRunDir_PreferExistingTmpDir(t *testing.T) {
+	xdgRuntimeDir, xdgCleanup := util.TestDir()
+	defer xdgCleanup()
+
+	tmpDir, tmpCleanup := util.TestDir()
+	defer tmpCleanup()
+
+	uid := os.Getuid()
+
+	tmpDirPath := filepath.Join(tmpDir, fmt.Sprintf("elvish-%d", uid))
+	err := os.MkdirAll(tmpDirPath, 0700)
+	if err != nil {
+		t.Errorf("Could not create test run dir: %v", err)
+	}
+
+	envOverrides := map[string]string{
+		"XDG_RUNTIME_DIR": xdgRuntimeDir,
+		"TMPDIR":          tmpDir,
+	}
+
+	restore := withTempEnvs(envOverrides)
+	defer restore()
+
+	runDir, err := getSecureRunDir()
+	if err != nil {
+		t.Errorf("Could not get secure run dir: %v", err)
+	}
+
+	if runDir != tmpDirPath {
+		t.Errorf("Got run dir %v, want %v", runDir, tmpDirPath)
+	}
+}
+
+func TestGetRunDirPaths(t *testing.T) {
+	uid := os.Getuid()
+
+	tests := []struct {
+		name          string
+		xdgRuntimeDir string
+		tmpdir        string
+		want          []string
+	}{
+		{
+			name:          "use XDG_RUNTIME_DIR when set",
+			xdgRuntimeDir: "/foo/runtime",
+			tmpdir:        "/foo/tmp",
+			want:          []string{"/foo/runtime/elvish", fmt.Sprintf("/foo/tmp/elvish-%d", uid)},
+		},
+		{
+			name:          "do not use XDG_RUNTIME_DIR when not set",
+			xdgRuntimeDir: "",
+			tmpdir:        "/foo/tmp",
+			want:          []string{fmt.Sprintf("/foo/tmp/elvish-%d", uid)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Helper()
+
+			envOverrides := map[string]string{
+				"XDG_RUNTIME_DIR": test.xdgRuntimeDir,
+				"TMPDIR":          test.tmpdir,
+			}
+
+			restore := withTempEnvs(envOverrides)
+			defer restore()
+
+			runDirPaths := getRunDirPaths()
+			wantDirPaths := test.want
+			if !reflect.DeepEqual(runDirPaths, wantDirPaths) {
+				t.Errorf("Got run dir paths %v, want %v", runDirPaths, wantDirPaths)
 			}
 		})
 	}


### PR DESCRIPTION
This pull-request uses `$XDG_RUNTIME_DIR` on Unix to store the runtime files. If `$XDG_RUNTIME_DIR` is not set it falls back to the old location (e.g.: `/tmp/elvish-$uid`).

This is a small first step towards [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) compliance on Unix (#383).