### PR TITLE
website/ref/language.md: Remove mention of exc module

### DIFF
--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -1753,7 +1753,7 @@ Namespaces that are not special (i.e. one of the above) are also called
 following modules that can be imported by `use`:
 
 -   The following modules are always available: [daemon](daemon.html),
-    [epm](epm.html), [exc](exc.html), [math](math.html),
+    [epm](epm.html), [math](math.html),
     [platform](platform.html), [str](str.html), [re](re.html),
     [readline-binding](readline-binding.html), [store](store.html).
 


### PR DESCRIPTION
A teeny weeny little doc update!

PS. I noticed that the page https://elv.sh/ref/exc.html is still there. Maybe the removal of defunct pages ought to be automated?