### PR TITLE
Improve test coverage of pkg/eval/external_cmd.go

### DIFF
--- a/pkg/eval/builtin_fn_misc_test.go
+++ b/pkg/eval/builtin_fn_misc_test.go
@@ -99,5 +99,6 @@ func TestResolve(t *testing.T) {
 		That("fn f { }; resolve f").Puts("$f~"),
 		That("use mod; resolve mod:func").Puts("$mod:func~"),
 		That("resolve cat").Puts("(external cat)"),
+		That(`resolve external`).Puts("$external~"),
 	)
 }

--- a/pkg/eval/external_cmd_test.go
+++ b/pkg/eval/external_cmd_test.go
@@ -1,0 +1,31 @@
+package eval
+
+import (
+	"os"
+	"testing"
+)
+
+func TestBuiltinFnExternal(t *testing.T) {
+	tmpHome, cleanup := InTempHome()
+	defer cleanup()
+
+	os.Setenv("PATH", tmpHome+":"+os.Getenv("PATH"))
+	Test(t,
+		That(`e = (external true); kind-of $e`).Puts("fn"),
+		That(`e = (external true); put (repr $e)`).Puts("<external true>"),
+		That(`e = (external false); m = [&$e=true]; put (repr $m)`).Puts("[&<external false>=true]"),
+		// This group tests the `ExternalCmd.Call` method.
+		That(`e = (external true); $e`).DoesNothing(),
+		That(`e = (external true); $e &option`).Throws(ErrExternalCmdOpts, "$e &option"),
+		That(`e = (external false); $e`).ThrowsCmdExit(
+			ExternalCmdExit{CmdName: "false", WaitStatus: exitWaitStatus(1)}),
+
+		// TODO: Modify the ExternalCmd.Call method to wrap the Go error in a
+		// predictable Elvish error so we don't have to resort to using
+		// ThrowsAny in the following tests.
+		//
+		// The command shouldn't be found when run so we should get an
+		// exception along the lines of "executable file not found in $PATH".
+		That(`e = (external true); E:PATH=/ $e`).ThrowsAny(),
+	)
+}

--- a/pkg/eval/external_cmd_unix_test.go
+++ b/pkg/eval/external_cmd_unix_test.go
@@ -1,0 +1,37 @@
+// +build !windows,!plan9,!js
+
+package eval
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TODO: When EachExternal is modified to work on Windows either fold this
+// test into external_cmd_test.go or create an external_cmd_windows_test.go
+// that performs an equivalent test on Windows.
+func TestEachExternal(t *testing.T) {
+	tmpHome, cleanup := InTempHome()
+	defer cleanup()
+
+	mustMkdirAll("dir")
+	mustCreateEmpty("cmdx")
+	mustWriteFile("cmd1", []byte("#!/bin/sh"), 0755)
+	mustWriteFile("cmd2", []byte("#!/bin/sh"), 0755)
+	mustWriteFile("cmd3", []byte(""), 0755)
+	mustCreateEmpty("file")
+
+	os.Setenv("PATH", "/argle:"+tmpHome+":/bargle")
+	wantCmds := []string{"cmd1", "cmd2", "cmd3"}
+	gotCmds := []string{}
+	EachExternal(func(filename string) {
+		gotCmds = append(gotCmds, filename)
+	})
+
+	sort.Strings(gotCmds)
+	if !reflect.DeepEqual(wantCmds, gotCmds) {
+		t.Errorf("EachExternal want %q got %q", wantCmds, gotCmds)
+	}
+}

--- a/pkg/eval/testutils_unix.go
+++ b/pkg/eval/testutils_unix.go
@@ -1,0 +1,14 @@
+// +build !windows,!plan9,!js
+
+package eval
+
+import (
+	"syscall"
+)
+
+func exitWaitStatus(exit uint32) syscall.WaitStatus {
+	// The exit<<8 is gross but I can't find any exported symbols that would
+	// allow us to construct WaitStatus. So assume legacy UNIX encoding
+	// for a process that exits normally; i.e., not due to a signal.
+	return syscall.WaitStatus(exit << 8)
+}

--- a/pkg/eval/testutils_windows.go
+++ b/pkg/eval/testutils_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package eval
+
+import (
+	"syscall"
+)
+
+func exitWaitStatus(exit uint32) syscall.WaitStatus {
+	return syscall.WaitStatus{exit}
+}

--- a/pkg/eval/vals/kind.go
+++ b/pkg/eval/vals/kind.go
@@ -14,6 +14,11 @@ type Kinder interface {
 // the File, List, Map types, StructMap types, and types satisfying the Kinder
 // interface. For other types, it returns the Go type name of the argument
 // preceded by "!!".
+//
+// TODO: Decide what `kind-of` should report for an external command object
+// and document the rationale for the choice in the doc string for `func
+// (ExternalCmd) Kind()` as well as user facing documentation. It's not
+// obvious why this returns "fn" rather than "external" for that case.
 func Kind(v interface{}) string {
 	switch v := v.(type) {
 	case nil:


### PR DESCRIPTION
Improve coverage of pkg/eval/external_cmd.go from 58.3% to 86.1% as
measured by `make cover` on macOS.

This also fixes a, presumably, copy/paste bug in `func (ExternalCmd)
Kind()` by correcting its returned value: "fn" should be "external".

This would have been a smaller change but I felt it was important to
actually validate the exception raised when an external command fails
rather than simply using `.ThrowsAny()`. That necessitated augmenting
the pkg/eval/testutils.go module.

Related #1062