### PR TITLE
Replace NewNs() with Ns{} to improve consistency

### DIFF
--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -24,7 +24,7 @@ type Editor struct {
 
 // NewEditor creates a new editor from input and output terminal files.
 func NewEditor(tty cli.TTY, ev *eval.Evaler, st store.Store) *Editor {
-	ns := eval.NewNs()
+	ns := eval.Ns{}
 	appSpec := cli.AppSpec{TTY: tty}
 
 	fuser, err := histutil.NewFuser(st)

--- a/pkg/eval/module_math.go
+++ b/pkg/eval/module_math.go
@@ -3,7 +3,7 @@ package eval
 import "math"
 
 // MathNs contains essential math functions.
-var MathNs = NewNs().AddGoFns("math", map[string]interface{}{
+var MathNs = Ns{}.AddGoFns("math", map[string]interface{}{
 	"abs":   math.Abs,
 	"ceil":  math.Ceil,
 	"floor": math.Floor,

--- a/pkg/eval/ns.go
+++ b/pkg/eval/ns.go
@@ -12,11 +12,6 @@ type Ns map[string]vars.Var
 
 var _ interface{} = Ns(nil)
 
-// NewNs creates an empty namespace.
-func NewNs() Ns {
-	return make(Ns)
-}
-
 func (Ns) Kind() string {
 	return "ns"
 }

--- a/pkg/eval/re/re.go
+++ b/pkg/eval/re/re.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Ns is the namespace for the re: module.
-var Ns = eval.NewNs().AddGoFns("re:", fns)
+var Ns = eval.Ns{}.AddGoFns("re:", fns)
 
 var fns = map[string]interface{}{
 	"quote":   regexp.QuoteMeta,

--- a/pkg/eval/store/store.go
+++ b/pkg/eval/store/store.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Ns(s store.Store) eval.Ns {
-	return eval.NewNs().AddGoFns("store:", map[string]interface{}{
+	return eval.Ns{}.AddGoFns("store:", map[string]interface{}{
 		"del-dir": s.DelDir,
 		"del-cmd": s.DelCmd,
 	})

--- a/pkg/eval/str/str.go
+++ b/pkg/eval/str/str.go
@@ -313,7 +313,7 @@ import (
 // ▶ '¡¡¡Hello, Elven!!!'
 // ```
 
-var Ns = eval.NewNs().AddGoFns("str:", fns)
+var Ns = eval.Ns{}.AddGoFns("str:", fns)
 
 var fns = map[string]interface{}{
 	"compare":      strings.Compare,


### PR DESCRIPTION
There are just a handful of NewNs() uses and more than twenty Ns{} uses.
NewNS() doesn't, and probably never will, do anything that can't done by
the Ns{} syntax so we can simplify the code and improve consistency by
removing it.