### PR TITLE
[cleanup] trivial golint suggested changes

### DIFF
--- a/pkg/cli/addons/histlist/histlist_test.go
+++ b/pkg/cli/addons/histlist/histlist_test.go
@@ -23,9 +23,9 @@ func TestStart_NoStore(t *testing.T) {
 
 type faultyStore struct{}
 
-var mockError = errors.New("mock error")
+var errMock = errors.New("mock error")
 
-func (s faultyStore) AllCmds() ([]store.Cmd, error) { return nil, mockError }
+func (s faultyStore) AllCmds() ([]store.Cmd, error) { return nil, errMock }
 
 func TestStart_StoreError(t *testing.T) {
 	f := Setup()

--- a/pkg/cli/addons/lastcmd/lastcmd_test.go
+++ b/pkg/cli/addons/lastcmd/lastcmd_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/elves/elvish/pkg/ui"
 )
 
-var mockError = errors.New("mock error")
+var errMock = errors.New("mock error")
 
 func TestStart_NoStore(t *testing.T) {
 	f := Setup()
@@ -32,7 +32,7 @@ func TestStart_StoreError(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 
 	Start(f.App, Config{Store: store})
 	f.TestTTYNotes(t, "db error: mock error")

--- a/pkg/cli/addons/navigation/navigation.go
+++ b/pkg/cli/addons/navigation/navigation.go
@@ -64,9 +64,8 @@ func (w *widget) Handle(event term.Event) bool {
 			return true
 		}
 		return false
-	} else {
-		return w.app.CodeArea().Handle(event)
 	}
+	return w.app.CodeArea().Handle(event)
 }
 
 func (w *widget) Render(width, height int) *term.Buffer {
@@ -368,8 +367,8 @@ func MutateFiltering(app cli.App, f func(bool) bool) {
 	})
 }
 
-// MutateFiltering changes whether the navigation addon should show file whose
-// names start with ".".
+// MutateShowHidden changes whether the navigation addon should show file
+// whose names start with ".".
 func MutateShowHidden(app cli.App, f func(bool) bool) {
 	actOnWidget(app, func(w *widget) {
 		w.MutateState(func(s *state) { s.ShowHidden = f(s.ShowHidden) })

--- a/pkg/cli/clitest/apptest.go
+++ b/pkg/cli/clitest/apptest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/elves/elvish/pkg/ui"
 )
 
-// Common stylesheet.
+// Styles defines a common stylesheet for unit tests.
 var Styles = ui.RuneStylesheet{
 	'_': ui.Underlined,
 	'b': ui.Bold,

--- a/pkg/cli/codearea.go
+++ b/pkg/cli/codearea.go
@@ -331,12 +331,13 @@ func (w *codeArea) handleKeyEvent(key ui.Key) bool {
 	}
 }
 
-// Determine if the rune is an alphanumeric character.
+// IsAlnum determines if the rune is an alphanumeric character.
 func IsAlnum(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsNumber(r)
 }
 
-// Determine if the rune is whitespace, alphanum, or something else.
+// CategorizeSmallWord determines if the rune is whitespace, alphanum, or
+// something else.
 func CategorizeSmallWord(r rune) int {
 	switch {
 	case unicode.IsSpace(r):

--- a/pkg/cli/histutil/db_store.go
+++ b/pkg/cli/histutil/db_store.go
@@ -2,8 +2,8 @@ package histutil
 
 import "github.com/elves/elvish/pkg/store"
 
-// Returns a Store backed by a database, with the view of all commands frozen at
-// creation.
+// NewDBStore returns a Store backed by a database with the view of all
+// commands frozen at creation.
 func NewDBStore(db DB) (Store, error) {
 	upper, err := db.NextCmdSeq()
 	if err != nil {

--- a/pkg/cli/histutil/db_store_test.go
+++ b/pkg/cli/histutil/db_store_test.go
@@ -32,20 +32,20 @@ func TestDBStore_Cursor(t *testing.T) {
 		}
 	}
 
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 	c.Prev()
-	expect(store.Cmd{Seq: 3}, mockError)
+	expect(store.Cmd{Seq: 3}, errMock)
 
 	c.Prev()
 	expect(store.Cmd{Text: "+ 3", Seq: 2}, nil)
 
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 	c.Prev()
-	expect(store.Cmd{Text: "+ 3", Seq: 2}, mockError)
+	expect(store.Cmd{Text: "+ 3", Seq: 2}, errMock)
 
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 	c.Next()
-	expect(store.Cmd{Text: "+ 3", Seq: 2}, mockError)
+	expect(store.Cmd{Text: "+ 3", Seq: 2}, errMock)
 }
 
 // Remaining methods tested with HybridStore.

--- a/pkg/cli/histutil/hybrid_store_test.go
+++ b/pkg/cli/histutil/hybrid_store_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elves/elvish/pkg/store"
 )
 
-var mockError = errors.New("mock error")
+var errMock = errors.New("mock error")
 
 func TestNewHybridStore_ReturnsMemStoreIfDBIsNil(t *testing.T) {
 	store, err := NewHybridStore(nil)
@@ -22,13 +22,13 @@ func TestNewHybridStore_ReturnsMemStoreIfDBIsNil(t *testing.T) {
 
 func TestNewHybridStore_ReturnsMemStoreOnDBError(t *testing.T) {
 	db := NewFaultyInMemoryDB()
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 	store, err := NewHybridStore(db)
 	if _, ok := store.(*memStore); !ok {
 		t.Errorf("NewHybridStore -> %v, want memStore", store)
 	}
-	if err != mockError {
-		t.Errorf("NewHybridStore -> error %v, want %v", err, mockError)
+	if err != errMock {
+		t.Errorf("NewHybridStore -> error %v, want %v", err, errMock)
 	}
 }
 
@@ -59,11 +59,11 @@ func TestFusuer_AddCmd_AddsBothToDBAndSession(t *testing.T) {
 func TestHybridStore_AddCmd_AddsToSessionEvenIfDBErrors(t *testing.T) {
 	db := NewFaultyInMemoryDB()
 	f := mustNewHybridStore(db)
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 
 	_, err := f.AddCmd(store.Cmd{Text: "haha"})
-	if err != mockError {
-		t.Errorf("AddCmd -> error %v, want %v", err, mockError)
+	if err != errMock {
+		t.Errorf("AddCmd -> error %v, want %v", err, errMock)
 	}
 
 	allCmds, err := f.AllCmds()
@@ -107,11 +107,11 @@ func TestHybridStore_AllCmds_ReturnsSessionIfDBErrors(t *testing.T) {
 	db := NewFaultyInMemoryDB("shared 1")
 	f := mustNewHybridStore(db)
 	f.AddCmd(store.Cmd{Text: "session 1"})
-	db.SetOneOffError(mockError)
+	db.SetOneOffError(errMock)
 
 	allCmds, err := f.AllCmds()
-	if err != mockError {
-		t.Errorf("AllCmds -> error %v, want %v", err, mockError)
+	if err != errMock {
+		t.Errorf("AllCmds -> error %v, want %v", err, errMock)
 	}
 	wantAllCmds := []store.Cmd{{Text: "session 1", Seq: 1}}
 	if !reflect.DeepEqual(allCmds, wantAllCmds) {

--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -317,14 +317,14 @@ func evalModule(fm *Frame, key string, src parse.Source, st *StackTrace) (Ns, er
 
 // Evaluates a source. Shared by evalModule and the eval builtin.
 func evalInner(fm *Frame, src parse.Source, ns Ns, st *StackTrace) error {
-	tree, err := parse.ParseWithDeprecation(src, fm.ports[2].File)
+	tree, err := parse.ParseWithDeprecation(src, fm.ErrorFile())
 	if err != nil {
 		return err
 	}
 	newFm := &Frame{
 		fm.Evaler, src, ns, make(Ns),
 		fm.intCh, fm.ports, fm.traceback, fm.background}
-	op, err := compile(newFm.Builtin.static(), ns.static(), tree, fm.ports[2].File)
+	op, err := compile(newFm.Builtin.static(), ns.static(), tree, fm.ErrorFile())
 	if err != nil {
 		return err
 	}

--- a/pkg/eval/compile_effect.go
+++ b/pkg/eval/compile_effect.go
@@ -175,7 +175,7 @@ func (op *pipelineOp) exec(fm *Frame) error {
 				if fm.Editor != nil {
 					fm.Editor.Notify("%s", msg)
 				} else {
-					fm.ports[2].File.WriteString(msg + "\n")
+					fm.ErrorFile().WriteString(msg + "\n")
 				}
 			}
 		}()

--- a/pkg/eval/evaltest/evaltest.go
+++ b/pkg/eval/evaltest/evaltest.go
@@ -75,8 +75,8 @@ func (t TestCase) Prints(s string) TestCase {
 	return t
 }
 
-// PrintsStderr returns an altered TestCase that requires the stderr output to
-// contain the given text.
+// PrintsStderrWith returns an altered TestCase that requires the stderr
+// output to contain the given text.
 func (t TestCase) PrintsStderrWith(s string) TestCase {
 	t.want.StderrOut = []byte(s)
 	return t

--- a/pkg/eval/frame.go
+++ b/pkg/eval/frame.go
@@ -199,6 +199,6 @@ func (fm *Frame) Deprecate(msg string, ctx *diag.Context) {
 	if prog.ShowDeprecations && fm.deprecations.register(dep) {
 		err := diag.Error{
 			Type: "deprecation", Message: dep.message, Context: *ctx}
-		fm.ports[2].File.WriteString(err.Show("") + "\n")
+		fm.ErrorFile().WriteString(err.Show("") + "\n")
 	}
 }

--- a/pkg/eval/frame.go
+++ b/pkg/eval/frame.go
@@ -77,7 +77,7 @@ func (fm *Frame) OutputFile() *os.File {
 	return fm.ports[1].File
 }
 
-// OutputFile returns a file onto which error messages can be written.
+// ErrorFile returns a file onto which error messages can be written.
 func (fm *Frame) ErrorFile() *os.File {
 	return fm.ports[2].File
 }

--- a/pkg/eval/glob.go
+++ b/pkg/eval/glob.go
@@ -29,7 +29,9 @@ var typeCbMap = map[string]func(os.FileMode) bool{
 }
 
 const (
-	NoMatchOK GlobFlag = 1 << iota
+	// noMatchOK indicates that the "nomatch-ok" glob index modifer was
+	// present.
+	noMatchOK GlobFlag = 1 << iota
 )
 
 func (f GlobFlag) Has(g GlobFlag) bool {
@@ -73,7 +75,7 @@ func (gp GlobPattern) Index(k interface{}) (interface{}, error) {
 	modifier := modifierv
 	switch {
 	case modifier == "nomatch-ok":
-		gp.Flags |= NoMatchOK
+		gp.Flags |= noMatchOK
 	case strings.HasPrefix(modifier, "but:"):
 		gp.Buts = append(gp.Buts, modifier[len("but:"):])
 	case modifier == "match-hidden":
@@ -254,7 +256,7 @@ func doGlob(gp GlobPattern, abort <-chan struct{}) ([]interface{}, error) {
 	}) {
 		return nil, ErrInterrupted
 	}
-	if len(vs) == 0 && !gp.Flags.Has(NoMatchOK) {
+	if len(vs) == 0 && !gp.Flags.Has(noMatchOK) {
 		return nil, ErrWildcardNoMatch
 	}
 	return vs, nil

--- a/pkg/eval/port.go
+++ b/pkg/eval/port.go
@@ -42,7 +42,7 @@ var (
 	// DevNullClosedChan is a port made up from DevNull and ClosedChan,
 	// suitable as placeholder input port.
 	DevNullClosedChan = &Port{File: DevNull, Chan: ClosedChan}
-	// DevNullClosedChan is a port made up from DevNull and BlackholeChan,
+	// DevNullBlackholeChan is a port made up from DevNull and BlackholeChan,
 	// suitable as placeholder output port.
 	DevNullBlackholeChan = &Port{File: DevNull, Chan: BlackholeChan}
 )

--- a/pkg/eval/variable_ref.go
+++ b/pkg/eval/variable_ref.go
@@ -28,15 +28,16 @@ func SplitQNameNs(qname string) (ns, name string) {
 	return qname[:colon+1], qname[colon+1:]
 }
 
-// SplitQNameNs splits an incomplete qualified variable name into the namespace
-// part and the name part.
+// SplitQNameNsIncomplete splits an incomplete qualified variable name into
+// the namespace part and the name part.
 func SplitQNameNsIncomplete(qname string) (ns, name string) {
 	colon := strings.LastIndexByte(qname, ':')
 	// If colon is -1, colon+1 will be 0, rendering an empty ns.
 	return qname[:colon+1], qname[colon+1:]
 }
 
-// SplitQNameNs splits a qualified variable name into the first part and the rest.
+// SplitQNameNsFirst splits a qualified variable name into the first part and
+// the rest.
 func SplitQNameNsFirst(qname string) (ns, rest string) {
 	colon := strings.IndexByte(qname, ':')
 	if colon == len(qname)-1 {
@@ -47,8 +48,8 @@ func SplitQNameNsFirst(qname string) (ns, rest string) {
 	return qname[:colon+1], qname[colon+1:]
 }
 
-// SplitIncompleteQNameNsFirst splits an incomplete qualified variable name into
-// the first part and the rest.
+// SplitIncompleteQNameFirstNs splits an incomplete qualified variable name
+// into the first part and the rest.
 func SplitIncompleteQNameFirstNs(qname string) (ns, rest string) {
 	colon := strings.IndexByte(qname, ':')
 	// If colon is -1, colon+1 will be 0, rendering an empty ns.

--- a/pkg/eval/vars/ptr.go
+++ b/pkg/eval/vars/ptr.go
@@ -44,7 +44,7 @@ func (v PtrVar) GetRaw() interface{} {
 	return reflect.Indirect(reflect.ValueOf(v.ptr)).Interface()
 }
 
-// Get sets the value pointed by the pointer, after conversion using ScanToGo.
+// Set sets the value pointed by the pointer, after conversion using ScanToGo.
 func (v PtrVar) Set(val interface{}) error {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()

--- a/pkg/parse/parseutil/parseutil.go
+++ b/pkg/parse/parseutil/parseutil.go
@@ -7,7 +7,7 @@ import (
 	"github.com/elves/elvish/pkg/parse"
 )
 
-// LeafNodeAtDot finds the leaf node at a specific position. It returns nil if
+// FindLeafNode finds the leaf node at a specific position. It returns nil if
 // position is out of bound.
 func FindLeafNode(n parse.Node, p int) parse.Node {
 descend:

--- a/pkg/prog/prog.go
+++ b/pkg/prog/prog.go
@@ -1,5 +1,5 @@
-// Package program provides the entry point to Elvish. Its subpackages
-// correspond to subprograms of Elvish.
+// Package prog provides the entry point to Elvish. Its subpackages correspond
+// to subprograms of Elvish.
 package prog
 
 // This package sets up the basic environment and calls the appropriate
@@ -21,7 +21,7 @@ import (
 // resembles "elvi".
 const defaultWebPort = 3171
 
-// Global flag of whether to show deprecations.
+// ShowDeprecations is a global flag that controls whether to show deprecations.
 var ShowDeprecations = false
 
 // SetShowDeprecations sets ShowDeprecations to the given value, and returns a

--- a/pkg/prog/progtest/progtest_test.go
+++ b/pkg/prog/progtest/progtest_test.go
@@ -14,7 +14,7 @@ func TestOutputCaptureDoesNotDeadlock(t *testing.T) {
 	// filling the pipe before the test completes. Pipes typically buffer 8 to
 	// 128 KiB.
 	bytes := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	for i := 0; i < 128*1024/len(bytes); i += 1 {
+	for i := 0; i < 128*1024/len(bytes); i++ {
 		f.pipes[1].w.Write(bytes[:])
 	}
 	f.pipes[1].w.WriteString("hello\n")

--- a/pkg/shell/paths_unix_test.go
+++ b/pkg/shell/paths_unix_test.go
@@ -16,7 +16,7 @@ import (
 // TODO(xiaq): Rewrite these tests to test the exported MakePaths instead of the
 // unexported getSecureRunDir.
 
-var elvishDashUid = fmt.Sprintf("elvish-%d", os.Getuid())
+var elvishDashUID = fmt.Sprintf("elvish-%d", os.Getuid())
 
 func TestGetSecureRunDir_PrefersXDGWhenNeitherExists(t *testing.T) {
 	xdg, _, cleanup := setupForSecureRunDir()
@@ -29,7 +29,7 @@ func TestGetSecureRunDir_PrefersXDGWhenBothExist(t *testing.T) {
 	defer cleanup()
 
 	os.MkdirAll(filepath.Join(xdg, "elvish"), 0700)
-	os.MkdirAll(filepath.Join(tmp, elvishDashUid), 0700)
+	os.MkdirAll(filepath.Join(tmp, elvishDashUID), 0700)
 
 	testSecureRunDir(t, filepath.Join(xdg, "elvish"), false)
 }
@@ -38,16 +38,16 @@ func TestGetSecureRunDir_PrefersTmpWhenOnlyItExists(t *testing.T) {
 	_, tmp, cleanup := setupForSecureRunDir()
 	defer cleanup()
 
-	os.MkdirAll(filepath.Join(tmp, elvishDashUid), 0700)
+	os.MkdirAll(filepath.Join(tmp, elvishDashUID), 0700)
 
-	testSecureRunDir(t, filepath.Join(tmp, elvishDashUid), false)
+	testSecureRunDir(t, filepath.Join(tmp, elvishDashUID), false)
 }
 
 func TestGetSecureRunDir_PrefersTmpWhenXdgEnvIsEmpty(t *testing.T) {
 	_, tmp, cleanup := setupForSecureRunDir()
 	defer cleanup()
 	os.Setenv(env.XDG_RUNTIME_DIR, "")
-	testSecureRunDir(t, filepath.Join(tmp, elvishDashUid), false)
+	testSecureRunDir(t, filepath.Join(tmp, elvishDashUID), false)
 }
 
 func TestGetSecureRunDir_ReturnsErrorWhenUnableToMkdir(t *testing.T) {

--- a/pkg/testutil/must.go
+++ b/pkg/testutil/must.go
@@ -23,7 +23,7 @@ func MustReadAllAndClose(r io.ReadCloser) []byte {
 	return bs
 }
 
-// Calls os.MkdirAll and panics if an error is returned.
+// MustMkdirAll calls os.MkdirAll and panics if an error is returned.
 func MustMkdirAll(names ...string) {
 	for _, name := range names {
 		err := os.MkdirAll(name, 0700)
@@ -33,7 +33,7 @@ func MustMkdirAll(names ...string) {
 	}
 }
 
-// Creates an empty file, and panics if an error occurs.
+// MustCreateEmpty creates an empty file, and panics if an error occurs.
 func MustCreateEmpty(names ...string) {
 	for _, name := range names {
 		file, err := os.Create(name)
@@ -44,7 +44,7 @@ func MustCreateEmpty(names ...string) {
 	}
 }
 
-// Calls ioutil.WriteFile and panics if an error occurs.
+// MustWriteFile calls ioutil.WriteFile and panics if an error occurs.
 func MustWriteFile(filename string, data []byte, perm os.FileMode) {
 	err := ioutil.WriteFile(filename, data, perm)
 	if err != nil {

--- a/pkg/ui/key_test.go
+++ b/pkg/ui/key_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/xiaq/persistent/hash"
 )
 
-var kTests = []struct {
+var identityTests = []struct {
 	k1 Key
 	k2 Key
 }{
@@ -17,7 +17,7 @@ var kTests = []struct {
 }
 
 func TestK(t *testing.T) {
-	for _, test := range kTests {
+	for _, test := range identityTests {
 		if test.k1 != test.k2 {
 			t.Errorf("%v != %v", test.k1, test.k2)
 		}


### PR DESCRIPTION
As with commit #eb2a792 I acknowledge that `golint` recommendations are
controversial and should not automatically be acted on. Nonetheless,
this change fixes legitimate lint issues such as copy/paste cleanups,
style problems I introduced (`i += 1` versus `i++`) or method/var comments
that are not in the preferred form.