### PR TITLE
Fix stale prompt example

### DIFF
--- a/website/ref/edit.md
+++ b/website/ref/edit.md
@@ -92,7 +92,7 @@ To see the transformer in action, try the following example (assuming default
 
 ```elvish
 n = 0
-edit:prompt = { sleep 2; put $n; n = (+ $n 1); put ': ' }
+edit:prompt = { sleep 2; to-string $n; n = (+ $n 1); put ': ' }
 edit:-prompt-eagerness = 10 # update prompt on each keystroke
 edit:prompt-stale-threshold = 0.5
 ```


### PR DESCRIPTION
The current example produces the following error:

    invalid output type from prompt: number

Changed `put` to `to-string` to fix this.