### PR TITLE
Implement the three inverse hyperbolic functions

### DIFF
--- a/pkg/eval/math/math.go
+++ b/pkg/eval/math/math.go
@@ -75,6 +75,21 @@ import (
 // ▶ (float64 NaN)
 // ```
 
+//elvdoc:fn acosh
+//
+// ```elvish
+// math:acosh $number
+// ```
+//
+// Outputs the inverse hyperbolic cosine of `$number`. Examples:
+//
+// ```elvish-transcript
+// ~> math:acosh 1
+// ▶ (float64 0)
+// ~> math:acosh 0
+// ▶ (float64 NaN)
+// ```
+
 //elvdoc:fn asin
 //
 // ```elvish
@@ -92,6 +107,21 @@ import (
 // ▶ (float64 NaN)
 // ```
 
+//elvdoc:fn asinh
+//
+// ```elvish
+// math:asinh $number
+// ```
+//
+// Outputs the inverse hyperbolic sine of `$number`. Examples:
+//
+// ```elvish-transcript
+// ~> math:asinh 0
+// ▶ (float64 0)
+// ~> math:asinh inf
+// ▶ (float64 +Inf)
+// ```
+
 //elvdoc:fn atan
 //
 // ```elvish
@@ -105,6 +135,21 @@ import (
 // ▶ (float64 0)
 // ~> math:atan $math:inf
 // ▶ (float64 1.5707963267948966)
+// ```
+
+//elvdoc:fn atanh
+//
+// ```elvish
+// math:atanh $number
+// ```
+//
+// Outputs the inverse hyperbolic tangent of `$number`. Examples:
+//
+// ```elvish-transcript
+// ~> math:atanh 0
+// ▶ (float64 0)
+// ~> math:atanh 1
+// ▶ (float64 +Inf)
 // ```
 
 //elvdoc:fn cos
@@ -367,8 +412,11 @@ var Ns = eval.Ns{
 var fns = map[string]interface{}{
 	"abs":           math.Abs,
 	"acos":          math.Acos,
+	"acosh":         math.Acosh,
 	"asin":          math.Asin,
+	"asinh":         math.Asinh,
 	"atan":          math.Atan,
+	"atanh":         math.Atanh,
 	"ceil":          math.Ceil,
 	"cos":           math.Cos,
 	"cosh":          math.Cosh,

--- a/pkg/eval/math/math_test.go
+++ b/pkg/eval/math/math_test.go
@@ -133,6 +133,18 @@ func TestMath(t *testing.T) {
 
 		That(`math:atan 0`).Puts(math.Atan(0)),
 		That(`math:atan 1`).Puts(math.Atan(1)),
-		That(`math:atan inf`).Puts(math.Pi / 2),
+		That(`math:atan inf`).Puts(math.Pi/2),
+
+		// Test the inverse hyperbolic trigonometric block of functions.
+		That(`math:acosh 0`).Puts(math.Acosh(0)),
+		That(`math:acosh 1`).Puts(math.Acosh(1)),
+		That(`math:acosh nan`).Puts(math.NaN()),
+
+		That(`math:asinh 0`).Puts(math.Asinh(0)),
+		That(`math:asinh 1`).Puts(math.Asinh(1)),
+		That(`math:asinh inf`).Puts(math.Inf(1)),
+
+		That(`math:atanh 0`).Puts(math.Atanh(0)),
+		That(`math:atanh 1`).Puts(math.Inf(1)),
 	)
 }


### PR DESCRIPTION
Related #727

P.S., The only other change I intend to make to the `math:` module is to implement `min()` and `max()`.  If and when someone asks for the remaining Go math functions (e.g., the bessel functions) it's easy enough to add them.