### PR TITLE
Add a `-i` CLI option

### DIFF
--- a/pkg/prog/prog.go
+++ b/pkg/prog/prog.go
@@ -63,6 +63,9 @@ func newFlagSet(stderr io.Writer, f *Flags) *flag.FlagSet {
 	fs.BoolVar(&f.BuildInfo, "buildinfo", false, "show build info and quit")
 	fs.BoolVar(&f.JSON, "json", false, "show output in JSON. Useful with -buildinfo.")
 
+	// The `-i` option is for compatibility with POSIX shells so that programs, such as the `script`
+	// command, will work when asked to launch an interactive Elvish shell.
+	fs.Bool("i", false, "force interactive mode; currently ignored")
 	fs.BoolVar(&f.CodeInArg, "c", false, "take first argument as code to execute")
 	fs.BoolVar(&f.CompileOnly, "compileonly", false, "Parse/Compile but do not execute")
 	fs.BoolVar(&f.NoRc, "norc", false, "run elvish without invoking rc.elv")


### PR DESCRIPTION
POSIX shells have a `-i` short option to force interactive mode. Some
programs, such as the `script` command, assume that option is recognized
by the shell it spawns. There isn't any reason elvish shouldn't silently
ignore that option.

Resolves #1292