### PR TITLE
Handle SGR codes in byte output in prompt

### DIFF
--- a/pkg/edit/complete/complete_test.go
+++ b/pkg/edit/complete/complete_test.go
@@ -279,7 +279,7 @@ func c(s string) completion.Item { return completion.Item{ToShow: s, ToInsert: s
 
 func fc(s, suffix string) completion.Item {
 	return completion.Item{ToShow: s, ToInsert: parse.Quote(s) + suffix,
-		ShowStyle: ui.StyleFromSGR(lscolors.GetColorist().GetStyle(s))}
+		ShowStyle: ui.StylingFromSGR(lscolors.GetColorist().GetStyle(s))}
 }
 
 func r(i, j int) diag.Ranging { return diag.Ranging{From: i, To: j} }

--- a/pkg/edit/prompt.go
+++ b/pkg/edit/prompt.go
@@ -175,21 +175,17 @@ func parseBytesIntoTokens(b []byte) (ret []rawToken) {
 	return
 }
 
-func parseTokensIntoText(rt []rawToken) ui.Text {
+func parseTokensIntoText(rt []rawToken) []ui.Segment {
 	segments := []ui.Segment{}
 	currentStyle := ui.Style{}
 	for _, token := range rt {
 		if !token.isSGRCode {
 			segments = append(segments, ui.Segment{Style: currentStyle, Text: string(token.data)})
 		} else {
-			currentStyle = ui.StyleFromSGR(strings.TrimPrefix(strings.TrimSuffix(string(token.data), "m"), "\033["))
+			ui.StylingFromSGR(strings.TrimPrefix(strings.TrimSuffix(string(token.data), "m"), "\033[")).Transform(&currentStyle)
 		}
 	}
-	ret := ui.Text{}
-	for idx := range segments {
-		ret = append(ret, &segments[idx])
-	}
-	return ret
+	return segments
 }
 
 // Calls a function with the given arguments and closed input, and concatenates
@@ -223,8 +219,8 @@ func callForStyledText(nt notifier, ev *eval.Evaler, ctx string, fn eval.Callabl
 		if err != nil {
 			nt.notifyf("error reading prompt byte output: %v", err)
 		}
-		if len(parsed) > 0 {
-			add(parsed)
+		for _, seg := range parsed {
+			add(seg)
 		}
 	}
 

--- a/pkg/ui/style_test.go
+++ b/pkg/ui/style_test.go
@@ -92,7 +92,7 @@ func TestMergeFromOptions(t *testing.T) {
 }
 
 func TestStyleFromSGR(t *testing.T) {
-	tt.Test(t, tt.Fn("StyleFromSGR", StyleFromSGR), tt.Table{
+	tt.Test(t, tt.Fn("StyleFromSGR", StylingFromSGR), tt.Table{
 		tt.Args("1").Rets(Style{Bold: true}),
 		// Invalid codes are ignored
 		tt.Args("1;invalid;10000").Rets(Style{Bold: true}),

--- a/pkg/ui/text.go
+++ b/pkg/ui/text.go
@@ -57,6 +57,8 @@ func (t Text) Concat(v interface{}) (interface{}, error) {
 	switch rhs := v.(type) {
 	case string:
 		return t.ConcatSegments(&Segment{Text: rhs}), nil
+	case Segment:
+		return t.ConcatSegments(&rhs), nil
 	case *Segment:
 		return t.ConcatSegments(rhs), nil
 	case Text:


### PR DESCRIPTION
This allows prompts such as Starship that output SGR colour sequences to render properly.

![ksnip_20200520-003028](https://user-images.githubusercontent.com/20326855/82405204-226f0e80-9a31-11ea-98a7-c46c83367305.png)

Left is how Starship renders without this patch.
Right is how Starship renders with this patch.

Fixes #814.