### PR TITLE
Change and document how abbreviation expansion works

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -123,6 +123,8 @@ func NewApp(spec AppSpec) App {
 		QuotePaste:     spec.QuotePaste,
 		OnSubmit:       a.CommitCode,
 		State:          spec.CodeAreaState,
+
+		SmallWordAbbreviations: spec.SmallWordAbbreviations,
 	})
 
 	return &a

--- a/pkg/cli/app_spec.go
+++ b/pkg/cli/app_spec.go
@@ -20,6 +20,8 @@ type AppSpec struct {
 	Abbreviations  func(f func(abbr, full string))
 	QuotePaste     func() bool
 
+	SmallWordAbbreviations func(f func(abbr, full string))
+
 	CodeAreaState CodeAreaState
 	State         State
 }

--- a/pkg/cli/codearea_test.go
+++ b/pkg/cli/codearea_test.go
@@ -294,6 +294,67 @@ var codeAreaHandleTests = []HandleTest{
 		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "dn", Dot: 2}},
 	},
 	{
+		Name: "abbreviation expansion",
+		Given: NewCodeArea(CodeAreaSpec{
+			Abbreviations: func(f func(abbr, full string)) {
+				f("||", " | less")
+			},
+		}),
+		Events:       []term.Event{term.K('x'), term.K('|'), term.K('|')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "x | less", Dot: 8}},
+	},
+	{
+		Name: "abbreviation expansion",
+		Given: NewCodeArea(CodeAreaSpec{
+			Abbreviations: func(f func(abbr, full string)) {
+				f("||", " | less")
+			},
+		}),
+		Events:       []term.Event{term.K('{'), term.K('e'), term.K('c'), term.K('h'), term.K('o'), term.K(' '), term.K('x'), term.K('}'), term.K('|'), term.K('|')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "{echo x} | less", Dot: 15}},
+	},
+	{
+		Name: "small word abbreviation expansion space trigger",
+		Given: NewCodeArea(CodeAreaSpec{
+			SmallWordAbbreviations: func(f func(abbr, full string)) {
+				f("eh", "echo hello")
+			},
+		}),
+		Events:       []term.Event{term.K('e'), term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "echo hello ", Dot: 11}},
+	},
+	{
+		Name: "small word abbreviation expansion non-space trigger",
+		Given: NewCodeArea(CodeAreaSpec{
+			SmallWordAbbreviations: func(f func(abbr, full string)) {
+				f("h", "hello")
+			},
+		}),
+		Events:       []term.Event{term.K('x'), term.K('['), term.K('h'), term.K(']')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "x[hello]", Dot: 8}},
+	},
+	{
+		Name: "small word abbreviation expansion preceding char invalid",
+		Given: NewCodeArea(CodeAreaSpec{
+			SmallWordAbbreviations: func(f func(abbr, full string)) {
+				f("h", "hello")
+			},
+		}),
+		Events:       []term.Event{term.K('g'), term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "gh ", Dot: 3}},
+	},
+	{
+		Name: "small word abbreviation expansion after backspace preceding char invalid",
+		Given: NewCodeArea(CodeAreaSpec{
+			SmallWordAbbreviations: func(f func(abbr, full string)) {
+				f("h", "hello")
+			},
+		}),
+		Events: []term.Event{term.K('g'), term.K(' '), term.K(ui.Backspace),
+			term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "gh ", Dot: 3}},
+	},
+	{
 		Name: "overlay handler",
 		Given: codeAreaWithOverlay(CodeAreaSpec{}, func(w *codeArea) Handler {
 			return MapHandler{

--- a/pkg/edit/builtins.go
+++ b/pkg/edit/builtins.go
@@ -404,7 +404,7 @@ func categorizeWord(r rune) int {
 // Deletes the the last small word to the left of the dot.
 
 func moveDotLeftSmallWord(buffer string, dot int) int {
-	return moveDotLeftGeneralWord(categorizeSmallWord, buffer, dot)
+	return moveDotLeftGeneralWord(cli.CategorizeSmallWord, buffer, dot)
 }
 
 //elvdoc:fn move-dot-right-small-word
@@ -416,18 +416,7 @@ func moveDotLeftSmallWord(buffer string, dot int) int {
 // Deletes the the first small word to the right of the dot.
 
 func moveDotRightSmallWord(buffer string, dot int) int {
-	return moveDotRightGeneralWord(categorizeSmallWord, buffer, dot)
-}
-
-func categorizeSmallWord(r rune) int {
-	switch {
-	case unicode.IsSpace(r):
-		return 0
-	case isAlnum(r):
-		return 1
-	default:
-		return 2
-	}
+	return moveDotRightGeneralWord(cli.CategorizeSmallWord, buffer, dot)
 }
 
 //elvdoc:fn move-dot-left-alnum-word
@@ -456,7 +445,7 @@ func moveDotRightAlnumWord(buffer string, dot int) int {
 
 func categorizeAlnum(r rune) int {
 	switch {
-	case isAlnum(r):
+	case cli.IsAlnum(r):
 		return 1
 	default:
 		return 0
@@ -573,8 +562,4 @@ func moveDotRightGeneralWord(categorize categorizer, buffer string, dot int) int
 	skipCat(0)
 
 	return len(buffer) - len(right)
-}
-
-func isAlnum(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsNumber(r)
 }


### PR DESCRIPTION
Document interactive abbreviation expansions.

Change the implementation in two ways:

1) Skip an abbreviation if it begins with an alphanum and the previous
   char in the insert buffer is also an alphanum or there is no
   preceding char.

2) Only perform an expansion when a space, pipe, newline, or punctuation
   char is typed rather than when the last char of the abbreviation is
   typed. This makes the behavior more consistent with editors like Vim
   and Emacs and friendlier to use.

Resolves #947