### PR TITLE
Fix the `unix` namespace documentation

### DIFF
--- a/website/ref/unix.md
+++ b/website/ref/unix.md
@@ -2,9 +2,11 @@
 
 # Introduction
 
-The `unix:` module provides access to features that only make sense
-on UNIX compatible operating systems such as Linux, FreeBSD, macOS,
-etc. On non-UNIX operating systems, such as MS Windows, this namespace
-will be empty.
+The `unix:` module provides access to features that only make sense on UNIX
+compatible operating systems such as Linux, FreeBSD, macOS, etc. On non-UNIX
+operating systems, such as MS Windows, this namespace does not exist and
+`use unix` will fail. See also the
+[`$platform:is-unix`](platform.html#platformis-unix) variable which can be used
+to determine if this namespace is usable.
 
 @elvdoc -ns unix: -dir ../pkg/eval/unix


### PR DESCRIPTION
I noticed that `make style` changed the line wrapping. Which in turn
caused me to notice I had failed to correct the description about the
ability to executed `use unix` on non-UNIX platforms.