### PR TITLE
Use port getter methods consistently

### DIFF
--- a/pkg/eval/benchmarks_test.go
+++ b/pkg/eval/benchmarks_test.go
@@ -44,22 +44,22 @@ func BenchmarkOutputCapture_Overhead(b *testing.B) {
 
 func BenchmarkOutputCapture_Values(b *testing.B) {
 	benchmarkOutputCapture(b.N, func(fm *Frame) {
-		fm.ports[1].Chan <- "test"
+		fm.OutputChan() <- "test"
 	})
 }
 
 func BenchmarkOutputCapture_Bytes(b *testing.B) {
 	bytesToWrite := []byte("test")
 	benchmarkOutputCapture(b.N, func(fm *Frame) {
-		fm.ports[1].File.Write(bytesToWrite)
+		fm.OutputFile().Write(bytesToWrite)
 	})
 }
 
 func BenchmarkOutputCapture_Mixed(b *testing.B) {
 	bytesToWrite := []byte("test")
 	benchmarkOutputCapture(b.N, func(fm *Frame) {
-		fm.ports[1].Chan <- false
-		fm.ports[1].File.Write(bytesToWrite)
+		fm.OutputChan() <- false
+		fm.OutputFile().Write(bytesToWrite)
 	})
 }
 

--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -189,7 +189,7 @@ func rangeFn(fm *Frame, opts rangeOpts, args ...float64) error {
 		return ErrArgs
 	}
 
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for f := lower; f < upper; f += opts.Step {
 		out <- vals.FromGo(f)
 	}
@@ -322,7 +322,7 @@ func dissoc(a, k interface{}) (interface{}, error) {
 // @cf one
 
 func all(fm *Frame, inputs Inputs) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	inputs(func(v interface{}) { out <- v })
 }
 
@@ -350,7 +350,8 @@ func one(fm *Frame, inputs Inputs) error {
 		n++
 	})
 	if n == 1 {
-		fm.OutputChan() <- val
+		out := fm.OutputChan()
+		out <- val
 		return nil
 	}
 	return fmt.Errorf("expect a single value, got %d", n)
@@ -380,7 +381,7 @@ func one(fm *Frame, inputs Inputs) error {
 // Etymology: Haskell.
 
 func take(fm *Frame, n int, inputs Inputs) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	i := 0
 	inputs(func(v interface{}) {
 		if i < n {
@@ -417,7 +418,7 @@ func take(fm *Frame, n int, inputs Inputs) {
 // @cf take
 
 func drop(fm *Frame, n int, inputs Inputs) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	i := 0
 	inputs(func(v interface{}) {
 		if i >= n {
@@ -609,7 +610,7 @@ func count(fm *Frame, args ...interface{}) (int, error) {
 // Note that there is no guaranteed order for the keys of a map.
 
 func keys(fm *Frame, v interface{}) error {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	return vals.IterateKeys(v, func(k interface{}) bool {
 		out <- k
 		return true
@@ -768,8 +769,9 @@ func order(fm *Frame, opts orderOptions, inputs Inputs) error {
 	if errSort != nil {
 		return errSort
 	}
+	out := fm.OutputChan()
 	for _, v := range values {
-		fm.OutputChan() <- v
+		out <- v
 	}
 	return nil
 }

--- a/pkg/eval/builtin_fn_debug.go
+++ b/pkg/eval/builtin_fn_debug.go
@@ -84,7 +84,7 @@ func _gc() {
 // This is only useful for debug purposes.
 
 func _stack(fm *Frame) {
-	out := fm.ports[1].File
+	out := fm.OutputFile()
 	// TODO(xiaq): Dup with main.go.
 	buf := make([]byte, 1024)
 	for runtime.Stack(buf, true) == cap(buf) {

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -114,7 +114,7 @@ func dirs(fm *Frame) error {
 	if err != nil {
 		return err
 	}
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, dir := range dirs {
 		out <- dirHistoryEntry{dir.Path, dir.Score}
 	}

--- a/pkg/eval/builtin_fn_io.go
+++ b/pkg/eval/builtin_fn_io.go
@@ -82,7 +82,7 @@ func init() {
 // [Ruby](https://ruby-doc.org/core-2.2.2/IO.html#method-i-puts) as `puts`.
 
 func put(fm *Frame, args ...interface{}) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, a := range args {
 		out <- a
 	}
@@ -185,7 +185,7 @@ type printOpts struct{ Sep string }
 func (o *printOpts) SetDefaultOptions() { o.Sep = " " }
 
 func print(fm *Frame, opts printOpts, args ...interface{}) {
-	out := fm.ports[1].File
+	out := fm.OutputFile()
 	for i, arg := range args {
 		if i > 0 {
 			out.WriteString(opts.Sep)
@@ -223,7 +223,8 @@ func print(fm *Frame, opts printOpts, args ...interface{}) {
 
 func echo(fm *Frame, opts printOpts, args ...interface{}) {
 	print(fm, opts, args...)
-	fm.ports[1].File.WriteString("\n")
+	out := fm.OutputFile()
+	out.WriteString("\n")
 }
 
 //elvdoc:fn pprint
@@ -254,7 +255,7 @@ func echo(fm *Frame, opts printOpts, args ...interface{}) {
 // @cf repr
 
 func pprint(fm *Frame, args ...interface{}) {
-	out := fm.ports[1].File
+	out := fm.OutputFile()
 	for _, arg := range args {
 		out.WriteString(vals.Repr(arg, 0))
 		out.WriteString("\n")
@@ -280,7 +281,7 @@ func pprint(fm *Frame, args ...interface{}) {
 // Etymology: [Python](https://docs.python.org/3/library/functions.html#repr).
 
 func repr(fm *Frame, args ...interface{}) {
-	out := fm.ports[1].File
+	out := fm.OutputFile()
 	for i, arg := range args {
 		if i > 0 {
 			out.WriteString(" ")
@@ -422,7 +423,7 @@ func onlyValues(fm *Frame) error {
 // [`File::Slurp`](http://search.cpan.org/~uri/File-Slurp-9999.19/lib/File/Slurp.pm).
 
 func slurp(fm *Frame) (string, error) {
-	b, err := ioutil.ReadAll(fm.ports[0].File)
+	b, err := ioutil.ReadAll(fm.InputFile())
 	return string(b), err
 }
 
@@ -446,7 +447,7 @@ func slurp(fm *Frame) (string, error) {
 // @cf to-lines
 
 func fromLines(fm *Frame) {
-	linesToChan(fm.ports[0].File, fm.ports[1].Chan)
+	linesToChan(fm.InputFile(), fm.OutputChan())
 }
 
 //elvdoc:fn from-json
@@ -483,8 +484,8 @@ func fromLines(fm *Frame) {
 // @cf to-json
 
 func fromJSON(fm *Frame) error {
-	in := fm.ports[0].File
-	out := fm.ports[1].Chan
+	in := fm.InputFile()
+	out := fm.OutputChan()
 
 	dec := json.NewDecoder(in)
 	for {
@@ -528,8 +529,7 @@ func fromJSON(fm *Frame) error {
 // @cf from-lines
 
 func toLines(fm *Frame, inputs Inputs) {
-	out := fm.ports[1].File
-
+	out := fm.OutputFile()
 	inputs(func(v interface{}) {
 		fmt.Fprintln(out, vals.ToString(v))
 	})

--- a/pkg/eval/builtin_fn_misc.go
+++ b/pkg/eval/builtin_fn_misc.go
@@ -85,7 +85,7 @@ func nop(opts RawOptions, args ...interface{}) {
 // The terminology and definition of "kind" is subject to change.
 
 func kindOf(fm *Frame, args ...interface{}) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, a := range args {
 		out <- vals.Kind(a)
 	}
@@ -128,7 +128,7 @@ func constantly(args ...interface{}) Callable {
 	return NewGoFn(
 		"created by constantly",
 		func(fm *Frame) {
-			out := fm.ports[1].Chan
+			out := fm.OutputChan()
 			for _, v := range args {
 				out <- v
 			}
@@ -323,7 +323,7 @@ func source(fm *Frame, fname string) error {
 		return err
 	}
 	src := parse.Source{Name: fname, Code: code, IsFile: true}
-	tree, err := parse.ParseWithDeprecation(src, fm.ports[2].File)
+	tree, err := parse.ParseWithDeprecation(src, fm.ErrorFile())
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func source(fm *Frame, fname string) error {
 	for name := range fm.up.static() {
 		scriptGlobal.set(name)
 	}
-	op, err := compile(fm.Builtin.static(), scriptGlobal, tree, fm.ports[2].File)
+	op, err := compile(fm.Builtin.static(), scriptGlobal, tree, fm.ErrorFile())
 	if err != nil {
 		return err
 	}
@@ -481,7 +481,7 @@ func timeCmd(fm *Frame, opts timeOpt, f Callable) error {
 			err = errCb
 		}
 	} else {
-		fmt.Fprintln(fm.ports[1].File, dt)
+		fmt.Fprintln(fm.OutputFile(), dt)
 	}
 
 	return err
@@ -502,7 +502,7 @@ func _ifaddrs(fm *Frame) error {
 	if err != nil {
 		return err
 	}
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, addr := range addrs {
 		out <- addr.String()
 	}

--- a/pkg/eval/builtin_fn_num.go
+++ b/pkg/eval/builtin_fn_num.go
@@ -241,7 +241,7 @@ func slash(fm *Frame, args ...float64) error {
 }
 
 func divide(fm *Frame, prod float64, nums ...float64) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, f := range nums {
 		prod /= f
 	}

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -168,7 +168,7 @@ func toString(fm *Frame, args ...interface{}) {
 // @cf chr
 
 func ord(fm *Frame, s string) {
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, r := range s {
 		out <- "0x" + strconv.FormatInt(int64(r), 16)
 	}
@@ -239,7 +239,7 @@ func base(fm *Frame, b int, nums ...int) error {
 		return ErrBadBase
 	}
 
-	out := fm.ports[1].Chan
+	out := fm.OutputChan()
 	for _, num := range nums {
 		out <- strconv.FormatInt(int64(num), b)
 	}

--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -317,14 +317,14 @@ func evalModule(fm *Frame, key string, src parse.Source, st *StackTrace) (Ns, er
 
 // Evaluates a source. Shared by evalModule and the eval builtin.
 func evalInner(fm *Frame, src parse.Source, ns Ns, st *StackTrace) error {
-	tree, err := parse.ParseWithDeprecation(src, fm.ports[2].File)
+	tree, err := parse.ParseWithDeprecation(src, fm.ErrorFile())
 	if err != nil {
 		return err
 	}
 	newFm := &Frame{
 		fm.Evaler, src, ns, make(Ns),
 		fm.intCh, fm.ports, fm.traceback, fm.background}
-	op, err := compile(newFm.Builtin.static(), ns.static(), tree, fm.ports[2].File)
+	op, err := compile(newFm.Builtin.static(), ns.static(), tree, fm.ErrorFile())
 	if err != nil {
 		return err
 	}

--- a/pkg/eval/compile_effect.go
+++ b/pkg/eval/compile_effect.go
@@ -155,7 +155,7 @@ func (op *pipelineOp) exec(fm *Frame) error {
 				// mitigates the effect of erroneous pipelines like
 				// "range 100 | cat"; without draining the pipeline will
 				// lock up.
-				for range newFm.ports[0].Chan {
+				for range newFm.InputChan() {
 				}
 			}
 		}()
@@ -175,7 +175,7 @@ func (op *pipelineOp) exec(fm *Frame) error {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {
-					fm.ports[2].File.WriteString(msg + "\n")
+					fm.ErrorFile().WriteString(msg + "\n")
 				}
 			}
 		}()

--- a/pkg/eval/frame.go
+++ b/pkg/eval/frame.go
@@ -77,6 +77,11 @@ func (fm *Frame) OutputFile() *os.File {
 	return fm.ports[1].File
 }
 
+// ErrorFile returns a file onto which error output can be written.
+func (fm *Frame) ErrorFile() *os.File {
+	return fm.ports[2].File
+}
+
 // IterateInputs calls the passed function for each input element.
 func (fm *Frame) IterateInputs(f func(interface{})) {
 	var w sync.WaitGroup
@@ -84,11 +89,11 @@ func (fm *Frame) IterateInputs(f func(interface{})) {
 
 	w.Add(2)
 	go func() {
-		linesToChan(fm.ports[0].File, inputs)
+		linesToChan(fm.InputFile(), inputs)
 		w.Done()
 	}()
 	go func() {
-		for v := range fm.ports[0].Chan {
+		for v := range fm.InputChan() {
 			inputs <- v
 		}
 		w.Done()
@@ -194,6 +199,6 @@ func (fm *Frame) Deprecate(msg string, ctx *diag.Context) {
 	if prog.ShowDeprecations && fm.deprecations.register(dep) {
 		err := diag.Error{
 			Type: "deprecation", Message: dep.message, Context: *ctx}
-		fm.ports[2].File.WriteString(err.Show("") + "\n")
+		fm.ErrorFile().WriteString(err.Show("") + "\n")
 	}
 }


### PR DESCRIPTION
I was working on a fix for #1149 and noticed inconsistencies in how I/O
ports are referred to. This simply replaces are direct references to
fm.ports[] with the appropriate getter method. Go inlines the methods so
this doesn't incur any runtime overhead.