### PR TITLE
Make test coverage statistics more accurate

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,11 +4,13 @@ environment:
   GOPATH: c:\gopath
   ELVISH_TEST_TIME_SCALE: 10
 install:
-  # Needed since the codecov uploader depends on a UNIX "find" command.
+  # The coverage script and codecov uploader depend on a POSIX shell and
+  # commands such as `find` so ensure the relevant Windows MSYS2 directory is
+  # in the external command search path.
   - set PATH=C:\msys64\usr\bin;%PATH%
 build: off
 before_test:
   - go version
 test_script:
-  - go test -coverprofile=coverage -covermode=set ./...
+  - bash -e tools/test-coverage.sh
   - curl -s https://codecov.io/bash -o codecov && bash codecov -f coverage || ver > nul

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ test_task:
   test_script: go test $TEST_FLAG ./...
   upload_coverage_script:
     - test -z $SKIP_UPLOAD_COVERAGE || exit 0
-    - go test -coverprofile=coverage -covermode=set ./...
+    - bash -e tools/test-coverage.sh
     - curl -s https://codecov.io/bash -o codecov && bash codecov -f coverage -t $CODECOV_TOKEN || true
 
 checkstyle_go_task:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,10 +5,3 @@ coverage:
         threshold: 0.1%
     patch: off
 comment: false
-ignore:
-  # Exclude test helpers from coverage calculation.
-  - "pkg/cli/clitest"
-  - "pkg/eval/evaltest"
-  - "pkg/prog/progtest"
-  - "pkg/store/storetest"
-  - "pkg/testutil/must.go"

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ test:
 # Generate a basic test coverage report. This will open the report in your
 # browser. See also https://codecov.io/gh/elves/elvish/.
 cover:
-	go test -covermode=set -coverprofile=$@ ./...
-	go tool cover -html=$@
+	tools/test-coverage.sh
+	go tool cover -html=coverage
+	go tool cover -func=coverage | tail -1 | awk '{ print "Overall coverage:", $$NF }'
 
 # Ensure the style of Go and Markdown source files is consistent.
 style:

--- a/tools/test-coverage.sh
+++ b/tools/test-coverage.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+#
+# This script exists due to the problem noted in
+# https://github.com/elves/elvish/issues/1187. Specifically, `go test -cover`
+# only instruments code in the same package as the unit test. Which
+# effectively excludes coverage by integration tests.
+#
+# Testing each package individually with `-coverpackage=./...` produces, in
+# aggregate, a more accurate picture of which statements are executed by all
+# tests.
+
+# Exclude these test utilities (that will always have low coverage), and other
+# packages we don't care about having low coverage (e.g., pkg/web), from test
+# coverage reports.
+excluded_modules=(
+  "pkg/cli/clitest"
+  "pkg/eval/evaltest"
+  "pkg/prog/progtest"
+  "pkg/store/storetest"
+  "pkg/web"
+)
+
+exclusion_file=$(mktemp)
+rm -f $exclusion_file
+for excluded in ${excluded_modules[*]}
+do
+    echo "$excluded" >>$exclusion_file
+done
+
+rm -f coverage
+echo 'mode: set' >coverage
+for pkg in $(go list ./...)
+do
+    exclude=false
+    for excluded in ${excluded_modules[*]}
+    do
+        if [[ $pkg == *"$excluded"* ]]; then
+            exclude=true
+            break
+        fi
+    done
+    if [[ $exclude == true ]]
+    then
+        continue
+    fi
+
+    # The `|| true` is needed because some packages may not have any test
+    # coverage. We don't want that to cause this script to terminate.
+    rm -f coverage.tmp
+    go test -covermode=set -coverprofile=coverage.tmp -coverpkg=./... $pkg || true
+    tail +2 coverage.tmp | grep -v -F -f $exclusion_file >>coverage || true
+done
+rm -f coverage.tmp $exclusion_file


### PR DESCRIPTION
The default behavior of `go test -cover` ignores coverage by integration
tests. That is, it ignores coverage by tests in a different package. This
penalizes Elvish since Elvish has a lot of integration tests that are
meant to explicitly exercise code in other packages.

Resolves #1062
Resolves #1187