### PR TITLE
Implement a `printf` builtin

### DIFF
--- a/pkg/eval/builtin_fn_io.go
+++ b/pkg/eval/builtin_fn_io.go
@@ -25,6 +25,7 @@ func init() {
 
 		// Bytes output
 		"print":  print,
+		"printf": printf,
 		"echo":   echo,
 		"pprint": pprint,
 		"repr":   repr,
@@ -191,6 +192,180 @@ func print(fm *Frame, opts printOpts, args ...interface{}) {
 			out.WriteString(opts.Sep)
 		}
 		out.WriteString(vals.ToString(arg))
+	}
+}
+
+//elvdoc:fn printf
+//
+// ```elvish
+// printf $fmt $value...
+// ```
+//
+// Like [`print`](#print) but uses a formatting template to control how the
+// values appear in the output. An implicit newline is not added. You must
+// include a newline in the format (e.g., `printf "%s\n" yes`) or a string
+// value if a newline is desired in the output. This command writes its output
+// to the byte stream.
+//
+// See Go's [`fmt`](https://golang.org/pkg/fmt/#hdr-Printing) package for
+// details about the formatting verbs and the various flags that modify the
+// default behavior; e.g., left versus right justification. We explicitly
+// handle only strings and float64 data types. Printing other types is likely
+// to result in unexpected output (but not an exception). You can use the
+// numeric formatting verbs (e.g., `%d`, `%f`) with either a float64 or a
+// string that can be converted to a number. If you use a float64 value to
+// the `%s` verb it will first be converted to a string using the rules for
+// [numbers](language.html#number]).
+//
+// Examples:
+//
+// ```elvish-transcript
+// ~> printf "%10s %.2f\n" Pi $math:pi
+//         Pi 3.14
+// ~> printf "%-10s %.2f %s\n" Pi $math:pi $math:pi
+// Pi         3.14 3.141592653589793
+// ~> printf "%d\n" 0b11100111
+// 231
+// ~> printf "%08b\n" 231
+// 11100111
+// ```
+//
+// **Note**: A couple of Go's [formatting
+// verbs](https://golang.org/pkg/fmt/#hdr-Printing), such as `%b` and `%x`,
+// behave differently based on the associated value type. In Elvish the
+// type is always an integer; specifically, a Go `int`; regardless of whether
+// the Elvish value is a string or float64. That is, the number is coerced to
+// an int if possible else an exception is raised.
+//
+// **Note**: Do not use the `%p` or `%q` formatting verbs at this time. The `%p`
+// verb will never have any meaning. The `%q` formatting verb will eventually
+// behave as if you had printed the result of `repr` on the value. Similarly,
+// only scalars such as strings and numbers are currently supported. Passing
+// an Elvish list, map, exception, or other complex type will produce
+// unexpected output. This will be improved in the future.
+//
+// **Note**: This is loosely based on the [POSIX `printf`
+// command](https://pubs.opengroup.org/onlinepubs/007908799/xcu/printf.html).
+// There are three notable differences. The first is that the formatting verbs
+// and behavior use Go's [`fmt`](https://golang.org/pkg/fmt/) package and not
+// the POSIX specification. The two have many similarities but are not
+// identical. The second is that the number of values must match the number of
+// formatting verbs. Excess values do not result in the format being evaluated
+// additional times until all values are consumed as happens with the POSIX
+// command of the same name. You must explicitly split the value list and
+// invoke this builtin for each block of values. The third is that the Elvish
+// `printf` does not recognize backslash sequences such as `\n`. You must use
+// [double-quoted Elvish strings](language.html#double-quoted-string) if you
+// want such backslash sequences to be recognized -- just as you would with a
+// string passed to any other Elvish builtin.
+//
+// @cf print echo pprint repr
+
+type formatterString struct {
+	str string
+}
+type formatterFloat64 struct {
+	num float64
+}
+
+func printf(fm *Frame, template string, args ...interface{}) {
+	out := fm.OutputFile()
+	aliasedArgs := make([]interface{}, len(args))
+	// TODO: Implement support for `%q` but using Elvish's rules for quoting
+	// strings such as produced by `repr '\a"b'"\033'"` rather than Go's
+	// default `%q` behavior.
+	//
+	// TODO: Possibly special case other Elvish types such as lists, maps and
+	// exceptions.
+	for i, a := range args {
+		switch a := a.(type) {
+		case string:
+			aliasedArgs[i] = formatterString{a}
+		case float64:
+			aliasedArgs[i] = formatterFloat64{a}
+		default:
+			// This will pretty much only work if the `%v` fmt verb is used or
+			// the argument type matches the formatting verg (e.g., passing
+			// `$true` to the `%t` verb).
+			aliasedArgs[i] = a
+		}
+	}
+	s := fmt.Sprintf(template, aliasedArgs...)
+	out.WriteString(s)
+}
+
+// Convert a formatting verb state to a string that is logically equivalent to
+// the original formatting verb.
+func buildFmtVerb(state fmt.State, v rune) string {
+	var flags = []rune{'%'}
+	for _, f := range "+-# 0" {
+		if state.Flag(int(f)) {
+			flags = append(flags, f)
+		}
+	}
+	s := string(flags)
+	if w, ok := state.Width(); ok {
+		s = fmt.Sprintf("%s%d", s, w)
+	}
+	if p, ok := state.Precision(); ok {
+		s = fmt.Sprintf("%s.%d", s, p)
+	}
+	return s + string(v)
+}
+
+func stringAsFloat(state fmt.State, r rune, s string) {
+	var n float64
+	if err := vals.ScanToGo(s, &n); err != nil {
+		fmt.Fprintf(state, "%%!f(%s)", err.Error())
+		return
+	}
+	verb := buildFmtVerb(state, r)
+	fmt.Fprintf(state, verb, n)
+}
+
+func stringAsInt(state fmt.State, r rune, s string) {
+	var n int
+	if err := vals.ScanToGo(s, &n); err != nil {
+		fmt.Fprintf(state, "%%!%c(%s)", r, err.Error())
+		return
+	}
+	verb := buildFmtVerb(state, r)
+	fmt.Fprintf(state, verb, n)
+}
+
+// Format an Elvish float64 according to the provided fmt verb.
+func (v formatterFloat64) Format(state fmt.State, r rune) {
+	switch r {
+	case 's', 'v':
+		verb := buildFmtVerb(state, r)
+		fmt.Fprintf(state, verb, vals.ToString(v.num))
+	case 'e', 'E', 'f', 'F', 'g', 'G':
+		verb := buildFmtVerb(state, r)
+		fmt.Fprintf(state, verb, v.num)
+	case 'b', 'd', 'o', 'O', 'x', 'X', 'U':
+		i := int(v.num)
+		if float64(i) != v.num {
+			fmt.Fprintf(state, "%%!d(must be an integer)")
+			return
+		}
+		verb := buildFmtVerb(state, r)
+		fmt.Fprintf(state, verb, i)
+	default:
+		fmt.Fprintf(state, "%%!%c(unsupported formatting verb)", r)
+	}
+}
+
+func (v formatterString) Format(state fmt.State, r rune) {
+	switch r {
+	case 's', 'v':
+		verb := buildFmtVerb(state, r)
+		fmt.Fprintf(state, verb, v.str)
+	case 'e', 'E', 'f', 'F', 'g', 'G':
+		stringAsFloat(state, r, v.str)
+	case 'b', 'd', 'o', 'O', 'x', 'X', 'U':
+		stringAsInt(state, r, v.str)
+	default:
+		fmt.Fprintf(state, "%%!%c(unsupported formatting verb)", r)
 	}
 }
 

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -55,3 +55,25 @@ func TestBuiltinFnIO(t *testing.T) {
 		That(`put [$nil foo] | to-json`).Prints("[null,\"foo\"]\n"),
 	)
 }
+
+func TestBuiltinFnPrintf(t *testing.T) {
+	Test(t,
+		That(`printf abcd`).Prints("abcd"),
+		That(`printf '%s\n%s\n' abc xyz`).Prints("abc\\nxyz\\n"),
+		That(`printf "%s\n%s\n" abc xyz`).Prints("abc\nxyz\n"),
+		That(`printf '%.1f' 3.1415`).Prints("3.1"),
+		That(`printf '%.1f' (float64 3.1415)`).Prints("3.1"),
+		That(`printf '%5.3s' 3.1415`).Prints("  3.1"),
+		That(`printf '%5.3s' (float64 3.1415)`).Prints("  3.1"),
+		That(`printf '%3d' (float64 5)`).Prints("  5"),
+		That(`printf '%3d' 5`).Prints("  5"),
+		That(`printf '%08b' (float64 5)`).Prints("00000101"),
+		That(`printf '%08b' 5`).Prints("00000101"),
+		That(`printf '%t' $true`).Prints("true"),
+
+		// Verify that corner cases produce the expected error output.
+		That(`printf '%f' 1.3x`).Prints("%!f(cannot parse as number: 1.3x)"),
+		That(`printf '%d' 3.5`).Prints("%!d(cannot parse as integer: 3.5)"),
+		That(`printf '%d' (float64 5.1)`).Prints("%!d(must be an integer)"),
+	)
+}


### PR DESCRIPTION
There is more work to be done but this should address 99.9999% of the
expected uses of a `printf` builtin. Some corner cases which don't have
a POSIX analog, such as support for Elvish bool types will be implemented
in future changes.

Resolves #1132