### PR TITLE
Panic during shell unit tests should be failures

### DIFF
--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/elves/elvish/pkg/eval"
@@ -9,6 +10,11 @@ import (
 	"github.com/elves/elvish/pkg/eval/vars"
 	. "github.com/elves/elvish/pkg/prog/progtest"
 )
+
+func TestMain(m *testing.M) {
+	interactiveRescueShell = false
+	os.Exit(m.Run())
+}
 
 func TestInteract_SingleCommand(t *testing.T) {
 	f := Setup()

--- a/pkg/shell/script.go
+++ b/pkg/shell/script.go
@@ -24,7 +24,6 @@ type ScriptConfig struct {
 
 // Script executes a shell script.
 func Script(fds [3]*os.File, args []string, cfg *ScriptConfig) int {
-	defer rescue()
 	ev, cleanup := setupShell(fds, cfg.Paths, cfg.SpawnDaemon)
 	defer cleanup()
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -2,16 +2,13 @@
 package shell
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
-	"syscall"
 
 	"github.com/elves/elvish/pkg/cli/term"
 	"github.com/elves/elvish/pkg/eval"
 	"github.com/elves/elvish/pkg/prog"
-	"github.com/elves/elvish/pkg/sys"
 	"github.com/elves/elvish/pkg/util"
 )
 
@@ -90,17 +87,4 @@ func saveEnv(name string) func() {
 		return func() { os.Setenv(name, v) }
 	}
 	return func() { os.Unsetenv(name) }
-}
-
-// Global panic handler.
-func rescue() {
-	r := recover()
-	if r != nil {
-		println()
-		print(sys.DumpStack())
-		println()
-		fmt.Println(r)
-		println("\nExecing recovery shell /bin/sh")
-		syscall.Exec("/bin/sh", []string{"/bin/sh"}, os.Environ())
-	}
 }


### PR DESCRIPTION
While debugging my fix for issue #661 I noticed that a panic that invokes
the `rescue` function causes Go to think the test passed due to launching
a rescue shell. This introduces a mechanism for elvish unit tests to
request that panics be fatal; i.e., exit with a non-zero status rather
than launch a rescue shell.

P.S., I verified that including this change with my preliminary, incomplete, fix for issue #661 does result in the test failing with the panic info being displayed.