### PR TITLE
go vet cleanup

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -284,9 +284,9 @@ func (a *app) ReadCode() (string, error) {
 			} else if err == term.ErrStopped {
 				return
 			} else if term.IsReadErrorRecoverable(err) {
-				a.loop.Input(term.NonfatalErrorEvent{err})
+				a.loop.Input(term.NonfatalErrorEvent{Err: err})
 			} else {
-				a.loop.Input(term.FatalErrorEvent{err})
+				a.loop.Input(term.FatalErrorEvent{Err: err})
 				return
 			}
 		}

--- a/pkg/cli/loop_test.go
+++ b/pkg/cli/loop_test.go
@@ -127,7 +127,9 @@ func quitOn(lp *loop, retTrigger event, ret string, err error) handleCb {
 	}
 }
 
-func ExampleLoop() {
+// This will be run by `go test` and compare the output to that in the comment
+// at the end of the function. See https://golang.org/pkg/testing/#pkg-examples.
+func Example_loop() {
 	buffer := ""
 	firstDrawerCall := true
 	drawer := func(flag redrawFlag) {

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -117,90 +117,90 @@ func (c *client) NextCmdSeq() (int, error) {
 }
 
 func (c *client) AddCmd(text string) (int, error) {
-	req := &api.AddCmdRequest{text}
+	req := &api.AddCmdRequest{Text: text}
 	res := &api.AddCmdResponse{}
 	err := c.call("AddCmd", req, res)
 	return res.Seq, err
 }
 
 func (c *client) DelCmd(seq int) error {
-	req := &api.DelCmdRequest{seq}
+	req := &api.DelCmdRequest{Seq: seq}
 	res := &api.DelCmdResponse{}
 	err := c.call("DelCmd", req, res)
 	return err
 }
 
 func (c *client) Cmd(seq int) (string, error) {
-	req := &api.CmdRequest{seq}
+	req := &api.CmdRequest{Seq: seq}
 	res := &api.CmdResponse{}
 	err := c.call("Cmd", req, res)
 	return res.Text, err
 }
 
 func (c *client) Cmds(from, upto int) ([]string, error) {
-	req := &api.CmdsRequest{from, upto}
+	req := &api.CmdsRequest{From: from, Upto: upto}
 	res := &api.CmdsResponse{}
 	err := c.call("Cmds", req, res)
 	return res.Cmds, err
 }
 
 func (c *client) CmdsWithSeq(from, upto int) ([]store.Cmd, error) {
-	req := &api.CmdsWithSeqRequest{from, upto}
+	req := &api.CmdsWithSeqRequest{From: from, Upto: upto}
 	res := &api.CmdsWithSeqResponse{}
 	err := c.call("CmdsWithSeq", req, res)
 	return res.Cmds, err
 }
 
 func (c *client) NextCmd(from int, prefix string) (store.Cmd, error) {
-	req := &api.NextCmdRequest{from, prefix}
+	req := &api.NextCmdRequest{From: from, Prefix: prefix}
 	res := &api.NextCmdResponse{}
 	err := c.call("NextCmd", req, res)
 	return store.Cmd{Text: res.Text, Seq: res.Seq}, err
 }
 
 func (c *client) PrevCmd(upto int, prefix string) (store.Cmd, error) {
-	req := &api.PrevCmdRequest{upto, prefix}
+	req := &api.PrevCmdRequest{Upto: upto, Prefix: prefix}
 	res := &api.PrevCmdResponse{}
 	err := c.call("PrevCmd", req, res)
 	return store.Cmd{Text: res.Text, Seq: res.Seq}, err
 }
 
 func (c *client) AddDir(dir string, incFactor float64) error {
-	req := &api.AddDirRequest{dir, incFactor}
+	req := &api.AddDirRequest{Dir: dir, IncFactor: incFactor}
 	res := &api.AddDirResponse{}
 	err := c.call("AddDir", req, res)
 	return err
 }
 
 func (c *client) DelDir(dir string) error {
-	req := &api.DelDirRequest{dir}
+	req := &api.DelDirRequest{Dir: dir}
 	res := &api.DelDirResponse{}
 	err := c.call("DelDir", req, res)
 	return err
 }
 
 func (c *client) Dirs(blacklist map[string]struct{}) ([]store.Dir, error) {
-	req := &api.DirsRequest{blacklist}
+	req := &api.DirsRequest{Blacklist: blacklist}
 	res := &api.DirsResponse{}
 	err := c.call("Dirs", req, res)
 	return res.Dirs, err
 }
 
 func (c *client) SharedVar(name string) (string, error) {
-	req := &api.SharedVarRequest{name}
+	req := &api.SharedVarRequest{Name: name}
 	res := &api.SharedVarResponse{}
 	err := c.call("SharedVar", req, res)
 	return res.Value, err
 }
 
 func (c *client) SetSharedVar(name, value string) error {
-	req := &api.SetSharedVarRequest{name, value}
+	req := &api.SetSharedVarRequest{Name: name, Value: value}
 	res := &api.SetSharedVarResponse{}
 	return c.call("SetSharedVar", req, res)
 }
 
 func (c *client) DelSharedVar(name string) error {
-	req := &api.DelSharedVarRequest{name}
+	req := &api.DelSharedVarRequest{Name: name}
 	res := &api.DelSharedVarResponse{}
 	return c.call("DelSharedVar", req, res)
 }

--- a/pkg/eval/compile_value.go
+++ b/pkg/eval/compile_value.go
@@ -274,8 +274,8 @@ func (cp *compiler) primaryOp(n *parse.Primary) valuesOp {
 			cp.errorpf(n, "%s", err)
 		}
 		vs := []interface{}{
-			GlobPattern{Pattern: glob.Pattern{[]glob.Segment{seg}, ""}, Flags: 0,
-				Buts: nil, TypeCb: nil}}
+			GlobPattern{Pattern: glob.Pattern{Segments: []glob.Segment{seg}, DirOverride: ""},
+				Flags: 0, Buts: nil, TypeCb: nil}}
 		return literalValues(n, vs...)
 	case parse.Tilde:
 		cp.errorpf(n, "compiler bug: Tilde not handled in .compound")

--- a/pkg/eval/glob.go
+++ b/pkg/eval/glob.go
@@ -82,7 +82,7 @@ func (gp GlobPattern) Index(k interface{}) (interface{}, error) {
 			return nil, err
 		}
 		gp.Segments[len(gp.Segments)-1] = glob.Wild{
-			lastSeg.Type, true, lastSeg.Matchers,
+			Type: lastSeg.Type, MatchHidden: true, Matchers: lastSeg.Matchers,
 		}
 	case strings.HasPrefix(modifier, "type:"):
 		if gp.TypeCb != nil {
@@ -184,8 +184,8 @@ func (gp *GlobPattern) addMatcher(matcher func(rune) bool) error {
 		return err
 	}
 	gp.Segments[len(gp.Segments)-1] = glob.Wild{
-		lastSeg.Type, lastSeg.MatchHidden,
-		append(lastSeg.Matchers, matcher),
+		Type: lastSeg.Type, MatchHidden: lastSeg.MatchHidden,
+		Matchers: append(lastSeg.Matchers, matcher),
 	}
 	return nil
 }
@@ -197,11 +197,11 @@ func (gp *GlobPattern) append(segs ...glob.Segment) {
 func wildcardToSegment(s string) (glob.Segment, error) {
 	switch s {
 	case "*":
-		return glob.Wild{glob.Star, false, nil}, nil
+		return glob.Wild{Type: glob.Star, MatchHidden: false, Matchers: nil}, nil
 	case "**":
-		return glob.Wild{glob.StarStar, false, nil}, nil
+		return glob.Wild{Type: glob.StarStar, MatchHidden: false, Matchers: nil}, nil
 	case "?":
-		return glob.Wild{glob.Question, false, nil}, nil
+		return glob.Wild{Type: glob.Question, MatchHidden: false, Matchers: nil}, nil
 	default:
 		return nil, fmt.Errorf("bad wildcard: %q", s)
 	}
@@ -214,7 +214,7 @@ func stringToSegments(s string) []glob.Segment {
 		for ; j < len(s) && s[j] != '/'; j++ {
 		}
 		if j > i {
-			segs = append(segs, glob.Literal{s[i:j]})
+			segs = append(segs, glob.Literal{Data: s[i:j]})
 		}
 		if j < len(s) {
 			for ; j < len(s) && s[j] == '/'; j++ {

--- a/pkg/eval/value_test.go
+++ b/pkg/eval/value_test.go
@@ -39,11 +39,11 @@ var stringToSegmentsTests = []struct {
 	want []glob.Segment
 }{
 	{"", []glob.Segment{}},
-	{"a", []glob.Segment{glob.Literal{"a"}}},
-	{"/a", []glob.Segment{glob.Slash{}, glob.Literal{"a"}}},
-	{"a/", []glob.Segment{glob.Literal{"a"}, glob.Slash{}}},
-	{"/a/", []glob.Segment{glob.Slash{}, glob.Literal{"a"}, glob.Slash{}}},
-	{"a//b", []glob.Segment{glob.Literal{"a"}, glob.Slash{}, glob.Literal{"b"}}},
+	{"a", []glob.Segment{glob.Literal{Data: "a"}}},
+	{"/a", []glob.Segment{glob.Slash{}, glob.Literal{Data: "a"}}},
+	{"a/", []glob.Segment{glob.Literal{Data: "a"}, glob.Slash{}}},
+	{"/a/", []glob.Segment{glob.Slash{}, glob.Literal{Data: "a"}, glob.Slash{}}},
+	{"a//b", []glob.Segment{glob.Literal{Data: "a"}, glob.Slash{}, glob.Literal{Data: "b"}}},
 }
 
 func TestStringToSegments(t *testing.T) {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -405,7 +405,8 @@ func (cn *Compound) parse(ps *parser) {
 func (cn *Compound) tilde(ps *parser) {
 	if ps.peek() == '~' {
 		ps.next()
-		base := node{diag.Ranging{ps.pos - 1, ps.pos}, "~", nil, nil}
+		base := node{Ranging: diag.Ranging{From: ps.pos - 1, To: ps.pos},
+			sourceText: "~", parent: nil, children: nil}
 		pn := &Primary{node: base, Type: Tilde, Value: "~"}
 		in := &Indexing{node: base}
 		parsed{pn}.addAs(&in.Head, in)
@@ -900,7 +901,7 @@ type Sep struct {
 
 // NewSep makes a new Sep.
 func NewSep(src string, begin, end int) *Sep {
-	return &Sep{node{diag.Ranging{begin, end}, src[begin:end], nil, nil}}
+	return &Sep{node: node{diag.Ranging{From: begin, To: end}, src[begin:end], nil, nil}}
 }
 
 func (*Sep) parse(*parser) {


### PR DESCRIPTION
Most of the code uses keyed fields in composite literals; i.e., struct
literals. However, running `go vet ./...` reports a few places that use
anonymous fields. This modifies those composite literals to use keyed
fields. This does make the code a bit more verbose without reducing
the likelihood of a bug. But it does make the code more consistent, use
best practices, and make it easier to notice if a potential problem is
introduced when running `go vet ./...` since that command now produces
no diagnostic output.

I considered adding a `make vet` target that explicitly ran

    go vet -composites=false ./...

I decided not to do that since consistently using keyed composite literals
is preferable to having a mix of keyed and unkeyed composite literals.

This also removes the unused `ExampleLoop` function which causes this
`go vet` warning:

    pkg/cli/loop_test.go:130:1: ExampleLoop refers to unknown identifier: Loop