### PR TITLE
Remove obsolete store API method

### DIFF
--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -137,13 +137,6 @@ func (c *client) Cmd(seq int) (string, error) {
 	return res.Text, err
 }
 
-func (c *client) Cmds(from, upto int) ([]string, error) {
-	req := &api.CmdsRequest{From: from, Upto: upto}
-	res := &api.CmdsResponse{}
-	err := c.call("Cmds", req, res)
-	return res.Cmds, err
-}
-
 func (c *client) CmdsWithSeq(from, upto int) ([]store.Cmd, error) {
 	req := &api.CmdsWithSeqRequest{From: from, Upto: upto}
 	res := &api.CmdsWithSeqResponse{}

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -65,15 +65,6 @@ func (s *service) Cmd(req *api.CmdRequest, res *api.CmdResponse) error {
 	return err
 }
 
-func (s *service) Cmds(req *api.CmdsRequest, res *api.CmdsResponse) error {
-	if s.err != nil {
-		return s.err
-	}
-	cmds, err := s.store.Cmds(req.From, req.Upto)
-	res.Cmds = cmds
-	return err
-}
-
 func (s *service) CmdsWithSeq(req *api.CmdsWithSeqRequest, res *api.CmdsWithSeqResponse) error {
 	if s.err != nil {
 		return s.err

--- a/pkg/edit/config_api_test.go
+++ b/pkg/edit/config_api_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/cli/term"
+	"src.elv.sh/pkg/store"
 	"src.elv.sh/pkg/ui"
 )
 
@@ -49,7 +50,7 @@ func TestAddCmdFilters(t *testing.T) {
 		name        string
 		rc          string
 		input       string
-		wantHistory []string
+		wantHistory []store.Cmd
 	}{
 		// TODO: Enable the following two tests once error output can
 		// be tested.
@@ -69,7 +70,7 @@ func TestAddCmdFilters(t *testing.T) {
 			name:        "callback outputs true",
 			rc:          "edit:add-cmd-filters = [[_]{ put $true }]",
 			input:       "echo\n",
-			wantHistory: []string{"echo"},
+			wantHistory: []store.Cmd{store.Cmd{Text: "echo", Seq: 1}},
 		},
 		{
 			name:        "callback outputs false",
@@ -93,7 +94,7 @@ func TestAddCmdFilters(t *testing.T) {
 			name:        "positive",
 			rc:          "edit:add-cmd-filters = [[cmd]{ ==s $cmd echo }]",
 			input:       "echo\n",
-			wantHistory: []string{"echo"},
+			wantHistory: []store.Cmd{store.Cmd{Text: "echo", Seq: 1}},
 		},
 		{
 			name:        "negative",

--- a/pkg/edit/editor_test.go
+++ b/pkg/edit/editor_test.go
@@ -14,7 +14,7 @@ func TestEditor_AddsHistoryAfterAccepting(t *testing.T) {
 	feedInput(f.TTYCtrl, "echo x\n")
 	f.Wait()
 
-	testCommands(t, f.Store, "echo x")
+	testCommands(t, f.Store, store.Cmd{Text: "echo x", Seq: 1})
 }
 
 func TestEditor_DoesNotAddEmptyCommandToHistory(t *testing.T) {
@@ -27,9 +27,9 @@ func TestEditor_DoesNotAddEmptyCommandToHistory(t *testing.T) {
 	testCommands(t, f.Store /* no commands */)
 }
 
-func testCommands(t *testing.T, store store.Store, wantCmds ...string) {
+func testCommands(t *testing.T, store store.Store, wantCmds ...store.Cmd) {
 	t.Helper()
-	cmds, err := store.Cmds(0, 1024)
+	cmds, err := store.CmdsWithSeq(0, 1024)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/store/cmd.go
+++ b/pkg/store/cmd.go
@@ -78,17 +78,6 @@ func (s *dbStore) IterateCmds(from, upto int, f func(Cmd)) error {
 	})
 }
 
-// Cmds returns the contents of all commands within the specified range.
-//
-// NOTE: Deprecated as of 0.13. Delete after release of 0.14.
-func (s *dbStore) Cmds(from, upto int) ([]string, error) {
-	var cmds []string
-	err := s.IterateCmds(from, upto, func(cmd Cmd) {
-		cmds = append(cmds, cmd.Text)
-	})
-	return cmds, err
-}
-
 // CmdsWithSeq returns all commands within the specified range.
 func (s *dbStore) CmdsWithSeq(from, upto int) ([]Cmd, error) {
 	var cmds []Cmd

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -16,7 +16,6 @@ type Store interface {
 	AddCmd(text string) (int, error)
 	DelCmd(seq int) error
 	Cmd(seq int) (string, error)
-	Cmds(from, upto int) ([]string, error)
 	CmdsWithSeq(from, upto int) ([]Cmd, error)
 	NextCmd(from int, prefix string) (Cmd, error)
 	PrevCmd(upto int, prefix string) (Cmd, error)


### PR DESCRIPTION
While working on issue #568 to add a `&dedup` option to the
`edit:command-history` command I noticed that the `store.Cmd.Cmds()`
method should be removed.