### PR TITLE
Initialize a lambda var to $nop~

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -11,6 +11,10 @@ This is the draft release notes for 0.16.0. It is scheduled to be released on
     Instead, the history listing mode now applies smart-case matching by
     default.
 
+-   Declaring a variable with a `~` suffix, without an explicit initial value,
+    now defaults to $builtin:nop rather than $builtin:nil
+    ([#1248](https://b.elv.sh/1248)).
+
 # Notable bugfixes
 
 -   The `path:is-dir` and `path:is-regular` commands no longer follow symlinks,

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -24,6 +24,9 @@ func TestVar(t *testing.T) {
 		That("var 'a/b'", "put $'a/b'").Puts(nil),
 		// Declaring one variable whose name ends in ":".
 		That("var a:").DoesNothing(),
+		// Declaring a variable whose name ends in "~" has default value $builtin:nop rather than
+		// $builtin:nil. See https://github.com/elves/elvish/issues/1248.
+		That("var cmd~; cmd &ignored-opt ignored-arg").DoesNothing(),
 		// Declaring multiple variables
 		That("var x y", "put $x $y").Puts(nil, nil),
 		// Declaring one variable with initial value

--- a/pkg/eval/closure.go
+++ b/pkg/eval/closure.go
@@ -146,7 +146,7 @@ func (c *closure) Call(fm *Frame, args []interface{}, opts map[string]interface{
 func MakeVarFromName(name string) vars.Var {
 	switch {
 	case strings.HasSuffix(name, FnSuffix):
-		val := Callable(nil)
+		val := NewGoFn("nop~", nop)
 		return vars.FromPtr(&val)
 	case strings.HasSuffix(name, NsSuffix):
 		val := (*Ns)(nil)

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -621,7 +621,8 @@ when used as the suffix of a variable name:
 
 -   If a variable name ends with `~`, it can only take callable values, which
     are functions and external commands. Such variables are consulted when
-    resolving [ordinary commands](#ordinary-command).
+    resolving [ordinary commands](#ordinary-command). The default value is the
+    [`builtin:nop`](builtin.html#nop) command.
 
 -   If a variable name ends with `:`, it can only take namespaces as values.
     They are used for accessing namespaced variables.


### PR DESCRIPTION
You cannot assign $nil to a lambda var so that should not be the initial
value of `var x~`. Instead, assign $builtin:nop~.

Fixes #1248