### PR TITLE
Ensure the daemon doesn't have fds open on the tty

### DIFF
--- a/pkg/daemon/spawn_unix.go
+++ b/pkg/daemon/spawn_unix.go
@@ -7,11 +7,15 @@ import (
 	"syscall"
 )
 
-func procAttrForSpawn() *os.ProcAttr {
+func procAttrForSpawn(stdout *os.File) *os.ProcAttr {
+	// The daemon should not inherit a reference to the stdin file descriptor
+	// of the original shell. The daemon shouldn't read anything from stdin so
+	// use the null device.
+	devnull, _ := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
 	return &os.ProcAttr{
-		Dir:   "/",        // cd to /
-		Env:   []string{}, // empty environment
-		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Dir:   "/",
+		Env:   []string{},
+		Files: []*os.File{devnull, stdout, stdout},
 		Sys: &syscall.SysProcAttr{
 			Setsid: true, // detach from current terminal
 		},

--- a/pkg/daemon/spawn_windows.go
+++ b/pkg/daemon/spawn_windows.go
@@ -15,11 +15,15 @@ const (
 	daemonCreationFlags = CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
 )
 
-func procAttrForSpawn() *os.ProcAttr {
+func procAttrForSpawn(stdout *os.File) *os.ProcAttr {
+	// The daemon should not inherit a reference to the stdin file descriptor
+	// of the original shell. The daemon shouldn't read anything from stdin so
+	// use the null device.
+	devnull, _ := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
 	return &os.ProcAttr{
 		Dir:   `C:\`,
 		Env:   []string{"SystemRoot=" + os.Getenv("SystemRoot")}, // SystemRoot is needed for net.Listen for some reason
-		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Files: []*os.File{devnull, stdout, stdout},
 		Sys:   &syscall.SysProcAttr{CreationFlags: daemonCreationFlags},
 	}
 }

--- a/pkg/fsutil/claim.go
+++ b/pkg/fsutil/claim.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -53,7 +54,7 @@ func ClaimFile(dir, pattern string) (*os.File, error) {
 	}
 
 	for i := max + 1; ; i++ {
-		name := prefix + strconv.Itoa(i) + suffix
+		name := filepath.Join(dir, prefix+strconv.Itoa(i)+suffix)
 		f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, 0666)
 		if err == nil {
 			return f, nil

--- a/pkg/shell/paths.go
+++ b/pkg/shell/paths.go
@@ -11,9 +11,8 @@ import (
 
 // Paths keeps all paths required for the Elvish runtime.
 type Paths struct {
-	RunDir          string
-	Sock            string
-	DaemonLogPrefix string
+	RunDir string
+	Sock   string
 
 	DataDir string
 	Db      string
@@ -29,7 +28,6 @@ func MakePaths(stderr io.Writer, overrides Paths) Paths {
 	setDir(&p.RunDir, "secure run directory", getSecureRunDir, stderr)
 	if p.RunDir != "" {
 		setChild(&p.Sock, p.RunDir, "sock")
-		setChild(&p.DaemonLogPrefix, p.RunDir, "daemon.log-")
 	}
 
 	setDir(&p.DataDir, "data directory", ensureDataDir, stderr)

--- a/pkg/shell/paths_test.go
+++ b/pkg/shell/paths_test.go
@@ -14,9 +14,8 @@ var j = filepath.Join
 func TestMakePaths_PopulatesUnsetSubPaths(t *testing.T) {
 	paths := MakePaths(os.Stderr, Paths{RunDir: "run", DataDir: "data", Bin: "bin"})
 	wantPaths := Paths{
-		RunDir:          "run",
-		Sock:            j("run", "sock"),
-		DaemonLogPrefix: j("run", "daemon.log-"),
+		RunDir: "run",
+		Sock:   j("run", "sock"),
 
 		DataDir: "data",
 		Db:      j("data", "db"),

--- a/pkg/shell/runtime.go
+++ b/pkg/shell/runtime.go
@@ -59,10 +59,10 @@ func InitRuntime(stderr io.Writer, p Paths, spawn bool) *eval.Evaler {
 
 	if spawn && p.Sock != "" && p.Db != "" {
 		spawnCfg := &daemon.SpawnConfig{
-			BinPath:       p.Bin,
-			DbPath:        p.Db,
-			SockPath:      p.Sock,
-			LogPathPrefix: p.DaemonLogPrefix,
+			RunDir:   p.RunDir,
+			BinPath:  p.Bin,
+			DbPath:   p.Db,
+			SockPath: p.Sock,
 		}
 		// TODO(xiaq): Connect to daemon and install daemon module
 		// asynchronously.

--- a/pkg/shell/shell_unix_test.go
+++ b/pkg/shell/shell_unix_test.go
@@ -53,7 +53,7 @@ func TestShell_ConnectsToDaemon(t *testing.T) {
 		[]string{"use daemon; print $daemon:pid"},
 		&ScriptConfig{
 			Cmd: true, SpawnDaemon: true,
-			Paths: Paths{Sock: "sock", Db: "db", DaemonLogPrefix: "log-"}})
+			Paths: Paths{Sock: "sock", Db: "db", RunDir: "."}})
 	f.TestOut(t, 1, strconv.Itoa(os.Getpid()))
 	f.TestOut(t, 2, "")
 }


### PR DESCRIPTION
The Elvish daemon should not inherit file descriptors open on the tty.
Make the daemon's stdin open on the null device and its stdout/stderr
open on a predictable file.

Fixes #1191