### PR TITLE
Don't start interactive mode if stdin is not a tty

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -112,6 +112,10 @@ Other improvements:
 
 # Notable bugfixes
 
+-   Running elvish with stdin not attached to a tty no longer attempts to start
+    an interactive shell ([#661](https://b.elv.sh/661)). Depending on the CLI
+    arguments it may treat stdin as a script or data.
+
 -   Invalid option names or values passed to builtin functions now correctly
     trigger an exception, instead of being silently ignored.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/elves/elvish
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/kr/pty v1.1.4
+	github.com/creack/pty v1.1.11
 	github.com/mattn/go-isatty v0.0.12
 	github.com/xiaq/persistent v0.0.0-20190312105637-a1d9ac4077fc
 	go.etcd.io/bbolt v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/kr/pty v1.1.4 h1:5Myjjh3JY/NaAi4IsUbHADytDyl1VE1Y9PXDlL+P/VQ=
-github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=

--- a/pkg/cli/term/setup_unix_test.go
+++ b/pkg/cli/term/setup_unix_test.go
@@ -5,7 +5,7 @@ package term
 import (
 	"testing"
 
-	"github.com/kr/pty"
+	"github.com/creack/pty"
 )
 
 func TestSetupTerminal(t *testing.T) {

--- a/pkg/prog/progtest/progtest.go
+++ b/pkg/prog/progtest/progtest.go
@@ -19,8 +19,11 @@ type Fixture struct {
 	dirCleanup func()
 }
 
-// Setup sets up a test fixture. The caller is responsible for calling the
-// Cleanup method of the returned Fixture.
+// Setup sets up a test fixture for testing non-interactive behavior of
+// elvish. See also, SetupInteractive().
+//
+// The caller is responsible for calling the Cleanup method of the returned
+// Fixture.
 func Setup() *Fixture {
 	_, dirCleanup := util.InTestDir()
 	return &Fixture{[3]*pipe{makePipe(), makePipe(), makePipe()}, dirCleanup}

--- a/pkg/prog/progtest/setup_interactive.go
+++ b/pkg/prog/progtest/setup_interactive.go
@@ -1,0 +1,23 @@
+// +build !windows
+
+package progtest
+
+import (
+	"github.com/creack/pty"
+	"github.com/elves/elvish/pkg/util"
+)
+
+// SetupInteractive sets up a test fixture for use by an interactive elvish
+// shell. That is, one that reads commands from a tty/pty.
+//
+// The caller is responsible for calling the CleanupInteractive method of the
+// returned Fixture.
+func SetupInteractive() *Fixture {
+	_, dirCleanup := util.InTestDir()
+	pty, tty, err := pty.Open()
+	if err != nil {
+		panic(err)
+	}
+	pty_pipe := pipe{w: tty, r: pty}
+	return &Fixture{[3]*pipe{&pty_pipe, makePipe(), makePipe()}, dirCleanup}
+}

--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package shell
 
 import (
@@ -11,7 +13,7 @@ import (
 )
 
 func TestInteract_SingleCommand(t *testing.T) {
-	f := Setup()
+	f := SetupInteractive()
 	defer f.Cleanup()
 	f.FeedIn("echo hello\n")
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -30,11 +30,12 @@ func (program) Run(fds [3]*os.File, f *prog.Flags, args []string) error {
 	if f.NoRc {
 		p.Rc = ""
 	}
-	if len(args) > 0 {
-		exit := Script(
-			fds, args, &ScriptConfig{
-				Paths: p,
-				Cmd:   f.CodeInArg, CompileOnly: f.CompileOnly, JSON: f.JSON})
+	if len(args) > 0 || !sys.IsATTY(fds[0]) {
+		if !f.CodeInArg && len(args) == 0 && !sys.IsATTY(fds[0]) {
+			args = []string{"-"} // read the script from stdin
+		}
+		exit := Script(fds, args, &ScriptConfig{
+			Paths: p, Cmd: f.CodeInArg, CompileOnly: f.CompileOnly, JSON: f.JSON})
 		return prog.Exit(exit)
 	}
 	Interact(fds, &InteractConfig{SpawnDaemon: true, Paths: p})

--- a/website/learn/fundamentals.md
+++ b/website/learn/fundamentals.md
@@ -245,6 +245,109 @@ linux is at index 0
 Note that in this example, the two pairs of `[]` have different meanings: the
 first pair denotes lists, while the second pair denotes an indexing operation.
 
+# Output capture and multiple values
+
+Environment variables are not the only way to learn about a computer system; we
+can also gain more information by invoking commands. The `uname` command tells
+you which operation system the computer is running; for instance, if you are
+running Linux, it prints `Linux` (unsurprisingly):
+
+```elvish-transcript
+~> uname
+Linux
+```
+
+(If you are running macOS, `uname` will print `Darwin`, the
+[open-source core](<https://en.wikipedia.org/wiki/Darwin_(operating_system)>) of
+macOS.)
+
+Let's try to integrate this information into our "hello" message. The Elvish
+command-line allows us to run multiple commands in a batch, as long as they are
+separated by semicolons. We can build the message by running multiple commands,
+using `uname` for the OS part:
+
+```elvish-transcript
+~> echo Hello, $E:USER, ; uname ; echo user!
+Hello, xiaq,
+Linux
+user!
+```
+
+This has the undesirable effect that "Linux" appears on its own line. Instead of
+running this command directly, we can first **capture** its output in a
+variable:
+
+```elvish-transcript
+~> os = (uname)
+~> echo Hello, $E:USER, $os user!
+Hello, elf, Linux user!
+```
+
+You can also use the output capture construct directly as an argument to `echo`,
+without storing the result in a variable first:
+
+```elvish-transcript
+~> echo Hello, $E:USER, (uname) user!
+Hello, elf, Linux user!
+```
+
+## More arithmetics
+
+You can use output captures to construct do complex arithmetic involving more
+than one operation:
+
+```elvish-transcript
+~> # compute the answer to life, universe and everything
+   * (+ 3 4) (- 100 94)
+▶ 42
+```
+
+# Running elvish
+
+The `elvish` program has a large number of options; most of which you'll never
+need to use because they are for debugging or other esoteric situations. Run
+`elvish -help` to see all the available options.
+
+If you run `elvish` with no options, and stdin is a tty, an interactive session
+is started. See the sections on [command history](#history-and-scripting) and
+the [command editor](../ref/edit.html).
+
+If you run `elvish -c 'code'` stdin is treated as data (regardless of whether or
+not stdin is a tty). For example:
+
+```elvish-transcript
+~> { echo 'yes'; echo 'no' } | elvish -c 'from-lines'
+▶ yes
+▶ no
+```
+
+If stdin is not attached to a tty it may be treated as an Elvish script or data.
+If you provide no options then stdin will be treated as an Elvish script to run.
+For example:
+
+```elvish-transcript
+~> echo '+ 1 2' | elvish
+▶ 3
+```
+
+If you provide a path to a file that contains an Elvish script then stdin is
+treated as data:
+
+```elvish-transcript
+-> echo 'from-lines' > example.elv
+~> echo '+ 1 2' | elvish example.elv
+▶ '+ 1 2'
+```
+
+If you wish to read a script from stdin and pass arguments to it (see the
+discussion of [script arguments below](#script-arguments)) you need to use `-`
+as the script name to force reading the script from stdin:
+
+```elvish-transcript
+~> echo 'put $args' | elvish - arg1 arg2
+▶ [arg1 arg2]
+```
+
 ## Script arguments
 
 Recall the `dice.elv` script above:
@@ -309,63 +412,6 @@ Bye, Jane!
 ~> elvish greet-and-bye.elv John
 Hello, John!
 Bye, John!
-```
-
-# Output capture and multiple values
-
-Environment variables are not the only way to learn about a computer system; we
-can also gain more information by invoking commands. The `uname` command tells
-you which operation system the computer is running; for instance, if you are
-running Linux, it prints `Linux` (unsurprisingly):
-
-```elvish-transcript
-~> uname
-Linux
-```
-
-(If you are running macOS, `uname` will print `Darwin`, the
-[open-source core](<https://en.wikipedia.org/wiki/Darwin_(operating_system)>) of
-macOS.)
-
-Let's try to integrate this information into our "hello" message. The Elvish
-command-line allows us to run multiple commands in a batch, as long as they are
-separated by semicolons. We can build the message by running multiple commands,
-using `uname` for the OS part:
-
-```elvish-transcript
-~> echo Hello, $E:USER, ; uname ; echo user!
-Hello, xiaq,
-Linux
-user!
-```
-
-This has the undesirable effect that "Linux" appears on its own line. Instead of
-running this command directly, we can first **capture** its output in a
-variable:
-
-```elvish-transcript
-~> os = (uname)
-~> echo Hello, $E:USER, $os user!
-Hello, elf, Linux user!
-```
-
-You can also use the output capture construct directly as an argument to `echo`,
-without storing the result in a variable first:
-
-```elvish-transcript
-~> echo Hello, $E:USER, (uname) user!
-Hello, elf, Linux user!
-```
-
-## More arithmetics
-
-You can use output captures to construct do complex arithmetic involving more
-than one operation:
-
-```elvish-transcript
-~> # compute the answer to life, universe and everything
-   * (+ 3 4) (- 100 94)
-▶ 42
 ```
 
 <!--


### PR DESCRIPTION
If stdin is not a tty start a non-interactive shell. The bytes from
stdin will be treated as a script if there are no CLI arguments or the
first argument is "-". Otherwise the stdin stream is treated as data.

Fixes #661

## This will need more changes
The new section on "Running elvish" in the "fundamentals" page will likely benefit from some wordsmithing :smile: