### PR TITLE
Make key binding syntax more consistent

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -11,6 +11,10 @@ This is the draft release notes for 0.15.0, scheduled to be released on
     -   The `rest-arg` field now contains the index of the rest argument,
         instead of the name.
 
+-   Key modifiers are no longer case insensitive. Thus `Alt` is still recognized
+    but `alt` is not. This makes key modifier parsing consistent with key names.
+    See [#1163](https://b.elv.sh/1163).
+
 # Deprecated features
 
 The following deprecated features trigger a warning whenever the code is parsed

--- a/pkg/ui/key.go
+++ b/pkg/ui/key.go
@@ -25,7 +25,7 @@ func K(r rune, mods ...Mod) Key {
 	return Key{r, mod}
 }
 
-// Default is used in the key binding table to indicate default binding.
+// Default is used in the key binding table to indicate a default binding.
 var Default = Key{DefaultBindingRune, 0}
 
 // Mod represents a modifier key.
@@ -44,10 +44,11 @@ const (
 
 const functionKeyOffset = 1000
 
-// Special negative runes to represent function keys, used in the Rune field of
-// the Key struct.
+// Special negative runes to represent function keys, used in the Rune field
+// of the Key struct. This also has a few function names that are aliases for
+// simple runes. See keyNames below for mapping these values to strings.
 const (
-	// DefaultBindingRune is a special value to represent default binding.
+	// DefaultBindingRune is a special value to represent a default binding.
 	DefaultBindingRune rune = iota - functionKeyOffset
 
 	F1
@@ -75,24 +76,40 @@ const (
 	PageUp
 	PageDown
 
-	// Some function key names are just aliases for their ASCII representation
-
+	// Function key names that are aliases for their ASCII representation.
 	Tab       = '\t'
 	Enter     = '\n'
 	Backspace = 0x7f
 )
 
-// functionKey stores the names of function keys, in the same order they appeared above.
-var functionKeyNames = [...]string{
-	"Default",
-	"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
-	"Up", "Down", "Right", "Left",
-	"Home", "Insert", "Delete", "End", "PageUp", "PageDown",
-}
-
-// keyNames stores the name of function keys with a positive rune.
+// keyNames maps runes, whether simple or function, to symbolic key names.
 var keyNames = map[rune]string{
-	Tab: "Tab", Enter: "Enter", Backspace: "Backspace",
+	DefaultBindingRune: "Default",
+	F1:                 "F1",
+	F2:                 "F2",
+	F3:                 "F3",
+	F4:                 "F4",
+	F5:                 "F5",
+	F6:                 "F6",
+	F7:                 "F7",
+	F8:                 "F8",
+	F9:                 "F9",
+	F10:                "F10",
+	F11:                "F11",
+	F12:                "F12",
+	Up:                 "Up",
+	Down:               "Down",
+	Right:              "Right",
+	Left:               "Left",
+	Home:               "Home",
+	Insert:             "Insert",
+	Delete:             "Delete",
+	End:                "End",
+	PageUp:             "PageUp",
+	PageDown:           "PageDown",
+	Tab:                "Tab",
+	Enter:              "Enter",
+	Backspace:          "Backspace",
 }
 
 func (k Key) Kind() string {
@@ -113,6 +130,7 @@ func (k Key) Repr(int) string {
 
 func (k Key) String() string {
 	var b bytes.Buffer
+
 	if k.Mod&Ctrl != 0 {
 		b.WriteString("Ctrl-")
 	}
@@ -122,20 +140,17 @@ func (k Key) String() string {
 	if k.Mod&Shift != 0 {
 		b.WriteString("Shift-")
 	}
-	if k.Rune > 0 {
-		if name, ok := keyNames[k.Rune]; ok {
-			b.WriteString(name)
-		} else {
-			b.WriteRune(k.Rune)
-		}
+
+	if name, ok := keyNames[k.Rune]; ok {
+		b.WriteString(name)
 	} else {
-		i := int(k.Rune + functionKeyOffset)
-		if i < 0 || i >= len(functionKeyNames) {
-			fmt.Fprintf(&b, "(bad function key %d)", k.Rune)
+		if k.Rune >= 0 {
+			b.WriteRune(k.Rune)
 		} else {
-			b.WriteString(functionKeyNames[i])
+			fmt.Fprintf(&b, "(bad function key %d)", k.Rune)
 		}
 	}
+
 	return b.String()
 }
 
@@ -143,32 +158,33 @@ func (k Key) String() string {
 // the modifier string is first turned to lower case, so that all of C, c,
 // CTRL, Ctrl and ctrl can represent the Ctrl modifier.
 var modifierByName = map[string]Mod{
-	"s": Shift, "shift": Shift,
-	"a": Alt, "alt": Alt,
-	"m": Alt, "meta": Alt,
-	"c": Ctrl, "ctrl": Ctrl,
+	"S": Shift, "Shift": Shift,
+	"A": Alt, "Alt": Alt,
+	"M": Alt, "Meta": Alt,
+	"C": Ctrl, "Ctrl": Ctrl,
 }
 
-// ParseKey parses a key. The syntax is:
+// ParseKey parses a symbolic key. The syntax is:
 //
-// Key = { Mod ('+' | '-') } BareKey
+//   Key = { Mod ('+' | '-') } BareKey
 //
-// BareKey = FunctionKeyName | SingleRune
+//   BareKey = FunctionKeyName | SingleRune
 func ParseKey(s string) (Key, error) {
 	var k Key
-	// parse modifiers
+
+	// Parse modifiers.
 	for {
 		i := strings.IndexAny(s, "+-")
 		if i == -1 {
 			break
 		}
-		modname := strings.ToLower(s[:i])
-		mod, ok := modifierByName[modname]
-		if !ok {
+		modname := s[:i]
+		if mod, ok := modifierByName[modname]; ok {
+			k.Mod |= mod
+			s = s[i+1:]
+		} else {
 			return Key{}, fmt.Errorf("bad modifier: %s", parse.Quote(modname))
 		}
-		k.Mod |= mod
-		s = s[i+1:]
 	}
 
 	if len(s) == 1 {
@@ -182,29 +198,25 @@ func ParseKey(s string) (Key, error) {
 			if 'a' <= k.Rune && k.Rune <= 'z' {
 				k.Rune += 'A' - 'a'
 			}
-			// Tab is equivalent to Ctrl-I and Ctrl-J is equivalent to Enter.
-			// Normalize Ctrl-I to Tab and Ctrl-J to Enter.
+			// Normalize Ctrl-I to Tab, Ctrl-J to Enter, and Ctrl-? to Backspace.
 			if k.Rune == 'I' {
 				k.Mod &= ^Ctrl
 				k.Rune = Tab
 			} else if k.Rune == 'J' {
 				k.Mod &= ^Ctrl
 				k.Rune = Enter
+			} else if k.Rune == '?' {
+				k.Mod &= ^Ctrl
+				k.Rune = Backspace
 			}
 		}
 		return k, nil
 	}
 
+	// Is this is a symbolic key name, such as `Enter`, we recognize?
 	for r, name := range keyNames {
 		if s == name {
 			k.Rune = r
-			return k, nil
-		}
-	}
-
-	for i, name := range functionKeyNames {
-		if s == name {
-			k.Rune = rune(i - functionKeyOffset)
 			return k, nil
 		}
 	}

--- a/pkg/ui/key.go
+++ b/pkg/ui/key.go
@@ -189,6 +189,15 @@ func ParseKey(s string) (Key, error) {
 
 	if len(s) == 1 {
 		k.Rune = rune(s[0])
+		if k.Rune < ' ' {
+			if k.Mod&Ctrl != 0 {
+				return Key{}, fmt.Errorf("Ctrl modifier with literal control char: %q", k.Rune)
+			}
+			// Convert literal control char to the equivalent canonical form;
+			// e.g., "\e" to Ctrl-'[' and "\t" to Ctrl-I.
+			k.Mod |= Ctrl
+			k.Rune += '@'
+		}
 		// TODO(xiaq): The following assumptions about keys with Ctrl are not
 		// checked with all terminals.
 		if k.Mod&Ctrl != 0 {

--- a/pkg/ui/key_test.go
+++ b/pkg/ui/key_test.go
@@ -65,13 +65,17 @@ var parseKeyTests = []struct {
 	{s: "M-x", wantKey: Key{'x', Alt}},
 	{s: "Meta-x", wantKey: Key{'x', Alt}},
 
-	// Multiple modifiers can appear in any order.
+	// Multiple modifiers can appear in any order and with alternative
+	// separator chars.
 	{s: "Alt-Ctrl+Delete", wantKey: Key{Delete, Alt | Ctrl}},
 	{s: "Ctrl+Alt-Delete", wantKey: Key{Delete, Alt | Ctrl}},
 
-	// Ctrl-I and Ctrl-J are normalized to Tab and Enter.
-	{s: "Ctrl-I", wantKey: K(Tab)},
-	{s: "Ctrl-J", wantKey: K(Enter)},
+	// Confirm alternative symbolic keys are turned into the canonical form.
+	{s: "\t", wantKey: K(Tab)},           // literal tab is normalized to Tab
+	{s: "\n", wantKey: K(Enter)},         // literal newline is normalized to Enter
+	{s: "Ctrl-I", wantKey: K(Tab)},       // Ctrl-I is normalized to Tab
+	{s: "Ctrl-J", wantKey: K(Enter)},     // Ctrl-J is normalized to Enter
+	{s: "Ctrl-?", wantKey: K(Backspace)}, // Ctrl-? is normalized to Backspace
 
 	// Errors.
 	{s: "F123", wantErr: "bad key: F123"},

--- a/pkg/ui/key_test.go
+++ b/pkg/ui/key_test.go
@@ -51,8 +51,8 @@ var parseKeyTests = []struct {
 	{s: "F1", wantKey: K(F1)},
 
 	// Alt- keys are case-sensitive.
-	{s: "a-x", wantKey: Key{'x', Alt}},
-	{s: "a-X", wantKey: Key{'X', Alt}},
+	{s: "A-x", wantKey: Key{'x', Alt}},
+	{s: "A-X", wantKey: Key{'X', Alt}},
 
 	// Ctrl- keys are case-insensitive.
 	{s: "C-x", wantKey: Key{'X', Ctrl}},
@@ -66,8 +66,8 @@ var parseKeyTests = []struct {
 	{s: "Meta-x", wantKey: Key{'x', Alt}},
 
 	// Multiple modifiers can appear in any order.
-	{s: "Alt-Ctrl-Delete", wantKey: Key{Delete, Alt | Ctrl}},
-	{s: "Ctrl-Alt-Delete", wantKey: Key{Delete, Alt | Ctrl}},
+	{s: "Alt-Ctrl+Delete", wantKey: Key{Delete, Alt | Ctrl}},
+	{s: "Ctrl+Alt-Delete", wantKey: Key{Delete, Alt | Ctrl}},
 
 	// Ctrl-I and Ctrl-J are normalized to Tab and Enter.
 	{s: "Ctrl-I", wantKey: K(Tab)},
@@ -75,7 +75,8 @@ var parseKeyTests = []struct {
 
 	// Errors.
 	{s: "F123", wantErr: "bad key: F123"},
-	{s: "Super-X", wantErr: "bad modifier: super"},
+	{s: "Super-X", wantErr: "bad modifier: Super"},
+	{s: "a-x", wantErr: "bad modifier: a"},
 }
 
 func TestParseKey(t *testing.T) {

--- a/pkg/ui/key_test.go
+++ b/pkg/ui/key_test.go
@@ -58,6 +58,13 @@ var parseKeyTests = []struct {
 	{s: "C-x", wantKey: Key{'X', Ctrl}},
 	{s: "C-X", wantKey: Key{'X', Ctrl}},
 
+	// Literal control chars are equivalent to the preferred Ctrl-? formulation.
+	{s: "\033", wantKey: Key{'[', Ctrl}},
+	{s: "\t", wantKey: K(Tab)},
+	{s: "Alt-\t", wantKey: Key{Tab, Alt}},
+	{s: "\n", wantKey: K(Enter)},
+	{s: "\x7F", wantKey: K(Backspace)},
+
 	// + is the same as -.
 	{s: "C+X", wantKey: Key{'X', Ctrl}},
 
@@ -81,6 +88,7 @@ var parseKeyTests = []struct {
 	{s: "F123", wantErr: "bad key: F123"},
 	{s: "Super-X", wantErr: "bad modifier: Super"},
 	{s: "a-x", wantErr: "bad modifier: a"},
+	{s: "Ctrl-\t", wantErr: `Ctrl modifier with literal control char: '\t'`},
 }
 
 func TestParseKey(t *testing.T) {

--- a/website/ref/edit.md
+++ b/website/ref/edit.md
@@ -183,7 +183,38 @@ Bound functions have their inputs redirected to /dev/null.
 
 ### Format of Keys
 
-TBD
+Key modifiers and names are case sensitive. This includes single character key
+names such as `x` and `Y` as well as function key names such as `Enter`.
+
+Key names have zero or more modifiers from the following symbols:
+
+```
+    A  Alt
+    C  Ctrl
+    M  Meta
+    S  Shift
+```
+
+Modifiers, if present, end with either a `-` or `+`; e.g., `S-F1`, `Ctrl-X` or
+`Alt+Enter`. You can stack modifiers; e.g., `C+A-X`.
+
+The key name may be a simple character such as `x` or a function key from these
+symbols:
+
+```
+    F1  F2  F3  F4  F5  F6  F7  F8  F9  F10  F11  F12
+    Up  Down  Right  Left
+    Home  Insert  Delete  End  PageUp  PageDown
+    Tab  Enter  Backspace
+```
+
+**Note:** `Tab` is an alias for `"\t"` (aka `Ctrl-I`), `Enter` for `"\n"` (aka
+`Ctrl-J`), and `Backspace` for `"\x7F"` (aka `Ctrl-?`).
+
+**Note:** The `Shift` modifier is only applicable to function keys such as `F1`.
+You cannot write `Shift-m` as a synonym for `M`.
+
+**TODO:** Document the behavior of the `Shift` modifier.
 
 ### Listing Modes
 


### PR DESCRIPTION
Document the format of key names. Make function key name matching
case-insensitive for consistency with how key modifers (e.g., "Alt")
are handled.

Resolves #1163