### PR TITLE
Validate a for loop corner case

### DIFF
--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -87,6 +87,9 @@ func TestBuiltinSpecial(t *testing.T) {
 				What:     "iterator",
 				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"x,y"),
+		// Invalid for loop lvalue. You can't use a var in a namespace other
+		// than the special "local:" namespace as the lvalue in a for loop.
+		That("for no-such-namespace:x [a b] { }").ThrowsMessage("new variables can only be created in local scope"),
 		// Exception when evaluating iterable.
 		That("for x [][0] { }").Throws(errWithType{errs.OutOfRange{}}, "[][0]"),
 		// More than one iterable.


### PR DESCRIPTION
This exercises the first failure condition in the `evalForVar` function.
Thus bringing coverage of pkg/eval/value_helper.go to 100%.

Related #1062