### PR TITLE
Set read-only var error should include var name

### DIFF
--- a/pkg/edit/navigation.go
+++ b/pkg/edit/navigation.go
@@ -89,7 +89,7 @@ func initNavigation(ed *Editor, ev *eval.Evaler) {
 	binding := newMapBinding(ed, ev, bindingVar)
 	widthRatioVar := newListVar(vals.MakeList(1.0, 3.0, 4.0))
 
-	selectedFileVar := vars.FromGet(func() interface{} {
+	selectedFileVar := vars.FromGet("selected-file", func() interface{} {
 		name := navigation.SelectedName(ed.app)
 		if name == "" {
 			return nil

--- a/pkg/edit/testutils_test.go
+++ b/pkg/edit/testutils_test.go
@@ -35,7 +35,7 @@ func rc(codes ...string) func(*fixture) {
 
 func assign(name string, val interface{}) func(*fixture) {
 	return func(f *fixture) {
-		f.Evaler.Global["temp"] = vars.NewReadOnly(val)
+		f.Evaler.Global["temp"] = vars.NewReadOnly("temp", val)
 		evals(f.Evaler, name+` = $temp`)
 	}
 }

--- a/pkg/eval/builtin_ns.go
+++ b/pkg/eval/builtin_ns.go
@@ -81,13 +81,13 @@ import (
 
 var builtinNs = Ns{
 	"_":     vars.NewBlackhole(),
-	"pid":   vars.NewReadOnly(strconv.Itoa(syscall.Getpid())),
-	"ok":    vars.NewReadOnly(OK),
-	"nil":   vars.NewReadOnly(nil),
-	"true":  vars.NewReadOnly(true),
-	"false": vars.NewReadOnly(false),
+	"args":  vars.NewReadOnly("args", vector.Empty),
+	"pid":   vars.NewReadOnly("pid", strconv.Itoa(syscall.Getpid())),
+	"ok":    vars.NewReadOnly("ok", OK),
+	"nil":   vars.NewReadOnly("nil", nil),
+	"true":  vars.NewReadOnly("true", true),
+	"false": vars.NewReadOnly("false", false),
 	"paths": NewEnvListVar("PATH"),
-	"args":  vars.NewReadOnly(vector.Empty),
 }
 
 func addBuiltinFns(fns map[string]interface{}) {

--- a/pkg/eval/compile_effect_test.go
+++ b/pkg/eval/compile_effect_test.go
@@ -118,8 +118,8 @@ func TestCompileEffect(t *testing.T) {
 		// Assignment errors when the RHS errors.
 		That("x = [][1]").Throws(ErrorWithType(errs.OutOfRange{}), "[][1]"),
 		// Assignment errors itself.
-		That("true = 1").Throws(vars.ErrSetReadOnlyVar, "true = 1"),
-		That("@true = 1").Throws(vars.ErrSetReadOnlyVar, "@true = 1"),
+		That("true = 1").Throws(&vars.ErrSetReadOnlyVar{"true"}, "true = 1"),
+		That("@true = 1").Throws(&vars.ErrSetReadOnlyVar{"true"}, "@true = 1"),
 		// Arity mismatch.
 		That("x = 1 2").Throws(
 			errs.ArityMismatch{

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -169,7 +169,7 @@ func NewEvaler() *Evaler {
 		&ev.state.valuePrefix, &ev.state.mutex)
 	builtin["notify-bg-job-success"] = vars.FromPtrWithMutex(
 		&ev.state.notifyBgJobSuccess, &ev.state.mutex)
-	builtin["num-bg-jobs"] = vars.FromGet(func() interface{} {
+	builtin["num-bg-jobs"] = vars.FromGet("num-bg-jobs", func() interface{} {
 		return strconv.Itoa(ev.state.getNumBgJobs())
 	})
 	builtin["pwd"] = NewPwdVar(ev)
@@ -237,7 +237,7 @@ func (ev *Evaler) SetArgs(args []string) {
 	for _, arg := range args {
 		v = v.Cons(arg)
 	}
-	ev.Builtin["args"] = vars.NewReadOnly(v)
+	ev.Builtin["args"] = vars.NewReadOnly("args", v)
 }
 
 // SetLibDir sets the library directory, in which external modules are to be

--- a/pkg/eval/mods/daemon/daemon.go
+++ b/pkg/eval/mods/daemon/daemon.go
@@ -38,8 +38,8 @@ func Ns(d daemon.Client, spawnCfg *daemon.SpawnConfig) eval.Ns {
 	}
 
 	return eval.Ns{
-		"pid":  vars.FromGet(getPidVar),
-		"sock": vars.NewReadOnly(string(d.SockPath())),
+		"pid":  vars.FromGet("pid", getPidVar),
+		"sock": vars.NewReadOnly("sock", string(d.SockPath())),
 	}.AddGoFns("daemon:", map[string]interface{}{
 		"pid":   getPid,
 		"spawn": spawn,

--- a/pkg/eval/mods/math/math.go
+++ b/pkg/eval/mods/math/math.go
@@ -485,8 +485,8 @@ import (
 
 // Ns is the namespace for the math: module.
 var Ns = eval.Ns{
-	"e":  vars.NewReadOnly(math.E),
-	"pi": vars.NewReadOnly(math.Pi),
+	"e":  vars.NewReadOnly("e", math.E),
+	"pi": vars.NewReadOnly("pi", math.Pi),
 }.AddGoFns("math:", fns)
 
 var fns = map[string]interface{}{

--- a/pkg/eval/mods/platform/platform.go
+++ b/pkg/eval/mods/platform/platform.go
@@ -73,10 +73,10 @@ func hostname(opts hostnameOpt) (string, error) {
 }
 
 var Ns = eval.Ns{
-	"arch":       vars.NewReadOnly(runtime.GOARCH),
-	"os":         vars.NewReadOnly(runtime.GOOS),
-	"is-unix":    vars.NewReadOnly(isUnix),
-	"is-windows": vars.NewReadOnly(isWindows),
+	"arch":       vars.NewReadOnly("arch", runtime.GOARCH),
+	"os":         vars.NewReadOnly("os", runtime.GOOS),
+	"is-unix":    vars.NewReadOnly("is-unix", isUnix),
+	"is-windows": vars.NewReadOnly("is-windows", isWindows),
 }.AddGoFns("platform:", map[string]interface{}{
 	"hostname": hostname,
 })

--- a/pkg/eval/purely_eval_test.go
+++ b/pkg/eval/purely_eval_test.go
@@ -38,8 +38,8 @@ func TestPurelyEvalCompound(t *testing.T) {
 	}
 
 	ev := NewEvaler()
-	ev.Global.Add("x", vars.NewReadOnly("bar"))
-	ev.Global.Add("y", vars.NewReadOnly(vals.MakeList()))
+	ev.Global.Add("x", vars.NewReadOnly("x", "bar"))
+	ev.Global.Add("y", vars.NewReadOnly("y", vals.MakeList()))
 
 	for _, test := range tests {
 		t.Run(test.code, func(t *testing.T) {

--- a/pkg/eval/resolve.go
+++ b/pkg/eval/resolve.go
@@ -84,7 +84,7 @@ func (fm *Frame) ResolveVar(qname string) vars.Var {
 		return vars.FromEnv(name)
 	case "e:":
 		if strings.HasSuffix(name, FnSuffix) {
-			return vars.NewReadOnly(ExternalCmd{name[:len(name)-len(FnSuffix)]})
+			return vars.NewReadOnly(qname, ExternalCmd{name[:len(name)-len(FnSuffix)]})
 		}
 		return nil
 	case "local:":

--- a/pkg/eval/resolve_test.go
+++ b/pkg/eval/resolve_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elves/elvish/pkg/eval/vars"
 )
 
-var testVar = vars.NewReadOnly("")
+var testVar = vars.NewReadOnly("testVar", "")
 
 var eachVariableInTopTests = []struct {
 	builtin   Ns
@@ -29,12 +29,12 @@ var eachVariableInTopTests = []struct {
 		wantNames: []string{"bar", "foo", "ipsum", "lorem"},
 	},
 	{
-		builtin:   Ns{"mod:": vars.NewReadOnly(Ns{"a": testVar, "b": testVar})},
+		builtin:   Ns{"mod:": vars.NewReadOnly("mod:", Ns{"a": testVar, "b": testVar})},
 		ns:        "mod:",
 		wantNames: []string{"a", "b"},
 	},
 	{
-		global:    Ns{"mod:": vars.NewReadOnly(Ns{"a": testVar, "b": testVar})},
+		global:    Ns{"mod:": vars.NewReadOnly("mod:", Ns{"a": testVar, "b": testVar})},
 		ns:        "mod:",
 		wantNames: []string{"a", "b"},
 	},

--- a/pkg/eval/vars/callback.go
+++ b/pkg/eval/vars/callback.go
@@ -5,6 +5,11 @@ type callback struct {
 	get func() interface{}
 }
 
+type roCallback struct {
+	name string
+	get  func() interface{}
+}
+
 // FromSetGet makes a variable from a set callback and a get callback.
 func FromSetGet(set func(interface{}) error, get func() interface{}) Var {
 	return &callback{set, get}
@@ -18,17 +23,15 @@ func (cv *callback) Get() interface{} {
 	return cv.get()
 }
 
-type roCallback func() interface{}
-
 // FromGet makes a variable from a get callback. The variable is read-only.
-func FromGet(get func() interface{}) Var {
-	return roCallback(get)
+func FromGet(name string, get func() interface{}) Var {
+	return roCallback{name, get}
 }
 
-func (cv roCallback) Set(interface{}) error {
-	return ErrSetReadOnlyVar
+func (cv roCallback) Set(val interface{}) error {
+	return &ErrSetReadOnlyVar{cv.name}
 }
 
 func (cv roCallback) Get() interface{} {
-	return cv()
+	return cv.get()
 }

--- a/pkg/eval/vars/callback_test.go
+++ b/pkg/eval/vars/callback_test.go
@@ -33,7 +33,7 @@ func TestFromGet(t *testing.T) {
 		getCalled = true
 		return "cb"
 	}
-	v := FromGet(get)
+	v := FromGet("v", get)
 	if v.Get() != "cb" {
 		t.Errorf("roCbVariable doesn't return value from callback")
 	}

--- a/pkg/eval/vars/read_only.go
+++ b/pkg/eval/vars/read_only.go
@@ -1,24 +1,31 @@
 package vars
 
 import (
-	"errors"
+	"fmt"
 )
 
 // ErrSetReadOnlyVar is returned by the Set method of a read-only variable.
-var ErrSetReadOnlyVar = errors.New("read-only variable; cannot be set")
+type ErrSetReadOnlyVar struct {
+	VarName string
+}
+
+func (e *ErrSetReadOnlyVar) Error() string {
+	return fmt.Sprintf("%s: read-only variable cannot be set", e.VarName)
+}
 
 type readOnly struct {
+	name  string
 	value interface{}
 }
 
 // NewReadOnly creates a variable that is read-only and always returns an error
 // on Set.
-func NewReadOnly(v interface{}) Var {
-	return readOnly{v}
+func NewReadOnly(name string, value interface{}) Var {
+	return readOnly{name, value}
 }
 
 func (rv readOnly) Set(val interface{}) error {
-	return ErrSetReadOnlyVar
+	return &ErrSetReadOnlyVar{rv.name}
 }
 
 func (rv readOnly) Get() interface{} {

--- a/pkg/eval/vars/read_only_test.go
+++ b/pkg/eval/vars/read_only_test.go
@@ -1,13 +1,23 @@
 package vars
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestNewReadOnly(t *testing.T) {
-	v := NewReadOnly("haha")
+	v := NewReadOnly("v", "haha")
 	if v.Get() != "haha" {
 		t.Errorf("Get doesn't return initial value")
 	}
-	if v.Set("lala") != ErrSetReadOnlyVar {
-		t.Errorf("Set doesn't error")
+
+	err := v.Set("lala")
+	switch err := err.(type) {
+	case *ErrSetReadOnlyVar:
+		if err.VarName != "v" {
+			t.Errorf("Set doesn't correctly report read-only error: expected err.VarName %v got %v",
+				err.VarName, "v")
+		}
+	default:
+		t.Errorf("Set doesn't report read-only error")
 	}
 }

--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -81,7 +81,7 @@ func TestInteract_RcFile_NonexistentIsOK(t *testing.T) {
 
 func TestExtractExports(t *testing.T) {
 	ns := eval.Ns{
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc("a", "lorem")),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc("a", "lorem")),
 	}
 	extractExports(ns, &bytes.Buffer{})
 	if ns.HasName(exportsVarName) {
@@ -94,7 +94,7 @@ func TestExtractExports(t *testing.T) {
 
 func TestExtractExports_IgnoreNonMapExports(t *testing.T) {
 	ns := eval.Ns{
-		exportsVarName: vars.NewReadOnly("x"),
+		exportsVarName: vars.NewReadOnly(exportsVarName, "x"),
 	}
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)
@@ -105,7 +105,7 @@ func TestExtractExports_IgnoreNonMapExports(t *testing.T) {
 
 func TestExtractExports_IgnoreNonStringKeys(t *testing.T) {
 	ns := eval.Ns{
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc(vals.EmptyList, "lorem")),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc(vals.EmptyList, "lorem")),
 	}
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)
@@ -116,8 +116,8 @@ func TestExtractExports_IgnoreNonStringKeys(t *testing.T) {
 
 func TestExtractExports_DoesNotOverwrite(t *testing.T) {
 	ns := eval.Ns{
-		"a":            vars.NewReadOnly("lorem"),
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc("a", "ipsum")),
+		"a":            vars.NewReadOnly("a", "lorem"),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc("a", "ipsum")),
 	}
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)


### PR DESCRIPTION
Modifying a read-only var should include the var name in the error message.

Fixes #255