### PR TITLE
Fix handling of unexpected errors

### DIFF
--- a/pkg/eval/compile_effect.go
+++ b/pkg/eval/compile_effect.go
@@ -139,7 +139,12 @@ func (op *pipelineOp) exec(fm *Frame) error {
 			err := thisOp.exec(newFm)
 			newFm.Close()
 			if err != nil {
-				*thisError = err.(*Exception)
+				switch err := err.(type) {
+				case *Exception:
+					*thisError = err
+				default:
+					*thisError = &Exception{Reason: err, StackTrace: nil}
+				}
 			}
 			wg.Done()
 			if hasChanInput {


### PR DESCRIPTION
Doing something like the following is likely to result in too many open
files (assuming `ulimit -n` == 256) resulting in a panic:

    > fn fact [n]{ if (== $n 0) { put 1 } else { put (* $n (fact (- $n 1))) } }
    > fact 60
    panic: interface conversion: error is *os.SyscallError, not
    *eval.Exception

    goroutine 24161 [running]:
    github.com/elves/elvish/pkg/eval.(*pipelineOp).exec.func1(0x152a5a0,
    0xc000dca210, 0xc000a44e70, 0xc00057b540, 0xc001030590, 0x203000)
        github.com/elves/elvish/pkg/eval/compile_effect.go:153 +0x152
    created by github.com/elves/elvish/pkg/eval.(*pipelineOp).exec
        github.com/elves/elvish/pkg/eval/compile_effect.go:149 +0x225
    Exception: elvish exited with 2

Fixes #1208