### PR TITLE
Make test coverage statistics more accurate

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,11 +4,13 @@ environment:
   GOPATH: c:\gopath
   ELVISH_TEST_TIME_SCALE: 10
 install:
-  # Needed since the codecov uploader depends on a UNIX "find" command.
+  # The codecov uploader depends on a POSIX shell and commands such as `find`
+  # so ensure the relevant Windows MSYS2 directory is in the external command
+  # search path.
   - set PATH=C:\msys64\usr\bin;%PATH%
 build: off
 before_test:
   - go version
 test_script:
-  - go test -coverprofile=coverage -covermode=set ./...
-  - curl -s https://codecov.io/bash -o codecov && bash codecov -f coverage || ver > nul
+  - go test -coverprofile=cover -coverpkg=./pkg/... ./pkg/...
+  - curl -s https://codecov.io/bash -o codecov && bash codecov -f cover || ver > nul

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,8 +51,8 @@ test_task:
   test_script: go test $TEST_FLAG ./...
   upload_coverage_script:
     - test -z $SKIP_UPLOAD_COVERAGE || exit 0
-    - go test -coverprofile=coverage -covermode=set ./...
-    - curl -s https://codecov.io/bash -o codecov && bash codecov -f coverage -t $CODECOV_TOKEN || true
+    - go test -coverprofile=cover -coverpkg=./pkg/... ./pkg/...
+    - curl -s https://codecov.io/bash -o codecov && bash codecov -f cover -t $CODECOV_TOKEN || true
 
 checkstyle_go_task:
   name: Check the style of .go files

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ test:
 # Generate a basic test coverage report. This will open the report in your
 # browser. See also https://codecov.io/gh/elves/elvish/.
 cover:
-	go test -covermode=set -coverprofile=$@ ./...
-	go tool cover -html=$@
+	go test -coverprofile=cover -coverpkg=./pkg/... ./pkg/...
+	go tool cover -html=cover
+	go tool cover -func=cover | tail -1 | awk '{ print "Overall coverage:", $$NF }'
 
 # Ensure the style of Go and Markdown source files is consistent.
 style:


### PR DESCRIPTION
The default behavior of `go test -cover` ignores coverage by integration
tests. That is, it ignores coverage by tests in a different package. This
penalizes Elvish since Elvish has a lot of integration tests that are
meant to explicitly exercise code in other packages.

Resolves #1062
Resolves #1187