### PR TITLE
Fix the handling of go test -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ generate:
 	go generate ./...
 
 test:
-	echo `go env GOOS GOARCH` | egrep -qx '(linux|freebsd|darwin|windows) amd64' \
-		&& go test -race ./... \
-		|| go test ./...
+	if echo `go env GOOS GOARCH` | egrep -qx '(linux|freebsd|darwin|windows) amd64'; then \
+		go test -race ./... ; \
+	else \
+		go test ./... ; \
+	fi
 
 style:
 	find . -name '*.go' | xargs goimports -w


### PR DESCRIPTION
The `test-race-works && go test -race || go test` formulation causes
tests to be run twice on platforms that support the `-race` option if
any test fails.

Fixes #1085