### PR TITLE
Fix some lint warnings

### DIFF
--- a/pkg/cli/addons/navigation/navigation.go
+++ b/pkg/cli/addons/navigation/navigation.go
@@ -62,9 +62,8 @@ func (w *widget) Handle(event term.Event) bool {
 				updateState(w, "")
 			}
 			return true
-		} else {
-			return false
 		}
+		return false
 	} else {
 		return w.app.CodeArea().Handle(event)
 	}
@@ -141,9 +140,8 @@ func Start(app cli.App, cfg Config) {
 			Prompt: func() ui.Text {
 				if w.CopyState().ShowHidden {
 					return cli.ModeLine(" NAVIGATING (show hidden) ", true)
-				} else {
-					return cli.ModeLine(" NAVIGATING ", true)
 				}
+				return cli.ModeLine(" NAVIGATING ", true)
 			},
 		}),
 		colView: cli.NewColView(cli.ColViewSpec{

--- a/pkg/cli/histutil/db_store_test.go
+++ b/pkg/cli/histutil/db_store_test.go
@@ -48,4 +48,4 @@ func TestDBStore_Cursor(t *testing.T) {
 	expect(store.Cmd{Text: "+ 3", Seq: 2}, mockError)
 }
 
-// Remaing methods tested with HybridStore
+// Remaining methods tested with HybridStore.

--- a/pkg/eval/compile_lvalue.go
+++ b/pkg/eval/compile_lvalue.go
@@ -127,11 +127,10 @@ func (op varOp) invoke(fm *Frame) ([]vars.Var, error) {
 	if variable == nil {
 		ns, _ := SplitQNameNs(op.qname)
 		if ns == "" || ns == ":" || ns == "local:" {
-			// This should have been created as part of pipelineOp; a compiler bug.
+			// This should have been created as part of pipelineOp.
 			return nil, errors.New("compiler bug: new local variable not created in pipeline")
-		} else {
-			return nil, fmt.Errorf("new variables can only be created in local scope")
 		}
+		return nil, fmt.Errorf("new variables can only be created in local scope")
 	}
 	return []vars.Var{variable}, nil
 }

--- a/pkg/eval/vals/index_list.go
+++ b/pkg/eval/vals/index_list.go
@@ -90,11 +90,10 @@ func ConvertListIndex(rawIndex interface{}, n int) (*ListIndex, error) {
 					return nil, errs.OutOfRange{
 						What:     "negative slice upper index here",
 						ValidLow: i - n, ValidHigh: -1, Actual: strconv.Itoa(j0)}
-				} else {
-					return nil, errs.OutOfRange{
-						What:     "slice upper index here",
-						ValidLow: i, ValidHigh: n, Actual: strconv.Itoa(j0)}
 				}
+				return nil, errs.OutOfRange{
+					What:     "slice upper index here",
+					ValidLow: i, ValidHigh: n, Actual: strconv.Itoa(j0)}
 			}
 		}
 		return &ListIndex{slice, i, j}, nil

--- a/pkg/store/cmd.go
+++ b/pkg/store/cmd.go
@@ -55,11 +55,11 @@ func (s *dbStore) Cmd(seq int) (string, error) {
 	var cmd string
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketCmd))
-		if v := b.Get(marshalSeq(uint64(seq))); v == nil {
+		v := b.Get(marshalSeq(uint64(seq)))
+		if v == nil {
 			return ErrNoMatchingCmd
-		} else {
-			cmd = string(v)
 		}
+		cmd = string(v)
 		return nil
 	})
 	return cmd, err

--- a/pkg/store/shared_var.go
+++ b/pkg/store/shared_var.go
@@ -21,12 +21,12 @@ func (s *dbStore) SharedVar(n string) (string, error) {
 	var value string
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketSharedVar))
-		if v := b.Get([]byte(n)); v == nil {
+		v := b.Get([]byte(n))
+		if v == nil {
 			return ErrNoSharedVar
-		} else {
-			value = string(v)
-			return nil
 		}
+		value = string(v)
+		return nil
 	})
 	return value, err
 }


### PR DESCRIPTION
In addition to an uncontroversial spelling fix this addresses several,
related, warnings produced by the `golint` tool. In general I agree with
golint that unnecessary "else" blocks should be avoided. So this change
refactors those cases.

Note: I recognize that `golint` is deprecated (see
https://github.com/golang/go/issues/38968) since it is no longer being
maintained and there is controversy about its set of warnings. Nonetheless,
it appears that the warnings it emits for this project are all reasonable
and actionable with one potential exception: the naming of the `map_`
method in pkg/eval/compile_value.go.