### PR TITLE
Convert "XXX" to "TODO" comments

### DIFF
--- a/pkg/cli/lscolors/feature_test.go
+++ b/pkg/cli/lscolors/feature_test.go
@@ -59,7 +59,7 @@ func TestDetermineFeature(t *testing.T) {
 	test("a", false, featureRegular)
 
 	// Setuid and Setgid.
-	// XXX(xiaq): Fails.
+	// TODO(xiaq): Fails.
 	/*
 		create("su", os.ModeSetuid)
 		test("su", true, featureSetuid)

--- a/pkg/cli/term/reader_unix.go
+++ b/pkg/cli/term/reader_unix.go
@@ -84,7 +84,7 @@ func readEvent(rd byteReaderWithTimeout) (event Event, err error) {
 			r2 = readRune()
 		}
 		if r2 == runeEndOfSeq {
-			// XXX Error is swallowed
+			// TODO(xiaq): Error is swallowed.
 			// Nothing follows. Taken as a lone Escape.
 			event = KeyEvent{'[', ui.Ctrl}
 			break

--- a/pkg/cli/term/reader_windows.go
+++ b/pkg/cli/term/reader_windows.go
@@ -13,7 +13,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// XXX Put here to make edit package build on Windows.
+// TODO(xiaq): Put here to make edit package build on Windows. Refactor so
+// that isn't needed?
 const DefaultSeqTimeout = 10 * time.Millisecond
 
 type reader struct {

--- a/pkg/cli/term/writer.go
+++ b/pkg/cli/term/writer.go
@@ -122,7 +122,7 @@ func (w *writer) CommitBuffer(bufNoti, buf *Buffer, fullRefresh bool) error {
 			switchStyle("")
 			bytesBuf.WriteString("\033[K\n")
 		}
-		// XXX Hacky.
+		// TODO(xiaq): This is hacky; try to improve it.
 		if len(w.curBuf.Lines) > 0 {
 			w.curBuf.Lines = w.curBuf.Lines[1:]
 		}

--- a/pkg/edit/complete/node_utils.go
+++ b/pkg/edit/complete/node_utils.go
@@ -50,7 +50,7 @@ func purelyEvalForm(form *parse.Form, seed string, upto int, ev PureEvaler) []st
 			break
 		}
 		if arg, err := ev.PurelyEvalCompound(compound); err == nil {
-			// XXX Arguments that are not simple compounds are simply ignored.
+			// TODO(xiaq): Arguments that are not simple compounds are simply ignored.
 			words = append(words, arg)
 		}
 	}

--- a/pkg/edit/complete_getopt.go
+++ b/pkg/edit/complete_getopt.go
@@ -175,7 +175,7 @@ func completeGetopt(fm *eval.Frame, vArgs, vOpts, vArgHandlers interface{}) erro
 	case getopt.ChainShortOption:
 		for _, opt := range opts.opts {
 			if opt.Short != 0 {
-				// XXX loses chained options
+				// TODO(xiaq): Loses chained options.
 				putShortOpt(opt)
 			}
 		}

--- a/pkg/eval/builtin_fn_debug.go
+++ b/pkg/eval/builtin_fn_debug.go
@@ -95,7 +95,7 @@ func _gc() {
 
 func _stack(fm *Frame) {
 	out := fm.ports[1].File
-	// XXX dup with main.go
+	// TODO(xiaq): Dup with main.go.
 	buf := make([]byte, 1024)
 	for runtime.Stack(buf, true) == cap(buf) {
 		buf = make([]byte, cap(buf)*2)

--- a/pkg/eval/builtin_fn_misc.go
+++ b/pkg/eval/builtin_fn_misc.go
@@ -246,7 +246,7 @@ func kindOf(fm *Frame, args ...interface{}) {
 }
 
 func constantly(args ...interface{}) Callable {
-	// XXX Repr of this fn is not right
+	// TODO(xiaq): Repr of this function is not right.
 	return NewGoFn(
 		"created by constantly",
 		func(fm *Frame) {

--- a/pkg/eval/compile_effect.go
+++ b/pkg/eval/compile_effect.go
@@ -296,7 +296,7 @@ func (op *formOp) invoke(fm *Frame) (errRet error) {
 			saveVars = append(saveVars, moreSaveVars...)
 		}
 		for i, v := range saveVars {
-			// XXX(xiaq): If the variable to save is a elemVariable, save
+			// TODO(xiaq): If the variable to save is a elemVariable, save
 			// the outermost variable instead.
 			if u := vars.HeadOfElement(v); u != nil {
 				v = u
@@ -319,9 +319,9 @@ func (op *formOp) invoke(fm *Frame) (errRet error) {
 			for i, v := range saveVars {
 				val := saveVals[i]
 				if val == nil {
-					// XXX Old value is nonexistent. We should delete the
-					// variable. However, since the compiler now doesn't delete
-					// it, we don't delete it in the evaler either.
+					// TODO(xiaq): Old value is nonexistent. We should delete
+					// the variable. However, since the compiler now doesn't
+					// delete it, we don't delete it in the evaler either.
 					val = ""
 				}
 				err := v.Set(val)
@@ -365,7 +365,7 @@ func (op *formOp) invoke(fm *Frame) (errRet error) {
 	}
 
 	// opts
-	// XXX This conversion should be avoided.
+	// TODO(xiaq): This conversion should be avoided.
 	optValues, err := op.optsOp.invoke(fm)
 	if err != nil {
 		return err

--- a/pkg/eval/compile_value.go
+++ b/pkg/eval/compile_value.go
@@ -477,7 +477,7 @@ func (cp *compiler) lambda(n *parse.Primary) valuesOpBody {
 	scopeOp := wrapScopeOp(chunkOp, cp.newLocals)
 	cp.newLocals = savedLocals
 
-	// XXX The fiddlings with cp.capture is error-prone.
+	// TODO(xiaq): The fiddlings with cp.capture is error-prone.
 	capture := cp.capture
 	cp.capture = make(staticNs)
 	cp.popScope()

--- a/pkg/eval/external_cmd.go
+++ b/pkg/eval/external_cmd.go
@@ -101,7 +101,7 @@ func (e ExternalCmd) Call(fm *Frame, argVals []interface{}, opts map[string]inte
 // TODO(xiaq): Windows support
 func EachExternal(f func(string)) {
 	for _, dir := range searchPaths() {
-		// XXX Ignore error
+		// TODO(xiaq): Ignore error.
 		infos, _ := ioutil.ReadDir(dir)
 		for _, info := range infos {
 			if !info.IsDir() && (info.Mode()&0111 != 0) {

--- a/pkg/eval/vals/has_key.go
+++ b/pkg/eval/vals/has_key.go
@@ -40,7 +40,8 @@ func HasKey(container, key interface{}) bool {
 			return found
 		}
 		if len := Len(container); len >= 0 {
-			// XXX(xiaq): Not all types that implement Lener have numerical indices
+			// TODO(xiaq): Not all types that implement Lener have numerical
+			// indices
 			_, err := ConvertListIndex(key, len)
 			return err == nil
 		}

--- a/pkg/eval/vars/element.go
+++ b/pkg/eval/vars/element.go
@@ -23,13 +23,13 @@ func (ev *elem) Set(v0 interface{}) error {
 		}
 	}
 	err = ev.variable.Set(v)
-	// XXX(xiaq): Remember the set value for use in Get.
+	// TODO(xiaq): Remember the set value for use in Get.
 	ev.setValue = v0
 	return err
 }
 
 func (ev *elem) Get() interface{} {
-	// XXX(xiaq): This is only called from fixNilVariables. We don't want to
+	// TODO(xiaq): This is only called from fixNilVariables. We don't want to
 	// waste time accessing the variable, so we simply return the value that was
 	// set.
 	return ev.setValue

--- a/pkg/glob/glob.go
+++ b/pkg/glob/glob.go
@@ -30,8 +30,8 @@ func (p Pattern) Glob(cb func(PathInfo) bool) bool {
 	segs := p.Segments
 	dir := ""
 
-	// XXX: This is a hack solely for supporting globs that start with ~ in the
-	// eval package.
+	// TODO(xiaq): This is a hack solely for supporting globs that start with
+	// ~ (tilde) in the eval package.
 	if p.DirOverride != "" {
 		dir = p.DirOverride
 	}
@@ -87,7 +87,7 @@ func glob(segs []Segment, dir string, cb func(PathInfo) bool) bool {
 
 	infos, err := readDir(dir)
 	if err != nil {
-		// XXX Silently drop the error
+		// TODO(xiaq): Silently drop the error.
 		return true
 	}
 

--- a/pkg/glob/parse.go
+++ b/pkg/glob/parse.go
@@ -62,7 +62,7 @@ rune:
 	return Pattern{segments, ""}
 }
 
-// XXX Contains duplicate code with parse/parser.go.
+// TODO(xiaq): Contains duplicate code with parse/parser.go.
 
 type parser struct {
 	src     string

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -813,7 +813,7 @@ func (pn *Primary) lbrace(ps *parser) {
 
 	pn.Type = Braced
 
-	// XXX: The compound can be empty, which allows us to parse {,foo}.
+	// TODO(xiaq): The compound can be empty, which allows us to parse {,foo}.
 	// Allowing compounds to be empty can be fragile in other cases.
 	ps.parse(&Compound{ExprCtx: BracedElemExpr}).addTo(&pn.Braced, pn)
 

--- a/pkg/ui/key.go
+++ b/pkg/ui/key.go
@@ -173,8 +173,8 @@ func ParseKey(s string) (Key, error) {
 
 	if len(s) == 1 {
 		k.Rune = rune(s[0])
-		// XXX The following assumptions about keys with Ctrl are not checked
-		// with all terminals.
+		// TODO(xiaq): The following assumptions about keys with Ctrl are not
+		// checked with all terminals.
 		if k.Mod&Ctrl != 0 {
 			// Keys with Ctrl as one of the modifiers and a single ASCII letter
 			// as the base rune do not distinguish between cases. So we


### PR DESCRIPTION
I stumbled across a comment that began with "XXX". It was clearly meant as
a "TODO" comment. This changes all such occurrences. However, a few "XXX"
comments are ambiguous and a better prefix might be "WARNING". The "TODO"
prefix at least ensures someone, eventually, looks into the situation
and either rewords the comment or fixes the problem. This change means
everyone can assume searching for "// TODO" will find all such comments
rather than requiring they also know to search for "// XXX".