### PR TITLE
Tell external cmds to ignore job control signals

### DIFF
--- a/pkg/cli/tty.go
+++ b/pkg/cli/tty.go
@@ -133,12 +133,6 @@ func (t *aTTY) UpdateBuffer(bufNotes, bufMain *term.Buffer, full bool) error {
 	return t.w.CommitBuffer(bufNotes, bufMain, full)
 }
 
-func (t *aTTY) NotifySignals() <-chan os.Signal {
-	t.sigCh = make(chan os.Signal, sigsChanBufferSize)
-	signal.Notify(t.sigCh)
-	return t.sigCh
-}
-
 func (t *aTTY) StopSignals() {
 	signal.Stop(t.sigCh)
 	close(t.sigCh)

--- a/pkg/cli/tty_nonunix.go
+++ b/pkg/cli/tty_nonunix.go
@@ -1,0 +1,16 @@
+// +build windows plan9 js
+
+package cli
+
+import (
+	"os"
+	"os/signal"
+)
+
+func (t *aTTY) NotifySignals() <-chan os.Signal {
+	// This implicitly catches every signal regardless of whether it is
+	// currently ignored.
+	t.sigCh = make(chan os.Signal, sigsChanBufferSize)
+	signal.Notify(t.sigCh)
+	return t.sigCh
+}

--- a/pkg/cli/tty_unix.go
+++ b/pkg/cli/tty_unix.go
@@ -1,0 +1,24 @@
+// +build !windows,!plan9,!js
+
+package cli
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func (t *aTTY) NotifySignals() <-chan os.Signal {
+	// This implicitly catches every signal regardless of whether it is
+	// currently ignored.
+	t.sigCh = make(chan os.Signal, sigsChanBufferSize)
+	signal.Notify(t.sigCh)
+	// TODO: Remove this if, and when, job control is implemented. This
+	// handles the case of running an external command from an interactive
+	// prompt.
+	//
+	// See https://github.com/elves/elvish/issues/988. See also setupShell()
+	// in pkg/shell/shell.go.
+	signal.Ignore(syscall.SIGTTIN, syscall.SIGTTOU, syscall.SIGTSTP)
+	return t.sigCh
+}


### PR DESCRIPTION
Since elvish does not support job control it should run all external
commands with the tty job control signals set to be ignored. See "APUE",
third edition, page 379.

This doesn't actually fix the problem in the case of broken programs
like vim which blindly assume the parent process implements job control.
But there isn't much we can do about that other than try to get those
programs to pay attention to being told to ignore SIGTSTP.

Fixes #988