### PR TITLE
Allow quoted var names in an `except...` block

### DIFF
--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -636,9 +636,14 @@ func compileTry(cp *compiler, fn *parse.Form) effectOp {
 		logger.Println("except-ing")
 		n := args.peek()
 		// Is this a variable?
-		if len(n.Indexings) == 1 && n.Indexings[0].Head.Type == parse.Bareword {
-			exceptVarNode = n
-			args.next()
+		if len(n.Indexings) == 1 {
+			// This mimics the compiler.literal function. That is, an exception capture var name can
+			// be a bareword or quoted string.
+			t := n.Indexings[0].Head.Type
+			if t == parse.Bareword || t == parse.SingleQuoted || t == parse.DoubleQuoted {
+				exceptVarNode = n
+				args.next()
+			}
 		}
 		exceptNode = args.nextMustLambda("except body")
 	}

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -157,6 +157,11 @@ func TestTry(t *testing.T) {
 
 		// wrong syntax
 		That("try { nop } except @a { }").DoesNotCompile(),
+
+		// A quoted var name, that would be invalid as a bareword, should be allowed as the referent
+		// in a `try...except...` block.
+		That("try { fail hard } except 'x=' { put 'x= ='(to-string $'x=') }").
+			Puts("x= =[&reason=[&content=hard &type=fail]]"),
 	)
 }
 


### PR DESCRIPTION
Related #1258