### PR TITLE
Try to resolve confusion around default bind of Alt-1 vs. Alt-, for last command mode

### DIFF
--- a/pkg/eval/mods/bundled/binding.elv.go
+++ b/pkg/eval/mods/bundled/binding.elv.go
@@ -19,7 +19,7 @@ fn install {
         &Alt-Down=      $edit:move-dot-down~
         &Alt-Enter=     $edit:insert-key~
         &Alt-.=         $edit:insert-last-word~
-        &Alt-1=         $edit:lastcmd:start~
+        &Alt-,=         $edit:lastcmd:start~
         &Alt-b=         $edit:move-dot-left-word~
         &Alt-f=         $edit:move-dot-right-word~
         &Alt-Backspace= $edit:kill-word-left~

--- a/website/learn/cookbook.md
+++ b/website/learn/cookbook.md
@@ -106,10 +106,9 @@ started quickly:
 
 -   Elvish doesn't support history expansion like `!!`. Instead, it has a "last
     command mode" offering the same functionality, triggered by <span
-    class="key">Alt-1</span> by default (resembling how you type `!` using
-    <span class="key">Shift-1</span>). In this mode, you can pick individual
+    class="key">Alt-,</span> by default. In this mode, you can pick individual
     arguments from the last command using numbers, or the entire command by
-    typing <span class="key">Alt-1</span> again.
+    typing <span class="key">Alt-,</span> again.
 
     This is showing me trying to fix a forgotten `sudo`:
 


### PR DESCRIPTION
Coming here because I was going through https://elv.sh/learn/cookbook.html and wondering why `Alt + 1` wasn't doing anything for me.

Seems like the actual default config is still `Alt + ,` even though an old changelog says the contrary: https://elv.sh/blog/0.9-release-notes.html

I did also find 1ecbe33d19cf121fd602ae760d4d1f96a2b3e407 which seems to reinforce that `Alt + ,` is the expected default binding.

From a stock setup, macOS 10.15.6, elvish 0.14.1 installed via homebrew:

```
pprint $edit:insert:binding
[
 &Up=	<builtin <edit:history>start>
 &Right=	<builtin <edit>move-dot-right>
 &Left=	<builtin <edit>move-dot-left>
 &Home=	<builtin <edit>move-dot-sol>
 &Delete=	<builtin <edit>kill-rune-right>
 &End=	<builtin <edit>move-dot-eol>
 &Tab=	<builtin <edit:completion>:smart-start>
 &Enter=	<builtin <edit>smart-enter>
 &Backspace=	<builtin <edit>kill-rune-left>
 &Alt-Right=	<builtin <edit>move-dot-right-word>
 &Alt-Left=	<builtin <edit>move-dot-left-word>
 &'Alt-,'=	<builtin <edit:lastcmd>start>
 &Alt-.=	<builtin <edit>insert-last-word>
 &Alt-b=	<builtin <edit>move-dot-left-word>
 &Alt-f=	<builtin <edit>move-dot-right-word>
 &Alt-x=	<builtin <edit:minibuf>:start>
 &Ctrl-Right=	<builtin <edit>move-dot-right-word>
 &Ctrl-Left=	<builtin <edit>move-dot-left-word>
 &Ctrl-D=	<builtin <edit>return-eof>
 &Ctrl-H=	<builtin <edit>kill-rune-left>
 &Ctrl-K=	<builtin <edit>kill-line-right>
 &Ctrl-L=	<builtin <edit:location>start>
 &Ctrl-N=	<builtin <edit:navigation>start>
 &Ctrl-R=	<builtin <edit:histlist>start>
 &Ctrl-U=	<builtin <edit>kill-line-left>
 &Ctrl-V=	<builtin <edit>insert-raw>
 &Ctrl-W=	<builtin <edit>kill-word-left>
]
```

Searching the code I have to assume this default is coming from https://github.com/elves/elvish/blob/master/pkg/edit/default_bindings.go

I could also change this to update `default_bindings.go` and leave the docs alone of course, but that seems like a breaking change at least with the behaviour I'm seeing.