### PR TITLE
Tell external cmds to ignore job control signals

### DIFF
--- a/pkg/cli/tty.go
+++ b/pkg/cli/tty.go
@@ -134,8 +134,7 @@ func (t *aTTY) UpdateBuffer(bufNotes, bufMain *term.Buffer, full bool) error {
 }
 
 func (t *aTTY) NotifySignals() <-chan os.Signal {
-	t.sigCh = make(chan os.Signal, sigsChanBufferSize)
-	signal.Notify(t.sigCh)
+	t.sigCh = sys.NotifySignals()
 	return t.sigCh
 }
 

--- a/pkg/sys/signals_nonunix.go
+++ b/pkg/sys/signals_nonunix.go
@@ -1,0 +1,15 @@
+// +build windows plan9 js
+
+package sys
+
+import (
+	"os"
+	"os/signal"
+)
+
+func NotifySignals() chan os.Signal {
+	// This catches every signal regardless of whether it is ignored.
+	sigCh := make(chan os.Signal, sigsChanBufferSize)
+	signal.Notify(sigCh)
+	return sigCh
+}

--- a/pkg/sys/signals_unix.go
+++ b/pkg/sys/signals_unix.go
@@ -1,0 +1,22 @@
+// +build !windows,!plan9,!js
+
+package sys
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func NotifySignals() chan os.Signal {
+	// This catches every signal regardless of whether it is ignored.
+	sigCh := make(chan os.Signal, sigsChanBufferSize)
+	signal.Notify(sigCh)
+	// TODO: Remove this if, and when, job control is implemented. This
+	// handles the case of running an external command from an interactive
+	// prompt.
+	//
+	// See https://github.com/elves/elvish/issues/988.
+	signal.Ignore(syscall.SIGTTIN, syscall.SIGTTOU, syscall.SIGTSTP)
+	return sigCh
+}

--- a/pkg/sys/sys.go
+++ b/pkg/sys/sys.go
@@ -1,2 +1,4 @@
 // Package sys provide convenient wrappers around syscalls.
 package sys
+
+const sigsChanBufferSize = 256


### PR DESCRIPTION
Since elvish does not support job control it should run all external
commands with the tty job control signals set to be ignored. See "APUE",
third edition, page 379.

This doesn't actually fix the problem in the case of broken programs
like vim which blindly assume the parent process implements job control.
But there isn't much we can do about that other than try to get those
programs to pay attention to being told to ignore SIGTSTP.

Fixes #988