### PR TITLE
Handling symlinks with an unresolvable target

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -11,6 +11,10 @@ This is the draft release notes for 0.16.0. It is scheduled to be released on
     Instead, the history listing mode now applies smart-case matching by
     default.
 
+-   The `path:eval-symlinks` command no longer returns an error when the
+    argument is an invalid path; instead it now returns the original path.
+    ([#1236](https://b.elv.sh/1236)).
+
 # Notable bugfixes
 
 -   The `path:is-dir` and `path:is-regular` commands no longer follow symlinks,

--- a/pkg/eval/mods/path/path_test.go
+++ b/pkg/eval/mods/path/path_test.go
@@ -19,6 +19,7 @@ var testDir = testutil.Dir{
 		},
 	},
 	"s1": testutil.Symlink{filepath.Join("d1", "d2")},
+	"s2": testutil.Symlink{"invalid"},
 }
 
 func TestPath(t *testing.T) {
@@ -47,12 +48,20 @@ func TestPath(t *testing.T) {
 		That(`path:ext a/b/s`).Puts(""),
 		That(`path:is-abs a/b/s`).Puts(false),
 		That(`path:is-abs `+absPath).Puts(true),
+		// We use more comprehensive tests of `path:eval-symlinks` because we're paranoid and there
+		// is no error case that is special-cased to not be an error.
 		That(`path:eval-symlinks d1/d2`).Puts(filepath.Join("d1", "d2")),
 		That(`path:eval-symlinks d1/d2/f`).Puts(filepath.Join("d1", "d2", "f")),
 		That(`path:eval-symlinks s1`).Puts(filepath.Join("d1", "d2")),
 		That(`path:eval-symlinks d1/f`).Puts(filepath.Join("d1", "d2", "f")),
 		That(`path:eval-symlinks s1/g`).Puts(filepath.Join("d1", "d2", "f")),
 		That(`path:eval-symlinks s1/empty`).Puts(filepath.Join("d1", "d2", "empty")),
+		// Regression test for https://b.elv.sh/1241. An invalid path should silently return the
+		// original path. Because the original path is returned unmodified we don't use
+		// filepath.Join() to construct the expected output.
+		That(`path:eval-symlinks invalid/anything`).Puts("invalid/anything"),
+		That(`path:eval-symlinks d1/does-not-exist`).Puts("d1/does-not-exist"),
+		That(`path:eval-symlinks s1/does-not-matter`).Puts("s1/does-not-matter"),
 
 		// Elvish `path:` module functions that are not trivial wrappers around a Go stdlib function
 		// should have comprehensive tests below this comment.


### PR DESCRIPTION
Symlinks in a pathname that cannot be resolved because the target is
not valid represent a special case. Specifically, if resolving a symlink
results in a syscall.ENOENT error it is friendlier, and generally more
useful, to treat it as a non-error that simply outputs the original path.
This makes the command consistent with the behavior of the external
`realpath` it mimics.

Fixes #1236