### PR TITLE
Documentation: Update references to deprecated `splits` and `joins`

### DIFF
--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -295,7 +295,8 @@ func dissoc(a, k interface{}) (interface{}, error) {
 // This function is useful for turning inputs into arguments, like:
 //
 // ```elvish-transcript
-// ~> put 'lorem,ipsum' | splits , (all)
+// ~> use str
+// ~> put 'lorem,ipsum' | str:split , (all)
 // ▶ lorem
 // ▶ ipsum
 // ```
@@ -370,7 +371,8 @@ func one(fm *Frame, inputs Inputs) error {
 // ▶ a
 // ▶ b
 // ▶ c
-// ~> splits ' ' 'how are you?' | take 1
+// ~> use str
+// ~> str:split ' ' 'how are you?' | take 1
 // ▶ how
 // ~> range 2 | take 10
 // ▶ 0
@@ -406,7 +408,8 @@ func take(fm *Frame, n int, inputs Inputs) {
 // ▶ c
 // ▶ d
 // ▶ e
-// ~> splits ' ' 'how are you?' | drop 1
+// ~> use str
+// ~> str:split ' ' 'how are you?' | drop 1
 // ▶ are
 // ▶ 'you?'
 // ~> range 2 | drop 10


### PR DESCRIPTION
This is an attempt to update documentation to reflect the following point from the 0.14.0 release notes. Feedback requested and welcomed.

```
-   The `joins`, `replaces` and `splits` commands are now deprecated. Use
    `str:join`, `str:replace` and `str:split` instead.
```

Note: The Effective Elvish doc already has some things like `$str:to-upper~` that don't work without a `use str`. I didn't touch any of those.

Edit: Fixed capitalization of Elvish as noted on https://elv.sh/learn/name.html