### PR TITLE
Document builtin `sleep` and add tests

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -26,6 +26,8 @@ or compiled, even if it is not executed:
 
 -   The `-source` command is now deprecated. Use `eval` instead.
 
+-   The undocumented `esleep` command is now deprecated. Use `sleep` instead.
+
 The following deprecated features trigger a warning when the code is evaluated:
 
 -   Using `:` in slice indicies is deprecated. Use `..` instead.
@@ -44,6 +46,8 @@ New features in the standard library:
 
 -   A new `eval` command supports evaluating a dynamic piece of code in a
     restricted namespace.
+
+-   A new `sleep` command.
 
 New features in the interactive editor:
 

--- a/pkg/eval/builtin_fn_misc_unix_test.go
+++ b/pkg/eval/builtin_fn_misc_unix_test.go
@@ -1,0 +1,28 @@
+// +build !windows,!plan9,!js
+
+package eval
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func interruptedTimeAfterMock(fm *Frame, d time.Duration) <-chan time.Time {
+	if d == 10*time.Millisecond {
+		// Special-case intended to verity that a sleep can be interrupted.
+		p, _ := os.FindProcess(os.Getpid())
+		p.Signal(os.Interrupt)
+		return time.After(1 * time.Second)
+	}
+	panic("unreachable")
+}
+
+func TestInterruptedSleep(t *testing.T) {
+	timeAfter = interruptedTimeAfterMock
+	Test(t,
+		// Special-case that should result in the sleep being interrupted. See
+		// timeAfterMock above.
+		That(`sleep 10ms`).Throws(ErrInterrupted, "sleep 10ms"),
+	)
+}

--- a/pkg/eval/compiler.go
+++ b/pkg/eval/compiler.go
@@ -169,6 +169,8 @@ func (cp *compiler) checkDeprecatedBuiltin(name string, r diag.Ranger) {
 		msg = `the "has-prefix" command is deprecated; use "str:has-prefix" instead`
 	case "has-suffix~":
 		msg = `the "has-suffix" command is deprecated; use "str:has-suffix" instead`
+	case "esleep~":
+		msg = `the "esleep" command is deprecated; use "sleep" instead`
 	default:
 		return
 	}

--- a/pkg/eval/testutils.go
+++ b/pkg/eval/testutils.go
@@ -290,7 +290,7 @@ func evalAndCollect(t *testing.T, ev *Evaler, texts []string) result {
 			continue
 		}
 		// NOTE: Only the exception of the last code that compiles is saved.
-		r.exception = ev.Eval(op, EvalCfg{Ports: ports})
+		r.exception = ev.Eval(op, EvalCfg{Ports: ports, Interrupt: ListenInterrupts})
 	}
 
 	stdout.Close()


### PR DESCRIPTION
I was reviewing test coverage and noticed that the `esleep`
implementation was undocumented and had no tests. This

a) renames the command to just `sleep`,

b) uses the Go time.ParseDuration function rather than assuming a
simple number of seconds,

c) documents the command,

d) adds tests of the function.

Related #1062