### PR TITLE
Introduce the `path:` module

### DIFF
--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -37,7 +37,7 @@ or compiled, even if it is not executed:
 
 -   The undocumented `esleep` command is now deprecated. Use `sleep` instead.
 
--   The `eval-symlinks` command is deprecated. Use `path:real` instead.
+-   The `eval-symlinks` command is deprecated. Use `path:eval-symlinks` instead.
 
 -   The `path-abs` command is deprecated. Use `path:abs` instead.
 

--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -37,6 +37,20 @@ or compiled, even if it is not executed:
 
 -   The undocumented `esleep` command is now deprecated. Use `sleep` instead.
 
+-   The `eval-symlinks` command is deprecated. Use `path:real` instead.
+
+-   The `path-abs` command is deprecated. Use `path:abs` instead.
+
+-   The `path-base` command is deprecated. Use `path:base` instead.
+
+-   The `path-clean` command is deprecated. Use `path:clean` instead.
+
+-   The `path-dir` command is deprecated. Use `path:dir` instead.
+
+-   The `path-ext` command is deprecated. Use `path:ext` instead.
+
+-   The `-is-dir` command is deprecated. Use `path:is-dir` instead.
+
 The following deprecated features trigger a warning when the code is evaluated:
 
 -   Using `:` in slice indices is deprecated. Use `..` instead.
@@ -57,6 +71,9 @@ New features in the standard library:
     restricted namespace.
 
 -   A new `sleep` command.
+
+-   A new `path:` module has been introduced for manipulating and testing
+    filesystem paths.
 
 New features in the interactive editor:
 

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -26,10 +26,9 @@ var ErrStoreNotConnected = errors.New("store not connected")
 //
 // See [godoc of path/filepath](https://godoc.org/path/filepath). Go errors are
 // turned into exceptions.
-
-// TODO(xiaq): Document eval-symlinks.
-
-// TODO(xiaq): Document -is-dir.
+//
+// These functions are deprecated. Use the equivalent functions in the
+// [path:](path.html) module.
 
 func init() {
 	addBuiltinFns(map[string]interface{}{

--- a/pkg/eval/mods/path/path.go
+++ b/pkg/eval/mods/path/path.go
@@ -8,6 +8,21 @@ import (
 	"github.com/elves/elvish/pkg/eval"
 )
 
+// Ns is the namespace for the re: module.
+var Ns = eval.NsBuilder{}.AddGoFns("path:", fns).Ns()
+
+var fns = map[string]interface{}{
+	"abs":           filepath.Abs,
+	"base":          filepath.Base,
+	"clean":         filepath.Clean,
+	"dir":           filepath.Dir,
+	"ext":           filepath.Ext,
+	"eval-symlinks": filepath.EvalSymlinks,
+	"is-abs":        filepath.IsAbs,
+	"is-dir":        isDir,
+	"is-regular":    isRegular,
+}
+
 //elvdoc:fn abs
 //
 // ```elvish
@@ -99,12 +114,12 @@ import (
 // ▶ true
 // ```
 
-//elvdoc:fn real
+//elvdoc:fn eval-symlinks
 //
 // ```elvish-transcript
 // ~> mkdir bin
 // ~> ln -s bin sbin
-// ~> path:real ./sbin/a_command
+// ~> path:eval-symlinks ./sbin/a_command
 // ▶ bin/a_command
 // ```
 //
@@ -155,15 +170,3 @@ func isRegular(path string) bool {
 	fi, err := os.Stat(path)
 	return err == nil && fi.Mode().IsRegular()
 }
-
-var Ns = eval.NsBuilder{}.AddGoFns("path:", map[string]interface{}{
-	"abs":        filepath.Abs,
-	"base":       filepath.Base,
-	"clean":      filepath.Clean,
-	"dir":        filepath.Dir,
-	"ext":        filepath.Ext,
-	"is-abs":     filepath.IsAbs,
-	"is-dir":     isDir,
-	"is-regular": isRegular,
-	"real":       filepath.EvalSymlinks,
-}).Ns()

--- a/pkg/eval/mods/path/path.go
+++ b/pkg/eval/mods/path/path.go
@@ -135,13 +135,35 @@ func isDir(path string) bool {
 	return err == nil && fi.Mode().IsDir()
 }
 
+//elvdoc:fn is-regular
+//
+// ```elvish
+// is-regular $path
+// ```
+//
+// Outputs `$true` if the path resolves to a directory.
+//
+// ```elvish-transcript
+// ~> touch not-a-dir
+// ~> path:is-regular not-a-dir
+// ▶ true
+// ~> path:is-dir /tmp
+// ▶ false
+// ```
+
+func isRegular(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
+}
+
 var Ns = eval.NsBuilder{}.AddGoFns("path:", map[string]interface{}{
-	"abs":    filepath.Abs,
-	"base":   filepath.Base,
-	"clean":  filepath.Clean,
-	"dir":    filepath.Dir,
-	"ext":    filepath.Ext,
-	"is-abs": filepath.IsAbs,
-	"is-dir": isDir,
-	"real":   filepath.EvalSymlinks,
+	"abs":        filepath.Abs,
+	"base":       filepath.Base,
+	"clean":      filepath.Clean,
+	"dir":        filepath.Dir,
+	"ext":        filepath.Ext,
+	"is-abs":     filepath.IsAbs,
+	"is-dir":     isDir,
+	"is-regular": isRegular,
+	"real":       filepath.EvalSymlinks,
 }).Ns()

--- a/pkg/eval/mods/path/path.go
+++ b/pkg/eval/mods/path/path.go
@@ -1,0 +1,147 @@
+// Package path provides functions for manipulating filesystem path names.
+package path
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/elves/elvish/pkg/eval"
+)
+
+//elvdoc:fn abs
+//
+// ```elvish
+// path:abs $path
+// ```
+//
+// Outputs `$path` converted to an absolute path.
+//
+// ```elvish-transcript
+// ~> cd ~
+// ~> path:abs bin
+// ▶ /home/user/bin
+// ```
+
+//elvdoc:fn base
+//
+// ```elvish
+// path:base $path
+// ```
+//
+// Outputs the last element of `$path`. This is analogous to the POSIX `basename` command. See the
+// [Go documentation](https://pkg.go.dev/path/filepath#Base) for more details.
+//
+// ```elvish-transcript
+// ~> path:base ~/bin
+// ▶ bin
+// ```
+
+//elvdoc:fn clean
+//
+// ```elvish
+// path:clean $path
+// ```
+//
+// Outputs the shortest version of `$path` equivalent to `$path` by purely lexical processing. This
+// is most useful for eliminating unnecessary relative path elements such as `.` and `..` without
+// asking the OS to evaluate the path name. See the [Go
+// documentation](https://pkg.go.dev/path/filepath#Clean) for more details.
+//
+// ```elvish-transcript
+// ~> path:clean ./../bin
+// ▶ ../bin
+// ```
+
+//elvdoc:fn dir
+//
+// ```elvish
+// path:dir $path
+// ```
+//
+// Outputs all but the last element of `$path`, typically the path's enclosing directory. See the
+// [Go documentation](https://pkg.go.dev/path/filepath#Dir) for more details. This is analogous to
+// the POSIX `dirname` command.
+//
+// ```elvish-transcript
+// ~> path:dir /a/b/c/something
+// ▶ /a/b/c
+// ```
+
+//elvdoc:fn ext
+//
+// ```elvish
+// ext $path
+// ```
+//
+// Outputs the file name extension used by `$path` (including the separating period). If there is no
+// extension the empty string is output. See the [Go
+// documentation](https://pkg.go.dev/path/filepath#Ext) for more details.
+//
+// ```elvish-transcript
+// ~> path:ext hello.elv
+// ▶ .elv
+// ```
+
+//elvdoc:fn is-abs
+//
+// ```elvish
+// is-abs $path
+// ```
+//
+// Outputs `$true` if the path is an abolute path. Note that platforms like Windows have different
+// rules than UNIX like platforms for what constitutes an absolute path. See the [Go
+// documentation](https://pkg.go.dev/path/filepath#IsAbs) for more details.
+//
+// ```elvish-transcript
+// ~> path:is-abs hello.elv
+// ▶ false
+// ~> path:is-abs /hello.elv
+// ▶ true
+// ```
+
+//elvdoc:fn real
+//
+// ```elvish-transcript
+// ~> mkdir bin
+// ~> ln -s bin sbin
+// ~> path:real ./sbin/a_command
+// ▶ bin/a_command
+// ```
+//
+// Outputs `$path` after resolving any symbolic links. If `$path` is relative the result will be
+// relative to the current directory, unless one of the components is an absolute symbolic link.
+// This function calls `path:clean` on the result before outputing it. This is analogous to the
+// external `realpath` or `readlink` command found on many systems. See the [Go
+// documentation](https://pkg.go.dev/path/filepath#EvalSymlinks) for more details.
+
+//elvdoc:fn is-dir
+//
+// ```elvish
+// is-dir $path
+// ```
+//
+// Outputs `$true` if the path resolves to a directory.
+//
+// ```elvish-transcript
+// ~> touch not-a-dir
+// ~> path:is-dir not-a-dir
+// ▶ false
+// ~> path:is-dir /tmp
+// ▶ true
+// ```
+
+func isDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsDir()
+}
+
+var Ns = eval.NsBuilder{}.AddGoFns("path:", map[string]interface{}{
+	"abs":    filepath.Abs,
+	"base":   filepath.Base,
+	"clean":  filepath.Clean,
+	"dir":    filepath.Dir,
+	"ext":    filepath.Ext,
+	"is-abs": filepath.IsAbs,
+	"is-dir": isDir,
+	"real":   filepath.EvalSymlinks,
+}).Ns()

--- a/pkg/eval/mods/path/path_test.go
+++ b/pkg/eval/mods/path/path_test.go
@@ -32,7 +32,7 @@ func TestPath(t *testing.T) {
 	}
 
 	setup := func(ev *eval.Evaler) {
-		ev.Global = eval.NsBuilder{}.AddNs("path", Ns).Ns()
+		ev.AddGlobal(eval.NsBuilder{}.AddNs("path", Ns).Ns())
 	}
 	TestWithSetup(t, setup,
 		// This block of tests is not meant to be comprehensive. Their primary purpose is to simply
@@ -47,12 +47,12 @@ func TestPath(t *testing.T) {
 		That(`path:ext a/b/s`).Puts(""),
 		That(`path:is-abs a/b/s`).Puts(false),
 		That(`path:is-abs `+absPath).Puts(true),
-		That(`path:real d1/d2`).Puts(filepath.Join("d1", "d2")),
-		That(`path:real d1/d2/f`).Puts(filepath.Join("d1", "d2", "f")),
-		That(`path:real s1`).Puts(filepath.Join("d1", "d2")),
-		That(`path:real d1/f`).Puts(filepath.Join("d1", "d2", "f")),
-		That(`path:real s1/g`).Puts(filepath.Join("d1", "d2", "f")),
-		That(`path:real s1/empty`).Puts(filepath.Join("d1", "d2", "empty")),
+		That(`path:eval-symlinks d1/d2`).Puts(filepath.Join("d1", "d2")),
+		That(`path:eval-symlinks d1/d2/f`).Puts(filepath.Join("d1", "d2", "f")),
+		That(`path:eval-symlinks s1`).Puts(filepath.Join("d1", "d2")),
+		That(`path:eval-symlinks d1/f`).Puts(filepath.Join("d1", "d2", "f")),
+		That(`path:eval-symlinks s1/g`).Puts(filepath.Join("d1", "d2", "f")),
+		That(`path:eval-symlinks s1/empty`).Puts(filepath.Join("d1", "d2", "empty")),
 
 		// Elvish `path:` module functions that are not trivial wrappers around a Go stdlib function
 		// should have comprehensive tests below this comment.

--- a/pkg/eval/mods/path/path_test.go
+++ b/pkg/eval/mods/path/path_test.go
@@ -1,0 +1,47 @@
+package path
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elves/elvish/pkg/eval"
+	. "github.com/elves/elvish/pkg/eval/evaltest"
+	"github.com/elves/elvish/pkg/testutil"
+)
+
+func TestPath(t *testing.T) {
+	tmpdir, cleanup := testutil.InTestDir()
+	defer cleanup()
+	testutil.Must(os.MkdirAll("d1/d2", 0700))
+	testutil.Must(os.Symlink("d1", "s1"))
+	absPath, err := filepath.Abs("a/b/c.png")
+	if err != nil {
+		panic("unable to convert a/b/c.png to an absolute path")
+	}
+
+	setup := func(ev *eval.Evaler) {
+		ev.Global = eval.NsBuilder{}.AddNs("path", Ns).Ns()
+	}
+	TestWithSetup(t, setup,
+		// This block of tests is not meant to be comprehensive. Their primary purpose is to simply
+		// ensure the Elvish command is correctly mapped to the relevant Go function. We assume the
+		// Go function behaves correctly.
+		That(`path:abs a/b/c.png`).Puts(absPath),
+		That(`path:base a/b/d.png`).Puts("d.png"),
+		That(`path:clean ././x`).Puts("x"),
+		That(`path:clean a/b/.././c`).Puts(filepath.Join("a", "c")),
+		That(`path:dir a/b/d.png`).Puts(filepath.Join("a", "b")),
+		That(`path:ext a/b/e.png`).Puts(".png"),
+		That(`path:ext a/b/s`).Puts(""),
+		That(`path:is-abs a/b/s`).Puts(false),
+		That(`path:is-abs `+absPath).Puts(true),
+		That(`path:real s1/d2`).Puts(filepath.Join("d1", "d2")),
+
+		// Elvish `path:` module functions that are not trivial wrappers around a Go stdlib function
+		// should have comprehensive tests below this comment.
+		That(`path:is-dir a/b/s`).Puts(false),
+		That(`path:is-dir `+tmpdir).Puts(true),
+		That(`path:is-dir s1`).Puts(true),
+	)
+}

--- a/pkg/eval/var_ref.go
+++ b/pkg/eval/var_ref.go
@@ -205,6 +205,20 @@ func (cp *compiler) checkDeprecatedBuiltin(name string, r diag.Ranger) {
 		msg = `the "has-suffix" command is deprecated; use "str:has-suffix" instead`
 	case "esleep~":
 		msg = `the "esleep" command is deprecated; use "sleep" instead`
+	case "eval-symlinks~":
+		msg = `the "eval-symlinks" command is deprecated; use "path:realpath" instead`
+	case "path-abs~":
+		msg = `the "path-abs" command is deprecated; use "path:abs" instead`
+	case "path-base~":
+		msg = `the "path-base" command is deprecated; use "path:base" instead`
+	case "path-clean~":
+		msg = `the "path-clean" command is deprecated; use "path:clean" instead`
+	case "path-dir~":
+		msg = `the "path-dir" command is deprecated; use "path:dir" instead`
+	case "path-ext~":
+		msg = `the "path-ext" command is deprecated; use "path:ext" instead`
+	case "-is-dir~":
+		msg = `the "-is-dir" command is deprecated; use "path:is-dir" instead`
 	default:
 		return
 	}

--- a/pkg/eval/var_ref.go
+++ b/pkg/eval/var_ref.go
@@ -206,7 +206,7 @@ func (cp *compiler) checkDeprecatedBuiltin(name string, r diag.Ranger) {
 	case "esleep~":
 		msg = `the "esleep" command is deprecated; use "sleep" instead`
 	case "eval-symlinks~":
-		msg = `the "eval-symlinks" command is deprecated; use "path:realpath" instead`
+		msg = `the "eval-symlinks" command is deprecated; use "path:eval-symlinks" instead`
 	case "path-abs~":
 		msg = `the "path-abs" command is deprecated; use "path:abs" instead`
 	case "path-base~":

--- a/pkg/shell/runtime.go
+++ b/pkg/shell/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elves/elvish/pkg/eval"
 	daemonmod "github.com/elves/elvish/pkg/eval/mods/daemon"
 	mathmod "github.com/elves/elvish/pkg/eval/mods/math"
+	pathmod "github.com/elves/elvish/pkg/eval/mods/path"
 	"github.com/elves/elvish/pkg/eval/mods/platform"
 	"github.com/elves/elvish/pkg/eval/mods/re"
 	"github.com/elves/elvish/pkg/eval/mods/store"
@@ -50,6 +51,7 @@ func InitRuntime(stderr io.Writer, p Paths, spawn bool) *eval.Evaler {
 	ev := eval.NewEvaler()
 	ev.SetLibDir(p.LibDir)
 	ev.AddModule("math", mathmod.Ns)
+	ev.AddModule("path", pathmod.Ns)
 	ev.AddModule("platform", platform.Ns)
 	ev.AddModule("re", re.Ns)
 	ev.AddModule("str", str.Ns)

--- a/pkg/testutil/testdir_test.go
+++ b/pkg/testutil/testdir_test.go
@@ -101,6 +101,49 @@ func TestApplyDir_CreatesDirectories(t *testing.T) {
 	testFileContent(t, "d/dd/dd1", "dd1 content")
 }
 
+func TestApplyDir_Symlinks(t *testing.T) {
+	testdir, cleanup := InTestDir()
+	defer cleanup()
+
+	ApplyDir(Dir{
+		"d1": Dir{
+			"f":  "d1/f content",
+			"d2": Symlink{testdir},
+		},
+		"sf1":   Symlink{filepath.Join("d1", "f")},
+		"sd1":   Symlink{"d1"},
+		"sd2":   Symlink{string(filepath.Separator)},
+		"empty": "",
+	})
+
+	testFileContent(t, "d1/f", "d1/f content")
+	symlinkTargets := [][2]string{
+		{"d1/d2", testdir},
+		{"sd1", "d1"},
+		{"sd2", string(filepath.Separator)},
+		{"sf1", filepath.Join("d1", "f")},
+	}
+	for _, fromTo := range symlinkTargets {
+		symlink, expected_target := fromTo[0], fromTo[1]
+		fi, err := os.Lstat(symlink)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("File %v isn't a symlink: err %v\n"+
+				"os.ModeSymlink %032b\n"+
+				"fi.Mode        %032b",
+				symlink, err, os.ModeSymlink, fi.Mode())
+		}
+		actual_target, err := filepath.EvalSymlinks(symlink)
+		if err != nil || expected_target != actual_target {
+			t.Errorf("Symlink %v is incorrect:\n"+
+				"Err: %v\n"+
+				"Exp: %v\n"+
+				"Act: %v",
+				symlink, err, expected_target, actual_target)
+
+		}
+	}
+}
+
 func getWd() string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/website/ref/index.toml
+++ b/website/ref/index.toml
@@ -21,6 +21,10 @@ name = "math"
 title = "math: Math Utilities"
 
 [[articles]]
+name = "path"
+title = "path: Filesystem Path Utilities"
+
+[[articles]]
 name = "platform"
 title = "platform: Information About the Platform"
 

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -2052,18 +2052,20 @@ use a/b/c foo # imports the "a/b/c" module as "foo:"
 ### Pre-Defined Modules
 
 Elvish's standard library provides the following pre-defined modules that can be
-imported by `use`:
+imported by the `use` command:
 
--   The following modules are always available: [daemon](daemon.html),
-    [epm](epm.html), [math](math.html), [platform](platform.html),
-    [str](str.html), [re](re.html), [readline-binding](readline-binding.html),
-    [store](store.html).
-
--   The [unix](unix.html) module is available on UNIX-like platforms (see
-    [`$platform:is-unix`](platform.html#platformis-unix)).
-
-The [edit](edit.html) module is available in interactive module. As a special
-case, it does not need importing, but this may change in the future.
+-   [edit](edit.html) is only available in interactive mode. As a special case
+    it does not need importing via `use`, but this may change in the future.
+-   [epm](epm.html)
+-   [math](math.html)
+-   [path](path.html)
+-   [platform](platform.html)
+-   [re](re.html)
+-   [readline-binding](readline-binding.html)
+-   [store](store.html)
+-   [str](str.html)
+-   [unix](unix.html) is only available on UNIX-like platforms (see
+    [`$platform:is-unix`](platform.html#platformis-unix))
 
 ### User-Defined Modules
 

--- a/website/ref/path.md
+++ b/website/ref/path.md
@@ -1,0 +1,11 @@
+<!-- toc -->
+
+# Introduction
+
+The `path:` module provides functions for manipulating and testing filesystem
+paths.
+
+Function usages are given in the same format as in the reference doc for the
+[builtin module](builtin.html).
+
+@elvdoc -ns path: -dir ../pkg/eval/mods/path


### PR DESCRIPTION
This is based on https://github.com/elves/elvish/pull/1084 by @kolbycrouch
submitted five months ago. It addresses all of the feedback on that
change and includes other documentation and unit test improvements. It
also includes a couple of extensions to the original P.R., such as a
`path:is-abs` command.

I decided to resurrect that change because I want better support for
filesystem path manipulation so that users can replace non-portable
external commands such as `realpath` and `find` with Elvish builtins. This
is a baby step towards that goal.

Related #849