### PR TITLE
Document edit "command" mode

### DIFF
--- a/pkg/edit/command_api.go
+++ b/pkg/edit/command_api.go
@@ -1,13 +1,27 @@
 package edit
 
+// Implementation of the editor "command" mode.
+
 import (
 	"src.elv.sh/pkg/cli/mode"
 	"src.elv.sh/pkg/eval"
 )
 
-//elv:fn command:start
+//elvdoc:var command:binding
 //
-// Starts the command mode.
+// Key bindings for command mode. The default bindings are a subset of Vi's command mode.
+//
+// TODO: Document the default bindings. For now note that they are codified in the
+// *pkg/edit/default_bindings.go* source file. Specifically the `command:binding` assignment.
+//
+// @cf edit:command:start
+
+//elvdoc:fn command:start
+//
+// Enter command mode. This is typically used to emulate the Vi editor's command mode by switching
+// to the appropriate key bindings.
+//
+// @cf edit:command:binding
 
 func initCommandAPI(ed *Editor, ev *eval.Evaler, nb eval.NsBuilder) {
 	bindingVar := newBindingVar(emptyBindingsMap)

--- a/website/ref/edit.md
+++ b/website/ref/edit.md
@@ -23,9 +23,9 @@ Each mode has its own submodule under `edit:`. For instance, builtin functions
 and configuration variables for the completion mode can be found in the
 `edit:completion:` module.
 
-The primary modes supported now are `insert`, `completion`, `navigation`,
-`history`, `histlist`, `location`, and `lastcmd`. The last 4 are "listing
-modes", and their particularity is documented below.
+The primary modes supported now are `insert`, `command`, `completion`,
+`navigation`, `history`, `histlist`, `location`, and `lastcmd`. The last 4 are
+"listing modes", and their particularity is documented below.
 
 ## Prompts
 


### PR DESCRIPTION
Fix `//elv:fn` to the correct `//elvdoc:fn` form. Add a little more
information about the "command" mode of the Elvish interactive editor.

Related #971