### PR TITLE
Proof-of-concept implementation of edit:after-prompt hook

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -48,6 +48,7 @@ type app struct {
 	MaxHeight         func() int
 	RPromptPersistent func() bool
 	BeforeReadline    []func()
+	AfterPrompt       []func() string
 	AfterReadline     []func(string)
 	Highlighter       Highlighter
 	Prompt            Prompt
@@ -87,6 +88,7 @@ func NewApp(spec AppSpec) App {
 		MaxHeight:         spec.MaxHeight,
 		RPromptPersistent: spec.RPromptPersistent,
 		BeforeReadline:    spec.BeforeReadline,
+		AfterPrompt:       spec.AfterPrompt,
 		AfterReadline:     spec.AfterReadline,
 		Highlighter:       spec.Highlighter,
 		Prompt:            spec.Prompt,

--- a/pkg/cli/app_spec.go
+++ b/pkg/cli/app_spec.go
@@ -10,6 +10,7 @@ type AppSpec struct {
 	MaxHeight         func() int
 	RPromptPersistent func() bool
 	BeforeReadline    []func()
+	AfterPrompt       []func() string
 	AfterReadline     []func(string)
 
 	Highlighter Highlighter

--- a/pkg/edit/config_api.go
+++ b/pkg/edit/config_api.go
@@ -143,7 +143,7 @@ func callHooksWithStringResult(ev *eval.Evaler, name string, hooks vals.List, ar
 			diag.Complainf(os.Stderr, "%s return error", name)
 			continue
 		}
-		for _,r := range out {
+		for _, r := range out {
 			p, ok := r.(string)
 			if !ok {
 				diag.Complainf(os.Stderr, "hook %s should return a string", name)


### PR DESCRIPTION
Initial attempt to address #1060.

**This is in no way ready for merge**, it's meant as an initial proof-of-concept with the intention to promote discussion. I am also not well versed in Go nor in the Elvish codebase. **Any** feedback is very welcome.

The new variable `edit:after-prompt` can contain a list of functions that will be executed every time the prompt is redrawn. Any output produced by the functions (either in the byte or the value stream) must be strings, and these strings will be concatenated and added to the output of `edit:prompt`.

I know there has been some pushback against #1060, which is why I thought it might be a good idea to get a feeling for how the feature might work. As a point of reference, the [`iterm2:init`](https://github.com/zzamboni/elvish-modules/blob/master/iterm2.org#shell-integration) function becomes much cleaner, not having to modify the `edit:prompt` function: 

```
fn init {
  edit:after-prompt = [
    { set-currentdir $pwd >/dev/tty }
    { ftcs-command-start >/dev/tty }
  ]
  edit:before-readline = [
    {
      ftcs-command-finished
      set-remotehost $E:USER (platform:hostname)
      ftcs-prompt
    }
    $@edit:before-readline
  ]
  edit:after-readline = [
    $ftcs-command-executed~
    $@edit:after-readline
  ]
}
```

Other notes:
- At the moment, the output from the functions in `edit:after-prompt` still has to be redirected to `/dev/tty`, otherwise the characters get escaped and displayed instead of sent to the terminal. Implementation of #1039 would make it possible to avoid this by simply returning the corresponding zero-width segments to be displayed after the prompt.
- Unclear what to do about rprompt - at the moment I only added this hook for the regular prompt.