### PR TITLE
Trivial documentation consistency change

### DIFF
--- a/pkg/eval/builtin_fn_pred.go
+++ b/pkg/eval/builtin_fn_pred.go
@@ -62,7 +62,9 @@ func init() {
 // ▶ $true
 // ```
 //
-// **NOTE**: `and` and `or` are implemented as special commands.
+// **Note**: `not` is a regular command, and thus can be overriden by a
+// function definition (though you shouldn't do so), while `and` and `or` are
+// implemented as [special commands](language.html#special-commands).
 //
 // @cf bool
 

--- a/pkg/eval/builtin_fn_styled.go
+++ b/pkg/eval/builtin_fn_styled.go
@@ -104,10 +104,10 @@ func styledSegment(options RawOptions, input interface{}) (*ui.Segment, error) {
 //
 //     -   A 24-bit RGB color written as `#RRGGBB` such as `'#778899'`.
 //
-//		   **NOTE:** You need to quote such values since an unquoted `#` char
+//		   **Note**: You need to quote such values since an unquoted `#` char
 //		   introduces a comment. So use `'bg-#778899'` not `bg-#778899`. If
 //		   you omit the quotes the text after the `#` char is ignored which
-//		   will likely result in an error or unexpected behavior.
+//		   will result in an error or unexpected behavior.
 //
 // -   A color name prefixed by `bg-` to set the background color.
 //


### PR DESCRIPTION
I noticed that most places in the documentation that emit a "note"
about Elvish behavior use `**Note**:`. There were two places that use
all uppercase. Make those consistent with the other uses. Also clarify
the note associated with the `not` builtin.