### PR TITLE
Add `make cover` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ _testmain.go
 
 # Project specific
 cover
+elvish-coverage.dat
 /_bin/
 /elvish

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ buildall:
 generate:
 	go generate ./...
 
+# Run unit tests -- with race detection if the platform supports it.
 test:
 	if echo `go env GOOS GOARCH` | egrep -qx '(linux|freebsd|darwin|windows) amd64'; then \
 		go test -race ./... ; \
@@ -19,6 +20,14 @@ test:
 		go test ./... ; \
 	fi
 
+# Generate a basic test coverage report. This will open the report in your
+# browser. See also https://codecov.io/gh/elves/elvish/.
+cover:
+	rm -f elvish-coverage.dat
+	go test -covermode=set -coverprofile=./elvish-coverage.dat ./...
+	go tool cover -html=./elvish-coverage.dat
+
+# Ensure the style of Go and Markdown source files is consistent.
 style:
 	find . -name '*.go' | xargs goimports -w
 	find . -name '*.md' | xargs prettier --tab-width 4 --prose-wrap always --write
@@ -36,4 +45,4 @@ checkstyle-md:
 		| sed 's/^/  /' | grep . && echo '  None!'
 
 .SILENT: checkstyle-go checkstyle-md
-.PHONY: default get generate test style checkstyle checkstyle-go checkstyle-md
+.PHONY: default get generate test style checkstyle checkstyle-go checkstyle-md cover


### PR DESCRIPTION
While working on issue #1062 I found myself wanting to generate coverage
reports on my local system. I wrote a trivial shell script to do that.
This simply converts that script into a `make` target.