### PR TITLE
Use str: equivalents for the deprecated builtins

### DIFF
--- a/pkg/eval/builtin_fn_cmd.go
+++ b/pkg/eval/builtin_fn_cmd.go
@@ -76,7 +76,7 @@ import (
 // Exit the Elvish process with `$status` (defaulting to 0).
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		// Command resolution
 		"external":        external,
 		"has-external":    hasExternal,

--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -372,7 +372,7 @@ import (
 // Note that there is no guaranteed order for the keys of a map.
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"ns": nsFn,
 
 		"make-map": makeMap,

--- a/pkg/eval/builtin_fn_debug.go
+++ b/pkg/eval/builtin_fn_debug.go
@@ -77,7 +77,7 @@ import (
 // This is only useful for debug purposes.
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"src":    src,
 		"-gc":    _gc,
 		"-stack": _stack,

--- a/pkg/eval/builtin_fn_env.go
+++ b/pkg/eval/builtin_fn_env.go
@@ -79,7 +79,7 @@ var errNonExistentEnvVar = errors.New("non-existent environment variable")
 // @cf has-env get-env set-env
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"has-env":   hasEnv,
 		"get-env":   getEnv,
 		"set-env":   os.Setenv,

--- a/pkg/eval/builtin_fn_flow.go
+++ b/pkg/eval/builtin_fn_flow.go
@@ -181,7 +181,7 @@ import (
 // @cf each run-parallel
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"run-parallel": runParallel,
 		// Exception and control
 		"fail":        fail,

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -78,7 +78,7 @@ var ErrStoreNotConnected = errors.New("store not connected")
 // TODO(xiaq): Document -is-dir.
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		// Directory
 		"cd":          cd,
 		"dir-history": dirs,

--- a/pkg/eval/builtin_fn_io.go
+++ b/pkg/eval/builtin_fn_io.go
@@ -337,7 +337,7 @@ import (
 // @cf prclose pipe
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		// Value output
 		"put": put,
 

--- a/pkg/eval/builtin_fn_misc.go
+++ b/pkg/eval/builtin_fn_misc.go
@@ -213,7 +213,7 @@ import (
 // This should be part of a networking module instead of the builtin module.
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"nop":        nop,
 		"kind-of":    kindOf,
 		"constantly": constantly,

--- a/pkg/eval/builtin_fn_num.go
+++ b/pkg/eval/builtin_fn_num.go
@@ -167,7 +167,7 @@ import (
 // ```
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		// Constructor
 		"float64": toFloat64,
 

--- a/pkg/eval/builtin_fn_pred.go
+++ b/pkg/eval/builtin_fn_pred.go
@@ -127,7 +127,7 @@ import "github.com/elves/elvish/pkg/eval/vals"
 // @cf eq
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"bool":   vals.Bool,
 		"not":    not,
 		"is":     is,

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -274,7 +274,7 @@ var ErrInputOfEawkMustBeString = errors.New("input of eawk must be string")
 // ```
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"<s":  func(a, b string) bool { return a < b },
 		"<=s": func(a, b string) bool { return a <= b },
 		"==s": func(a, b string) bool { return a == b },
@@ -291,13 +291,6 @@ func init() {
 		"wcswidth":          wcwidth.Of,
 		"-override-wcwidth": wcwidth.Override,
 
-		"has-prefix": strings.HasPrefix,
-		"has-suffix": strings.HasSuffix,
-
-		"joins":    joins,
-		"splits":   splits,
-		"replaces": replaces,
-
 		"eawk": eawk,
 	})
 }
@@ -308,46 +301,6 @@ func toString(fm *Frame, args ...interface{}) {
 	for _, a := range args {
 		out <- vals.ToString(a)
 	}
-}
-
-// joins joins all input strings with a delimiter.
-func joins(sep string, inputs Inputs) (string, error) {
-	var buf bytes.Buffer
-	var errJoin error
-	first := true
-	inputs(func(v interface{}) {
-		if errJoin != nil {
-			return
-		}
-		if s, ok := v.(string); ok {
-			if first {
-				first = false
-			} else {
-				buf.WriteString(sep)
-			}
-			buf.WriteString(s)
-		} else {
-			errJoin = fmt.Errorf("join wants string input, got %s", vals.Kind(v))
-		}
-	})
-	return buf.String(), errJoin
-}
-
-type maxOpt struct{ Max int }
-
-func (o *maxOpt) SetDefaultOptions() { o.Max = -1 }
-
-// splits splits an argument strings by a delimiter and writes all pieces.
-func splits(fm *Frame, opts maxOpt, sep, s string) {
-	out := fm.ports[1].Chan
-	parts := strings.SplitN(s, sep, opts.Max)
-	for _, p := range parts {
-		out <- p
-	}
-}
-
-func replaces(opts maxOpt, old, repl, s string) string {
-	return strings.Replace(s, old, repl, opts.Max)
 }
 
 func ord(fm *Frame, s string) {

--- a/pkg/eval/builtin_fn_str_test.go
+++ b/pkg/eval/builtin_fn_str_test.go
@@ -21,13 +21,6 @@ func TestBuiltinFnStr(t *testing.T) {
 
 		That(`to-string str (float64 1) $true`).Puts("str", "1", "$true"),
 
-		That(`joins : [/usr /bin /tmp]`).Puts("/usr:/bin:/tmp"),
-		That(`joins : ['' a '']`).Puts(":a:"),
-		That(`splits : /usr:/bin:/tmp`).Puts("/usr", "/bin", "/tmp"),
-		That(`splits : /usr:/bin:/tmp &max=2`).Puts("/usr", "/bin:/tmp"),
-		That(`replaces : / ":usr:bin:tmp"`).Puts("/usr/bin/tmp"),
-		That(`replaces &max=2 : / :usr:bin:tmp`).Puts("/usr/bin:tmp"),
-
 		That(`ord a`).Puts("0x61"),
 		That(`ord 你好`).Puts("0x4f60", "0x597d"),
 		That(`chr 0x61`).Puts("a"),
@@ -42,10 +35,6 @@ func TestBuiltinFnStr(t *testing.T) {
 		That(`wcswidth 你好`).Puts("4"),
 		That(`-override-wcwidth x 10; wcswidth 1x2x; -override-wcwidth x 1`).
 			Puts("22"),
-
-		That(`has-prefix golang go`).Puts(true),
-		That(`has-prefix golang x`).Puts(false),
-		That(`has-suffix golang x`).Puts(false),
 
 		That(`echo "  ax  by cz  \n11\t22 33" | eawk [@a]{ put $a[-1] }`).
 			Puts("cz", "33"),

--- a/pkg/eval/builtin_fn_styled.go
+++ b/pkg/eval/builtin_fn_styled.go
@@ -99,7 +99,7 @@ var errStyledSegmentArgType = errors.New("argument to styled-segment must be a s
 // ```
 
 func init() {
-	addBuiltinFns(map[string]interface{}{
+	AddBuiltinFns(map[string]interface{}{
 		"styled-segment": styledSegment,
 		"styled":         Styled,
 	})

--- a/pkg/eval/builtin_ns.go
+++ b/pkg/eval/builtin_ns.go
@@ -92,6 +92,6 @@ var builtinNs = Ns{
 	"args":  vars.NewReadOnly(vector.Empty),
 }
 
-func addBuiltinFns(fns map[string]interface{}) {
+func AddBuiltinFns(fns map[string]interface{}) {
 	builtinNs.AddGoFns("", fns)
 }

--- a/pkg/eval/str/str.go
+++ b/pkg/eval/str/str.go
@@ -452,3 +452,16 @@ var fns = map[string]interface{}{
 	"trim-prefix": strings.TrimPrefix,
 	"trim-suffix": strings.TrimSuffix,
 }
+
+// TODO: Remove this when the deprecated builtins are eliminated sometime
+// after the 0.15 release. Don't forget to remove the corresponding
+// documentation in pkg/eval/builtin_fn_str.go.
+func init() {
+	eval.AddBuiltinFns(map[string]interface{}{
+		"has-prefix": strings.HasPrefix,
+		"has-suffix": strings.HasSuffix,
+		"joins":      join,
+		"splits":     split,
+		"replaces":   replace,
+	})
+}


### PR DESCRIPTION
I noticed that the builtin `joins` function did not have 100% test coverage
while the equivalent `str:join` did have 100% coverage. This replaces
the builtin string commands with those in the `str` module in order to
help ensure anyone using the legacy builtin is actually using the `str`
version. This ensures we don't have two implementations of each command
that behave differently. Bonus: Dedundant code is removed.

This, unfortunately, decreases test coverage of pkg/eval/builtin_fn_str.go
by 1.8% because it removes a bunch of lines that were exercised while
leaving the `eawk` function which has poor coverage. That will be remedied
by improving coverage of the `eawk` function in a separate change.

Related #1062