### PR TITLE
Fix missing package in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:alpine as builder
+FROM golang:1.16-alpine as builder
 RUN apk update && \
     apk add --virtual build-deps make git
 # Build Elvish
 COPY . /go/src/src.elv.sh
 RUN make -C /go/src/src.elv.sh get
 
-FROM alpine
+FROM alpine:3.13
 COPY --from=builder /go/bin/elvish /bin/elvish
 RUN adduser -D elf
 RUN apk update && apk add tmux mandoc man-pages vim curl git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN make -C /go/src/src.elv.sh get
 FROM alpine
 COPY --from=builder /go/bin/elvish /bin/elvish
 RUN adduser -D elf
-RUN apk update && apk add tmux man man-pages vim curl git
+RUN apk update && apk add tmux mandoc man-pages vim curl git
 USER elf
 WORKDIR /home/elf
 CMD ["/bin/elvish"]


### PR DESCRIPTION
It appears that in Alpine 3.12, the man package was renamed to mandoc.
To prevent similar issues from re-occurring, I also added version constraints to the images referenced in the Dockerfile.