### PR TITLE
Simplify count implementation

### DIFF
--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -526,31 +526,11 @@ func hasKey(container, key interface{}) bool {
 	return vals.HasKey(container, key)
 }
 
-func count(fm *Frame, args ...interface{}) (int, error) {
+func count(fm *Frame, inputs Inputs) (int, error) {
 	var n int
-	switch len(args) {
-	case 0:
-		// Count inputs.
-		fm.IterateInputs(func(interface{}) {
-			n++
-		})
-	case 1:
-		// Get length of argument.
-		v := args[0]
-		if len := vals.Len(v); len >= 0 {
-			n = len
-		} else {
-			err := vals.Iterate(v, func(interface{}) bool {
-				n++
-				return true
-			})
-			if err != nil {
-				return 0, fmt.Errorf("cannot get length of a %s", vals.Kind(v))
-			}
-		}
-	default:
-		return 0, errors.New("want 0 or 1 argument")
-	}
+	inputs(func(_ interface{}) {
+		n++
+	})
 	return n, nil
 }
 

--- a/pkg/eval/builtin_fn_container_test.go
+++ b/pkg/eval/builtin_fn_container_test.go
@@ -43,7 +43,9 @@ func TestBuiltinFnContainer(t *testing.T) {
 
 		That(`range 100 | count`).Puts("100"),
 		That(`count [(range 100)]`).Puts("100"),
+		That(`count 123`).Puts("3"),
 		That(`count 1 2 3`).ThrowsAny(),
+		That(`count $true`).ThrowsAny(),
 
 		That(`keys [&]`).DoesNothing(),
 		That(`keys [&a=foo]`).Puts("a"),


### PR DESCRIPTION
Update the count command to use the same `Inputs` based implementation
as every other command that iterates over an optional iterable argument.

Resolves #966