### PR TITLE
Fix how [ctrl-v] works on BSD systems

### DIFF
--- a/pkg/cli/term/setup_unix.go
+++ b/pkg/cli/term/setup_unix.go
@@ -26,6 +26,7 @@ func setup(in, out *os.File) (func() error, error) {
 	savedTermios := term.Copy()
 
 	term.SetICanon(false)
+	term.SetIExten(false)
 	term.SetEcho(false)
 	term.SetVMin(1)
 	term.SetVTime(0)

--- a/pkg/sys/termios.go
+++ b/pkg/sys/termios.go
@@ -51,6 +51,11 @@ func (term *Termios) SetICanon(v bool) {
 	setFlag(&term.Lflag, unix.ICANON, v)
 }
 
+// SetIExten sets the iexten flag.
+func (term *Termios) SetIExten(v bool) {
+	setFlag(&term.Lflag, unix.IEXTEN, v)
+}
+
 // SetEcho sets the echo flag.
 func (term *Termios) SetEcho(v bool) {
 	setFlag(&term.Lflag, unix.ECHO, v)


### PR DESCRIPTION
On BSD systems iexten has to be explicitly disabled. Whereas on Linux
systems it is implicitly ignored if icanon is disabled.

Fixes #917