### PR TITLE
Add option to reinstate old path:is-* behavior

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -38,10 +38,13 @@ or compiled, even if it is not executed:
 -   Iterating over certain list slices no longer crash Elvish
     ([#1287](https://b.elv.sh/1287)).
 
--   The `path:is-dir` and `path:is-regular` commands no longer follow symlinks,
-    as advertised in the documentation.
+-   The `path:is-dir` and `path:is-regular` commands default behavior no longer
+    follows a final symlink as advertised in the original documentation. A
+    `&follow-symlink` option has been added to get the old, undocumented,
+    behavior since it can be useful and avoids the need to use
+    `path:eval-symlinks` to transform the path in common use cases.
 
--   Evaluating `~username` no longer appends a slash
+*   Evaluating `~username` no longer appends a slash
     ([#1246](https://b.elv.sh/1246)).
 
 # Notable new features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,8 @@ Always document user-visible changes.
 ### Release notes
 
 Add a brief list item to the release note of the next release, in the
-appropriate section.
-
-The release notes live in `website/blog`; the symlink `NEXT-RELEASE.md` at the
-repo root always points to those of the next release.
+appropriate section. You can find the document at the root of the repo (called
+`$version-release-notes.md`).
 
 ### Reference docs
 

--- a/NEXT-RELEASE.md
+++ b/NEXT-RELEASE.md
@@ -1,1 +1,0 @@
-0.16.0-release-notes.md

--- a/pkg/eval/mods/path/path.go
+++ b/pkg/eval/mods/path/path.go
@@ -136,13 +136,15 @@ var fns = map[string]interface{}{
 //elvdoc:fn is-dir
 //
 // ```elvish
-// is-dir $path
+// is-dir &follow-symlink=$false $path
 // ```
 //
 // Outputs `$true` if the path resolves to a directory. If the final element of the path is a
 // symlink, even if it points to a directory, it still outputs `$false` since a symlink is not a
-// directory. Use [`eval-symlinks`](#patheval-symlinks) on the path first if you don't care if the
-// final element is a symlink.
+// directory. Setting option `&follow-symlink` to true will cause the last element of the path, if
+// it is a symlink, to be resolved before doing the test.
+//
+// @cf eval-symlinks
 //
 // ```elvish-transcript
 // ~> touch not-a-dir
@@ -152,21 +154,33 @@ var fns = map[string]interface{}{
 // ▶ true
 // ```
 
-func isDir(path string) bool {
-	fi, err := os.Lstat(path)
+type isOpts struct{ FollowSymlink bool }
+
+func (opts *isOpts) SetDefaultOptions() {}
+
+func isDir(opts isOpts, path string) bool {
+	var fi os.FileInfo
+	var err error
+	if opts.FollowSymlink {
+		fi, err = os.Stat(path)
+	} else {
+		fi, err = os.Lstat(path)
+	}
 	return err == nil && fi.Mode().IsDir()
 }
 
 //elvdoc:fn is-regular
 //
 // ```elvish
-// is-regular $path
+// is-regular &follow-symlink=$false $path
 // ```
 //
 // Outputs `$true` if the path resolves to a regular file. If the final element of the path is a
 // symlink, even if it points to a regular file, it still outputs `$false` since a symlink is not a
-// regular file. Use [`eval-symlinks`](#patheval-symlinks) on the path first if you don't care if
-// the final element is a symlink.
+// regular file. Setting option `&follow-symlink` to true will cause the last element of the path,
+// if it is a symlink, to be resolved before doing the test.
+//
+// @cf eval-symlinks
 //
 // ```elvish-transcript
 // ~> touch not-a-dir
@@ -176,8 +190,14 @@ func isDir(path string) bool {
 // ▶ false
 // ```
 
-func isRegular(path string) bool {
-	fi, err := os.Lstat(path)
+func isRegular(opts isOpts, path string) bool {
+	var fi os.FileInfo
+	var err error
+	if opts.FollowSymlink {
+		fi, err = os.Stat(path)
+	} else {
+		fi, err = os.Lstat(path)
+	}
 	return err == nil && fi.Mode().IsRegular()
 }
 

--- a/website/blog/prelude.md
+++ b/website/blog/prelude.md
@@ -1,2 +1,2 @@
 Note: the draft release notes for the next release can be found
-[here on GitHub](https://github.com/elves/elvish/blob/master/NEXT-RELEASE.md).
+[here on GitHub](https://github.com/elves/elvish/blob/master/0.16.0-release-notes.md).

--- a/website/get/prelude.md
+++ b/website/get/prelude.md
@@ -31,7 +31,7 @@ archive:
     <th>arm64</th>
   </tr>
   <tr>
-    <td>HEAD (<a href="https://github.com/elves/elvish/blob/master/NEXT-RELEASE.md">Draft Release Note</a>)</td>
+    <td>HEAD (<a href="https://github.com/elves/elvish/blob/master/0.16-release-notes.md">Draft Release Note</a>)</td>
     <td>
       @dl Linux linux-amd64/elvish-HEAD.tar.gz
       @dl macOS darwin-amd64/elvish-HEAD.tar.gz


### PR DESCRIPTION
This introduces a `&follow-symlink` option to the two existing `path:is-`
commands. It is sometimes useful to know if a given path resolves to a
particular filesystem object type even when the final component of the
path is a symbolic link.

Related #1236