### PR TITLE
Fix the $pwd tests

### DIFF
--- a/pkg/eval/pwd.go
+++ b/pkg/eval/pwd.go
@@ -19,13 +19,17 @@ type pwdVar struct {
 var _ vars.Var = pwdVar{}
 
 // Getwd allows for unit test error injection.
-var getwd func() (string, error) = os.Getwd
+var Getwd func() (string, error) = os.Getwd
 
 // Get returns the current working directory. It returns "/unknown/pwd" when
 // it cannot be determined.
 func (pwdVar) Get() interface{} {
-	pwd, err := getwd()
+	pwd, err := Getwd()
 	if err != nil {
+		// This should really use the path separator appropriate for the
+		// platform but in practice this hardcoded string works fine. Both
+		// because MS Windows supports forward slashes and this will very
+		// rarely occur.
 		return "/unknown/pwd"
 	}
 	return pwd


### PR DESCRIPTION
Not sure what happened but my fix for issue #1120 resulted in the core
unit test module not being executed due to a bogus "// +build wtf"
comment. Apparently I was experimenting with "+build" directives and
forgot to remove that line. This also improves the test coverage of the
$pwd code from 44% to 100%.