### PR TITLE
Fix when cursor is shown by `edit:clear`

### DIFF
--- a/pkg/cli/clitest/fake_tty.go
+++ b/pkg/cli/clitest/fake_tty.go
@@ -126,6 +126,12 @@ func (t *fakeTTY) UpdateBuffer(bufNotes, buf *term.Buffer, _ bool) error {
 	return nil
 }
 
+func (t *fakeTTY) HideCursor() {
+}
+
+func (t *fakeTTY) ShowCursor() {
+}
+
 func (t *fakeTTY) ClearScreen() {
 	t.cleared++
 }

--- a/pkg/cli/term/writer.go
+++ b/pkg/cli/term/writer.go
@@ -19,6 +19,9 @@ type Writer interface {
 	// ClearScreen clears the terminal screen and places the cursor at the top
 	// left corner.
 	ClearScreen()
+	// Control whether the terminal cursor is visible.
+	HideCursor()
+	ShowCursor()
 }
 
 // writer renders the editor UI.
@@ -186,11 +189,17 @@ func (w *writer) CommitBuffer(bufNoti, buf *Buffer, fullRefresh bool) error {
 	return nil
 }
 
+func (w *writer) HideCursor() {
+	fmt.Fprint(w.file, hideCursor)
+}
+
+func (w *writer) ShowCursor() {
+	fmt.Fprint(w.file, showCursor)
+}
+
 func (w *writer) ClearScreen() {
 	fmt.Fprint(w.file,
-		hideCursor,
 		"\033[H",  // move cursor to the top left corner
 		"\033[2J", // clear entire buffer
-		showCursor,
 	)
 }

--- a/pkg/cli/tty.go
+++ b/pkg/cli/tty.go
@@ -55,6 +55,9 @@ type TTY interface {
 	// ClearScreen clears the terminal screen and places the cursor at the top
 	// left corner.
 	ClearScreen()
+	// Control whether the terminal cursor is visible.
+	HideCursor()
+	ShowCursor()
 }
 
 type aTTY struct {
@@ -129,6 +132,14 @@ func (t *aTTY) ResetBuffer() {
 
 func (t *aTTY) UpdateBuffer(bufNotes, bufMain *term.Buffer, full bool) error {
 	return t.w.CommitBuffer(bufNotes, bufMain, full)
+}
+
+func (t *aTTY) HideCursor() {
+	t.w.HideCursor()
+}
+
+func (t *aTTY) ShowCursor() {
+	t.w.ShowCursor()
 }
 
 func (t *aTTY) ClearScreen() {

--- a/pkg/edit/builtins.go
+++ b/pkg/edit/builtins.go
@@ -91,8 +91,10 @@ func redraw(app cli.App, opts redrawOpts) {
 // the screen.
 
 func clear(app cli.App, tty cli.TTY) {
+	tty.HideCursor()
 	tty.ClearScreen()
 	app.RedrawFull()
+	tty.ShowCursor()
 }
 
 //elvdoc:fn insert-raw


### PR DESCRIPTION
Showing the cursor should only happen after the prompt is redrawn.

Fixes #1238