### PR TITLE
Introduce new path: module

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -26,6 +26,19 @@ or compiled, even if it is not executed:
 
 -   The `-source` command is now deprecated. Use `eval` instead.
 
+-   The `eval-symlinks` command is now deprecated. Use `path:eval-symlinks`
+    instead.
+
+-   The `path-abs` command is now deprecated. Use `path:abs` instead.
+
+-   The `path-base` command is now deprecated. Use `path:base` instead.
+
+-   The `path-clean` command is now deprecated. Use `path:clean` instead.
+
+-   The `path-dir` command is now deprecated. Use `path:dir` instead.
+
+-   The `path-ext` command is now deprecated. Use `path:ext` instead.
+
 The following deprecated features trigger a warning when the code is evaluated:
 
 -   Using `:` in slice indicies is deprecated. Use `..` instead.
@@ -44,6 +57,8 @@ New features in the standard library:
 
 -   A new `eval` command supports evaluating a dynamic piece of code in a
     restricted namespace.
+
+-   A new `path:` module has been introduced.
 
 # Notable bugfixes
 

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -26,6 +26,8 @@ var ErrStoreNotConnected = errors.New("store not connected")
 //
 // See [godoc of path/filepath](https://godoc.org/path/filepath). Go errors are
 // turned into exceptions.
+//
+// These functions are deprecated; use [path:](path.html)
 
 // TODO(xiaq): Document eval-symlinks.
 

--- a/pkg/eval/compiler.go
+++ b/pkg/eval/compiler.go
@@ -158,10 +158,22 @@ func (cp *compiler) checkDeprecatedBuiltin(name string, r diag.Ranger) {
 		msg = `the "ord" command is deprecated; use "str:to-codepoints" instead`
 	case "chr~":
 		msg = `the "chr" command is deprecated; use "str:from-codepoints" instead`
+	case "eval-symlinks~":
+		msg = `the "eval-symlinks" command is deprecated; use "path:eval-symlinks" instead`
 	case "has-prefix~":
 		msg = `the "has-prefix" command is deprecated; use "str:has-prefix" instead`
 	case "has-suffix~":
 		msg = `the "has-suffix" command is deprecated; use "str:has-suffix" instead`
+	case "path-abs~":
+		msg = `the "path-abs" command is deprecated; use "path:abs" instead`
+	case "path-base~":
+		msg = `the "path-base" command is deprecated; use "path:base" instead`
+	case "path-clean~":
+		msg = `the "path-clean" command is deprecated; use "path:clean" instead`
+	case "path-dir~":
+		msg = `the "path-dir" command is deprecated; use "path:dir" instead`
+	case "path-ext~":
+		msg = `the "path-ext" command is deprecated; use "path:ext" instead`
 	default:
 		return
 	}

--- a/pkg/eval/path/path.go
+++ b/pkg/eval/path/path.go
@@ -1,0 +1,94 @@
+// Package path exposes functionality from Go's path package as an Elvish
+// module.
+package path
+
+import (
+	"path/filepath"
+
+	"github.com/elves/elvish/pkg/eval"
+)
+
+//elvdoc:fn abs
+//
+// ```elvish
+// path:abs $path
+// ```
+//
+// Outputs the absolute path of `$path`.
+//
+// ```elvish-transcript
+// ~> path:abs ~/bin
+// ▶ /home/user/bin
+// ```
+
+//elvdoc:fn base
+//
+// ```elvish
+// path:base $path
+// ```
+//
+// Outputs the base path of `$path`.
+//
+// ```elvish-transcript
+// ~> path:base ~/bin
+// ▶ bin
+// ```
+
+//elvdoc:fn clean
+//
+// ```elvish
+// path:clean $path
+// ```
+//
+// Outputs `$path` with leading `./` removed.
+//
+// ```elvish-transcript
+// ~> path:clean ./../bin
+// ▶ ../bin
+// ```
+
+//elvdoc:fn dir
+//
+// ```elvish
+// path:dir $path
+// ```
+//
+// Outputs the parent directory of `$path`.
+//
+// ```elvish-transcript
+// ~> path:dir ~/bin
+// ▶ /home/user
+// ```
+
+//elvdoc:fn ext
+//
+// ```elvish
+// ext $path
+// ```
+//
+// Outputs the extension of `$path`.
+//
+// ```elvish-transcript
+// ~> path:ext hello.elv
+// ▶ .elv
+// ```
+
+//elvdoc:fn eval-symlinks
+//
+// ```elvish
+// eval-symlinks $path
+// ```
+//
+// Output the path name of $path after the evaluation of symbolic links.
+
+var Ns = eval.Ns{}.AddGoFns("path:", fns)
+
+var fns = map[string]interface{}{
+	"abs":   filepath.Abs,
+	"base":  filepath.Base,
+	"clean": filepath.Clean,
+	"dir":   filepath.Dir,
+	"ext":   filepath.Ext,
+
+	"eval-symlinks": filepath.EvalSymlinks,
+}

--- a/pkg/eval/path/path_test.go
+++ b/pkg/eval/path/path_test.go
@@ -1,0 +1,17 @@
+package path
+
+import (
+	"testing"
+
+	"github.com/elves/elvish/pkg/eval"
+)
+
+var That = eval.That
+
+func TestStr(t *testing.T) {
+	setup := func(ev *eval.Evaler) { ev.Builtin.AddNs("path", Ns) }
+	eval.TestWithSetup(t, setup,
+		That(`path:base a/b/c.png`).Puts("c.png"),
+		That(`path:ext a/b/c.png`).Puts(".png"),
+	)
+}

--- a/pkg/shell/runtime.go
+++ b/pkg/shell/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elves/elvish/pkg/eval"
 	daemonmod "github.com/elves/elvish/pkg/eval/daemon"
 	mathmod "github.com/elves/elvish/pkg/eval/math"
+	"github.com/elves/elvish/pkg/eval/path"
 	"github.com/elves/elvish/pkg/eval/platform"
 	"github.com/elves/elvish/pkg/eval/re"
 	"github.com/elves/elvish/pkg/eval/store"
@@ -50,6 +51,7 @@ func InitRuntime(stderr io.Writer, p Paths, spawn bool) *eval.Evaler {
 	ev := eval.NewEvaler()
 	ev.SetLibDir(p.LibDir)
 	ev.InstallModule("math", mathmod.Ns)
+	ev.InstallModule("path", path.Ns)
 	ev.InstallModule("platform", platform.Ns)
 	ev.InstallModule("re", re.Ns)
 	ev.InstallModule("str", str.Ns)

--- a/website/ref/index.toml
+++ b/website/ref/index.toml
@@ -21,6 +21,10 @@ name = "math"
 title = "math: Math Utilities"
 
 [[articles]]
+name = "path"
+title = "path: Path Utilities"
+
+[[articles]]
 name = "platform"
 title = "platform: Information About the Platform"
 

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -1829,9 +1829,9 @@ Elvish's standard library provides the following pre-defined modules that can be
 imported by `use`:
 
 -   The following modules are always available: [daemon](daemon.html),
-    [epm](epm.html), [math](math.html), [platform](platform.html),
-    [str](str.html), [re](re.html), [readline-binding](readline-binding.html),
-    [store](store.html).
+    [epm](epm.html), [math](math.html), [path](path.html),
+    [platform](platform.html), [str](str.html), [re](re.html),
+    [readline-binding](readline-binding.html), [store](store.html).
 
 -   The [unix](unix.html) module is available on UNIX-like platforms (see
     [`$platform:is-unix`](platform.html#platformis-unix)).

--- a/website/ref/path.md
+++ b/website/ref/path.md
@@ -1,0 +1,10 @@
+<!-- toc -->
+
+# Introduction
+
+The `path:` module provides path evaluation functions.
+
+Function usages are given in the same format as in the reference doc for the
+[builtin module](builtin.html).
+
+@elvdoc -ns path: -dir ../pkg/eval/path


### PR DESCRIPTION
Try to introduce a new `path:` module for path evaluating built-ins.

Starts by simply moving `path-/*` and `eval-symlinks` from the built-in namespace.
