### PR TITLE
Added the file:truncate function to the file module

### DIFF
--- a/pkg/eval/mods/file/file.go
+++ b/pkg/eval/mods/file/file.go
@@ -10,11 +10,12 @@ import (
 var Ns = eval.NsBuilder{}.AddGoFns("file:", fns).Ns()
 
 var fns = map[string]interface{}{
-	"close":   close,
-	"open":    open,
-	"pipe":    pipe,
-	"prclose": prclose,
-	"pwclose": pwclose,
+	"close":    close,
+	"open":     open,
+	"pipe":     pipe,
+	"prclose":  prclose,
+	"pwclose":  pwclose,
+	"truncate": truncate,
 }
 
 //elvdoc:fn open
@@ -123,4 +124,13 @@ func prclose(p vals.Pipe) error {
 
 func pwclose(p vals.Pipe) error {
 	return p.WriteEnd.Close()
+}
+
+func truncate(name string, size int) error {
+	s := int64(size)
+	err := os.Truncate(name, s)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
I have made ```file:truncate``` function. It takes two parameters, one of them being the name of the file and the other being the size. 
I was having a "type" problem with ```int64``` input for the function. You will be able to see in the code that I found my way around it but I don't think it is the best way to solve it. 
```
use file

file:truncate lotr.txt 10
```

I feel there will be a better way to do this, this function is working, I did some manual testing, didn't write test cases, but will write them after this is reviewed, would like some feedback on this. 

Related to issue #1262 