### PR TITLE
Improve error message when changing a read-only var

### DIFF
--- a/pkg/edit/navigation.go
+++ b/pkg/edit/navigation.go
@@ -108,7 +108,7 @@ func initNavigation(ed *Editor, ev *eval.Evaler, nb eval.NsBuilder) {
 	binding := newMapBinding(ed, ev, bindingVar)
 	widthRatioVar := newListVar(vals.MakeList(1.0, 3.0, 4.0))
 
-	selectedFileVar := vars.FromGet(func() interface{} {
+	selectedFileVar := vars.FromGet("edit:selected-file", func() interface{} {
 		name := navigation.SelectedName(ed.app)
 		if name == "" {
 			return nil

--- a/pkg/edit/ns_helper_test.go
+++ b/pkg/edit/ns_helper_test.go
@@ -9,7 +9,7 @@ import (
 	"src.elv.sh/pkg/eval/vars"
 )
 
-var testVar = vars.NewReadOnly("")
+var testVar = vars.NewReadOnly("testVar", "")
 
 var eachVariableInTopTests = []struct {
 	builtin   *eval.Ns
@@ -31,14 +31,14 @@ var eachVariableInTopTests = []struct {
 	},
 	{
 		builtin: eval.NsBuilder{
-			"mod:": vars.NewReadOnly(eval.NsBuilder{"a": testVar, "b": testVar}.Ns()),
+			"mod:": vars.NewReadOnly("mod:", eval.NsBuilder{"a": testVar, "b": testVar}.Ns()),
 		}.Ns(),
 		ns:        "mod:",
 		wantNames: []string{"a", "b"},
 	},
 	{
 		global: eval.NsBuilder{
-			"mod:": vars.NewReadOnly(eval.NsBuilder{"a": testVar, "b": testVar}.Ns()),
+			"mod:": vars.NewReadOnly("mod:", eval.NsBuilder{"a": testVar, "b": testVar}.Ns()),
 		}.Ns(),
 		ns:        "mod:",
 		wantNames: []string{"a", "b"},

--- a/pkg/edit/testutils_test.go
+++ b/pkg/edit/testutils_test.go
@@ -37,7 +37,7 @@ func rc(codes ...string) func(*fixture) {
 func assign(name string, val interface{}) func(*fixture) {
 	return func(f *fixture) {
 		f.Evaler.AddGlobal(eval.CombineNs(f.Evaler.Global(),
-			eval.NsBuilder{"temp": vars.NewReadOnly(val)}.Ns()))
+			eval.NsBuilder{"temp": vars.NewReadOnly("temp", val)}.Ns()))
 		evals(f.Evaler, name+` = $temp`)
 	}
 }

--- a/pkg/eval/builtin_ns.go
+++ b/pkg/eval/builtin_ns.go
@@ -80,11 +80,11 @@ import (
 
 var builtinNs = NsBuilder{
 	"_":     vars.NewBlackhole(),
-	"pid":   vars.NewReadOnly(strconv.Itoa(syscall.Getpid())),
-	"ok":    vars.NewReadOnly(OK),
-	"nil":   vars.NewReadOnly(nil),
-	"true":  vars.NewReadOnly(true),
-	"false": vars.NewReadOnly(false),
+	"pid":   vars.NewReadOnly("builtin:pid", strconv.Itoa(syscall.Getpid())),
+	"ok":    vars.NewReadOnly("builtin:ok", OK),
+	"nil":   vars.NewReadOnly("builtin:nil", nil),
+	"true":  vars.NewReadOnly("builtin:true", true),
+	"false": vars.NewReadOnly("builtin:false", false),
 	"paths": vars.NewEnvListVar("PATH"),
 }
 

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -221,7 +221,7 @@ func TestUse_SetsVariableCorrectlyIfModuleCallsAddGlobal(t *testing.T) {
 	ev := NewEvaler()
 	ev.SetLibDir(libdir)
 	addVar := func() {
-		ev.AddGlobal(NsBuilder{"b": vars.NewReadOnly("foo")}.Ns())
+		ev.AddGlobal(NsBuilder{"b": vars.NewReadOnly("b", "foo")}.Ns())
 	}
 	ev.AddBuiltin(NsBuilder{}.AddGoFn("", "add-var", addVar).Ns())
 

--- a/pkg/eval/compile_effect_test.go
+++ b/pkg/eval/compile_effect_test.go
@@ -135,8 +135,8 @@ func TestCommand_Assignment(t *testing.T) {
 		// Assignment errors when the RHS errors.
 		That("x = [][1]").Throws(ErrorWithType(errs.OutOfRange{}), "[][1]"),
 		// Assignment errors itself.
-		That("true = 1").Throws(vars.ErrSetReadOnlyVar, "true = 1"),
-		That("@true = 1").Throws(vars.ErrSetReadOnlyVar, "@true = 1"),
+		That("true = 1").Throws(&vars.ErrSetReadOnlyVar{"builtin:true"}, "true = 1"),
+		That("@true = 1").Throws(&vars.ErrSetReadOnlyVar{"builtin:true"}, "@true = 1"),
 		// Arity mismatch.
 		That("x = 1 2").Throws(
 			errs.ArityMismatch{

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -176,10 +176,10 @@ func NewEvaler() *Evaler {
 			&ev.valuePrefix, &ev.mu)).
 		Add("notify-bg-job-success", vars.FromPtrWithMutex(
 			&ev.notifyBgJobSuccess, &ev.mu)).
-		Add("num-bg-jobs", vars.FromGet(func() interface{} {
+			Add("num-bg-jobs", vars.FromGet("builtin:num-bg-jobs", func() interface{} {
 			return strconv.Itoa(ev.getNumBgJobs())
 		})).
-		Add("args", vars.FromGet(func() interface{} {
+		Add("args", vars.FromGet("builtin:args", func() interface{} {
 			return ev.getArgs()
 		})).
 		Ns()

--- a/pkg/eval/eval_test.go
+++ b/pkg/eval/eval_test.go
@@ -69,7 +69,7 @@ func TestMultipleEval(t *testing.T) {
 
 func TestEval_AlternativeGlobal(t *testing.T) {
 	ev := NewEvaler()
-	g := NsBuilder{"a": vars.NewReadOnly("")}.Ns()
+	g := NsBuilder{"a": vars.NewReadOnly("a", "")}.Ns()
 	err := ev.Eval(parse.Source{Code: "nop $a"}, EvalCfg{Global: g})
 	if err != nil {
 		t.Errorf("got error %v, want nil", err)

--- a/pkg/eval/mods/daemon/daemon.go
+++ b/pkg/eval/mods/daemon/daemon.go
@@ -38,8 +38,8 @@ func Ns(d daemon.Client, spawnCfg *daemon.SpawnConfig) *eval.Ns {
 	}
 
 	return eval.NsBuilder{
-		"pid":  vars.FromGet(getPidVar),
-		"sock": vars.NewReadOnly(string(d.SockPath())),
+		"pid":  vars.FromGet("daemon:pid", getPidVar),
+		"sock": vars.NewReadOnly("daemon:sock", string(d.SockPath())),
 	}.AddGoFns("daemon:", map[string]interface{}{
 		"pid":   getPid,
 		"spawn": spawn,

--- a/pkg/eval/mods/math/math.go
+++ b/pkg/eval/mods/math/math.go
@@ -485,8 +485,8 @@ import (
 
 // Ns is the namespace for the math: module.
 var Ns = eval.NsBuilder{
-	"e":  vars.NewReadOnly(math.E),
-	"pi": vars.NewReadOnly(math.Pi),
+	"e":  vars.NewReadOnly("math:e", math.E),
+	"pi": vars.NewReadOnly("math:pi", math.Pi),
 }.AddGoFns("math:", fns).Ns()
 
 var fns = map[string]interface{}{

--- a/pkg/eval/mods/platform/platform.go
+++ b/pkg/eval/mods/platform/platform.go
@@ -73,10 +73,10 @@ func hostname(opts hostnameOpt) (string, error) {
 }
 
 var Ns = eval.NsBuilder{
-	"arch":       vars.NewReadOnly(runtime.GOARCH),
-	"os":         vars.NewReadOnly(runtime.GOOS),
-	"is-unix":    vars.NewReadOnly(isUnix),
-	"is-windows": vars.NewReadOnly(isWindows),
+	"arch":       vars.NewReadOnly("platform:arch", runtime.GOARCH),
+	"os":         vars.NewReadOnly("platform:os", runtime.GOOS),
+	"is-unix":    vars.NewReadOnly("platform:is-unix", isUnix),
+	"is-windows": vars.NewReadOnly("platform:is-windows", isWindows),
 }.AddGoFns("platform:", map[string]interface{}{
 	"hostname": hostname,
 }).Ns()

--- a/pkg/eval/ns.go
+++ b/pkg/eval/ns.go
@@ -154,12 +154,12 @@ func (nb NsBuilder) Add(name string, v vars.Var) NsBuilder {
 
 // AddFn adds a function. The resulting variable will be read-only.
 func (nb NsBuilder) AddFn(name string, v Callable) NsBuilder {
-	return nb.Add(name+FnSuffix, vars.NewReadOnly(v))
+	return nb.Add(name+FnSuffix, vars.NewReadOnly(name+FnSuffix, v))
 }
 
 // AddNs adds a sub-namespace. The resulting variable will be read-only.
 func (nb NsBuilder) AddNs(name string, v *Ns) NsBuilder {
-	return nb.Add(name+NsSuffix, vars.NewReadOnly(v))
+	return nb.Add(name+NsSuffix, vars.NewReadOnly(name+NsSuffix, v))
 }
 
 // AddGoFn adds a Go function. The resulting variable will be read-only.

--- a/pkg/eval/ns_test.go
+++ b/pkg/eval/ns_test.go
@@ -26,6 +26,6 @@ func TestNs(t *testing.T) {
 
 func TestBuiltinFunctionsReadOnly(t *testing.T) {
 	Test(t,
-		That("return~ = { }").Throws(vars.ErrSetReadOnlyVar, "return~ = { }"),
+		That("return~ = { }").Throws(&vars.ErrSetReadOnlyVar{"return~"}, "return~ = { }"),
 	)
 }

--- a/pkg/eval/purely_eval_test.go
+++ b/pkg/eval/purely_eval_test.go
@@ -42,10 +42,10 @@ func TestPurelyEvalCompound(t *testing.T) {
 
 	ev := NewEvaler()
 	g := NsBuilder{
-		"x": vars.NewReadOnly("bar"),
-		"y": vars.NewReadOnly(vals.MakeList()),
+		"x": vars.NewReadOnly("x", "bar"),
+		"y": vars.NewReadOnly("y", vals.MakeList()),
 	}.
-		AddNs("ns", NsBuilder{"x": vars.NewReadOnly("foo")}.Ns()).
+		AddNs("ns", NsBuilder{"x": vars.NewReadOnly("x", "foo")}.Ns()).
 		Ns()
 	ev.AddGlobal(g)
 

--- a/pkg/eval/var_ref.go
+++ b/pkg/eval/var_ref.go
@@ -151,7 +151,7 @@ func derefBase(fm *Frame, ref *varRef) (vars.Var, []string) {
 	case envScope:
 		return vars.FromEnv(ref.subNames[0]), nil
 	case externalScope:
-		return vars.NewReadOnly(NewExternalCmd(ref.subNames[0])), nil
+		return vars.NewReadOnly("e:"+ref.subNames[0], NewExternalCmd(ref.subNames[0])), nil
 	default:
 		return nil, nil
 	}

--- a/pkg/eval/vars/callback.go
+++ b/pkg/eval/vars/callback.go
@@ -5,6 +5,11 @@ type callback struct {
 	get func() interface{}
 }
 
+type roCallback struct {
+	name string
+	get  func() interface{}
+}
+
 // FromSetGet makes a variable from a set callback and a get callback.
 func FromSetGet(set func(interface{}) error, get func() interface{}) Var {
 	return &callback{set, get}
@@ -18,17 +23,15 @@ func (cv *callback) Get() interface{} {
 	return cv.get()
 }
 
-type roCallback func() interface{}
-
 // FromGet makes a variable from a get callback. The variable is read-only.
-func FromGet(get func() interface{}) Var {
-	return roCallback(get)
+func FromGet(name string, get func() interface{}) Var {
+	return roCallback{name, get}
 }
 
-func (cv roCallback) Set(interface{}) error {
-	return ErrSetReadOnlyVar
+func (cv roCallback) Set(val interface{}) error {
+	return &ErrSetReadOnlyVar{cv.name}
 }
 
 func (cv roCallback) Get() interface{} {
-	return cv()
+	return cv.get()
 }

--- a/pkg/eval/vars/callback_test.go
+++ b/pkg/eval/vars/callback_test.go
@@ -33,7 +33,7 @@ func TestFromGet(t *testing.T) {
 		getCalled = true
 		return "cb"
 	}
-	v := FromGet(get)
+	v := FromGet("v", get)
 	if v.Get() != "cb" {
 		t.Errorf("roCbVariable doesn't return value from callback")
 	}

--- a/pkg/eval/vars/read_only.go
+++ b/pkg/eval/vars/read_only.go
@@ -1,24 +1,31 @@
 package vars
 
 import (
-	"errors"
+	"fmt"
 )
 
 // ErrSetReadOnlyVar is returned by the Set method of a read-only variable.
-var ErrSetReadOnlyVar = errors.New("read-only variable; cannot be set")
+type ErrSetReadOnlyVar struct {
+	VarName string
+}
+
+func (e *ErrSetReadOnlyVar) Error() string {
+	return fmt.Sprintf("read-only variable %s cannot be set", e.VarName)
+}
 
 type readOnly struct {
+	name  string
 	value interface{}
 }
 
 // NewReadOnly creates a variable that is read-only and always returns an error
-// on Set.
-func NewReadOnly(v interface{}) Var {
-	return readOnly{v}
+// when modified.
+func NewReadOnly(name string, value interface{}) Var {
+	return readOnly{name, value}
 }
 
 func (rv readOnly) Set(val interface{}) error {
-	return ErrSetReadOnlyVar
+	return &ErrSetReadOnlyVar{rv.name}
 }
 
 func (rv readOnly) Get() interface{} {

--- a/pkg/eval/vars/read_only_test.go
+++ b/pkg/eval/vars/read_only_test.go
@@ -1,13 +1,23 @@
 package vars
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestNewReadOnly(t *testing.T) {
-	v := NewReadOnly("haha")
+	v := NewReadOnly("v", "haha")
 	if v.Get() != "haha" {
 		t.Errorf("Get doesn't return initial value")
 	}
-	if v.Set("lala") != ErrSetReadOnlyVar {
-		t.Errorf("Set doesn't error")
+
+	err := v.Set("lala")
+	switch err := err.(type) {
+	case *ErrSetReadOnlyVar:
+		if err.VarName != "v" {
+			t.Errorf("Set doesn't correctly report read-only error: expected err.VarName %v got %v",
+				err.VarName, "v")
+		}
+	default:
+		t.Errorf("Set doesn't report read-only error")
 	}
 }

--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -86,7 +86,7 @@ func TestExtractExports(t *testing.T) {
 	defer restore()
 
 	ns := eval.NsBuilder{
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc("a", "lorem")),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc("a", "lorem")),
 	}.Ns()
 	ns2 := extractExports(ns, &bytes.Buffer{})
 	if a, _ := ns2.Index("a"); a != "lorem" {
@@ -99,7 +99,7 @@ func TestExtractExports_IgnoreNonMapExports(t *testing.T) {
 	defer restore()
 
 	ns := eval.NsBuilder{
-		exportsVarName: vars.NewReadOnly("x"),
+		exportsVarName: vars.NewReadOnly(exportsVarName, "x"),
 	}.Ns()
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)
@@ -113,7 +113,7 @@ func TestExtractExports_IgnoreNonStringKeys(t *testing.T) {
 	defer restore()
 
 	ns := eval.NsBuilder{
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc(vals.EmptyList, "lorem")),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc(vals.EmptyList, "lorem")),
 	}.Ns()
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)
@@ -127,8 +127,8 @@ func TestExtractExports_DoesNotOverwrite(t *testing.T) {
 	defer restore()
 
 	ns := eval.NsBuilder{
-		"a":            vars.NewReadOnly("lorem"),
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap.Assoc("a", "ipsum")),
+		"a":            vars.NewReadOnly("a", "lorem"),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap.Assoc("a", "ipsum")),
 	}.Ns()
 	var errBuf bytes.Buffer
 	ns2 := extractExports(ns, &errBuf)
@@ -145,7 +145,7 @@ func TestExtractExports_ShowsDeprecationWarning(t *testing.T) {
 	defer restore()
 
 	ns := eval.NsBuilder{
-		exportsVarName: vars.NewReadOnly(vals.EmptyMap),
+		exportsVarName: vars.NewReadOnly(exportsVarName, vals.EmptyMap),
 	}.Ns()
 	var errBuf bytes.Buffer
 	extractExports(ns, &errBuf)


### PR DESCRIPTION
Modifying a read-only var should include the var name in the error message.

Fixes #255