### PR TITLE
Correctly highlight read-only except var

### DIFF
--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -695,7 +695,7 @@ func (op *tryOp) exec(fm *Frame) Exception {
 			if exceptVar != nil {
 				err := exceptVar.Set(err.(Exception))
 				if err != nil {
-					return fm.errorp(op, err)
+					return fm.errorp(op.exceptVar, err)
 				}
 			}
 			err = except.Call(fm.fork("try except"), NoArgs, NoOpts)

--- a/pkg/eval/compile_effect_test.go
+++ b/pkg/eval/compile_effect_test.go
@@ -137,6 +137,12 @@ func TestCommand_Assignment(t *testing.T) {
 		// Assignment errors itself.
 		That("true = 1").Throws(vars.ErrSetReadOnlyVar, "true"),
 		That("@true = 1").Throws(vars.ErrSetReadOnlyVar, "@true"),
+		// A readonly var as a target for the `except` clause should error.
+		That("try { fail reason } except nil { }").Throws(vars.ErrSetReadOnlyVar, "nil"),
+		That("try { fail reason } except x { }").DoesNothing(),
+		// Evaluation of the assignability occurs at run-time so, if no exception is raised, this
+		// otherwise invalid use of `nil` is okay.
+		That("try { } except nil { }").DoesNothing(),
 		// Arity mismatch.
 		That("x = 1 2").Throws(
 			errs.ArityMismatch{


### PR DESCRIPTION
Using a read-only variable as the target of an `except` clause should
highlight just the var name rather than the entire `try...except...`
statement.

Resolves #1258