### PR TITLE
Treat SIGPIPE termination as a successful exit

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -42,6 +42,10 @@ New features in the language:
 -   Rest variables and rest arguments are no longer restricted to the last
     variable.
 
+-   Command termination due to SIGPIPE no longer causes an exception and is
+    treated as a successful exit. See
+    https://github.com/elves/elvish/issues/952.
+
 New features in the standard library:
 
 -   A new `eval` command supports evaluating a dynamic piece of code in a

--- a/pkg/eval/exception_unix_test.go
+++ b/pkg/eval/exception_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/elves/elvish/pkg/eval"
+	. "github.com/elves/elvish/pkg/eval/evaltest"
 
 	"github.com/elves/elvish/pkg/tt"
 )
@@ -35,4 +36,11 @@ func TestExternalCmdExit_Error(t *testing.T) {
 			tt.Args(ExternalCmdExit{0xff, "ls", 1}).Rets("ls has unknown WaitStatus 255"),
 		})
 	}
+
+	Test(t,
+		// Prior to the resolution of https://github.com/elves/elvish/issues/952
+		// this would result in a SIGPIPE exception. Verify that we now get a
+		// successful exit without an exception.
+		That("e:cat /dev/zero | e:true").DoesNothing(),
+	)
 }

--- a/pkg/eval/external_cmd_test.go
+++ b/pkg/eval/external_cmd_test.go
@@ -25,7 +25,7 @@ func TestBuiltinFnExternal(t *testing.T) {
 		That(`e = (external true); $e`).DoesNothing(),
 		That(`e = (external true); $e &option`).Throws(ErrExternalCmdOpts, "$e &option"),
 		That(`e = (external false); $e`).Throws(CmdExit(
-			ExternalCmdExit{CmdName: "false", WaitStatus: exitWaitStatus(1)})),
+			ExternalCmdExit{CmdName: "false", WaitStatus: ExitWaitStatus(1)})),
 
 		// TODO: Modify the ExternalCmd.Call method to wrap the Go error in a
 		// predictable Elvish error so we don't have to resort to using

--- a/pkg/eval/external_cmd_unix.go
+++ b/pkg/eval/external_cmd_unix.go
@@ -1,12 +1,12 @@
 // +build !windows,!plan9,!js
 
-package eval_test
+package eval
 
 import (
 	"syscall"
 )
 
-func exitWaitStatus(exit uint32) syscall.WaitStatus {
+func ExitWaitStatus(exit uint32) syscall.WaitStatus {
 	// The exit<<8 is gross but I can't find any exported symbols that would
 	// allow us to construct WaitStatus. So assume legacy UNIX encoding
 	// for a process that exits normally; i.e., not due to a signal.

--- a/pkg/eval/external_cmd_windows.go
+++ b/pkg/eval/external_cmd_windows.go
@@ -1,11 +1,11 @@
 // +build windows
 
-package eval_test
+package eval
 
 import (
 	"syscall"
 )
 
-func exitWaitStatus(exit uint32) syscall.WaitStatus {
+func ExitWaitStatus(exit uint32) syscall.WaitStatus {
 	return syscall.WaitStatus{exit}
 }


### PR DESCRIPTION
Resolves #952