### PR TITLE
Golint cleanups

### DIFF
--- a/pkg/cli/lscolors/lscolors.go
+++ b/pkg/cli/lscolors/lscolors.go
@@ -51,7 +51,7 @@ func GetColorist() Colorist {
 }
 
 func getLsColors() string {
-	lsColorString := os.Getenv(env.LS_COLORS)
+	lsColorString := os.Getenv(env.LsColors)
 	if len(lsColorString) == 0 {
 		return defaultLsColorString
 	}

--- a/pkg/edit/highlight_test.go
+++ b/pkg/edit/highlight_test.go
@@ -81,16 +81,16 @@ func TestMakeHasCommand(t *testing.T) {
 	// Set up environment.
 	testDir, cleanup := testutil.InTestDir()
 	defer cleanup()
-	oldPath := os.Getenv(env.PATH)
-	defer os.Setenv(env.PATH, oldPath)
+	oldPath := os.Getenv(env.Path)
+	defer os.Setenv(env.Path, oldPath)
 	if runtime.GOOS == "windows" {
-		oldPathExt := os.Getenv(env.PATHEXT)
-		defer os.Setenv(env.PATHEXT, oldPathExt)
-		os.Unsetenv(env.PATHEXT) // force default value
+		oldPathExt := os.Getenv(env.Pathext)
+		defer os.Setenv(env.Pathext, oldPathExt)
+		os.Unsetenv(env.Pathext) // force default value
 	}
 
 	// Set up a directory in PATH.
-	os.Setenv(env.PATH, filepath.Join(testDir, "bin"))
+	os.Setenv(env.Path, filepath.Join(testDir, "bin"))
 	mustMkdirAll("bin")
 	mustMkExecutable("bin/external")
 	mustMkExecutable("bin/@external")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -7,13 +7,13 @@ package env
 // Note that some of these env vars may be significant only in special
 // circumstances, such as when running unit tests.
 const (
-	ELVISH_TEST_TIME_SCALE = "ELVISH_TEST_TIME_SCALE"
-	HOME                   = "HOME"
-	LS_COLORS              = "LS_COLORS"
-	PATH                   = "PATH"
-	PATHEXT                = "PATHEXT"
-	PWD                    = "PWD"
-	SHLVL                  = "SHLVL"
-	USERNAME               = "USERNAME"
-	XDG_RUNTIME_DIR        = "XDG_RUNTIME_DIR"
+	ElvishTestTimeScale = "ELVISH_TEST_TIME_SCALE"
+	Home                = "HOME"
+	LsColors            = "LS_COLORS"
+	Path                = "PATH"
+	Pathext             = "PATHEXT"
+	Pwd                 = "PWD"
+	Shlvl               = "SHLVL"
+	Username            = "USERNAME"
+	XdgRuntimeDir       = "XDG_RUNTIME_DIR"
 )

--- a/pkg/eval/builtin_fn_cmd_unix.go
+++ b/pkg/eval/builtin_fn_cmd_unix.go
@@ -56,11 +56,11 @@ func execFn(fm *Frame, args ...interface{}) error {
 // Decrements $E:SHLVL. Called from execFn to ensure that $E:SHLVL remains the
 // same in the new command.
 func decSHLVL() {
-	i, err := strconv.Atoi(os.Getenv(env.SHLVL))
+	i, err := strconv.Atoi(os.Getenv(env.Shlvl))
 	if err != nil {
 		return
 	}
-	os.Setenv(env.SHLVL, strconv.Itoa(i-1))
+	os.Setenv(env.Shlvl, strconv.Itoa(i-1))
 }
 
 func fg(pids ...int) error {

--- a/pkg/eval/chdir_test.go
+++ b/pkg/eval/chdir_test.go
@@ -30,7 +30,7 @@ func TestChdir(t *testing.T) {
 	if err != nil {
 		t.Errorf("Chdir => error %v", err)
 	}
-	if envPwd := os.Getenv(env.PWD); envPwd != dst {
+	if envPwd := os.Getenv(env.Pwd); envPwd != dst {
 		t.Errorf("$PWD is %q after Chdir, want %q", envPwd, dst)
 	}
 

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -371,7 +371,7 @@ func (ev *Evaler) Chdir(path string) error {
 		logger.Println("getwd after cd:", err)
 		return nil
 	}
-	os.Setenv(env.PWD, pwd)
+	os.Setenv(env.Pwd, pwd)
 
 	return nil
 }

--- a/pkg/eval/vals/num.go
+++ b/pkg/eval/vals/num.go
@@ -153,13 +153,10 @@ func convertToFloat64(num Num) float64 {
 	case int:
 		return float64(num)
 	case *big.Int:
-		if num.IsInt64() {
-			// Might fit in float64
+		if num.IsInt64() { // probably fits in a float64
 			return float64(num.Int64())
-		} else {
-			// Definitely won't fit in float64
-			return math.Inf(num.Sign())
 		}
+		return math.Inf(num.Sign()) // definitely won't fit in a float64
 	case *big.Rat:
 		f, _ := num.Float64()
 		return f

--- a/pkg/fsutil/gethome.go
+++ b/pkg/fsutil/gethome.go
@@ -18,7 +18,7 @@ func GetHome(uname string) (string, error) {
 	if uname == "" {
 		// Use $HOME as override if we are looking for the home of the current
 		// variable.
-		home := os.Getenv(env.HOME)
+		home := os.Getenv(env.Home)
 		if home != "" {
 			return strings.TrimRight(home, pathSep), nil
 		}

--- a/pkg/fsutil/getwd_test.go
+++ b/pkg/fsutil/getwd_test.go
@@ -36,12 +36,12 @@ func TestGetwd(t *testing.T) {
 		{"wd not abbreviated when HOME is slash", "/", tmpdir, tmpdir},
 	}
 
-	oldHome := os.Getenv(env.HOME)
-	defer os.Setenv(env.HOME, oldHome)
+	oldHome := os.Getenv(env.Home)
+	defer os.Setenv(env.Home, oldHome)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv(env.HOME, test.home)
+			os.Setenv(env.Home, test.home)
 			testutil.MustChdir(test.chdir)
 			if gotWd := Getwd(); gotWd != test.wantWd {
 				t.Errorf("Getwd() -> %v, want %v", gotWd, test.wantWd)

--- a/pkg/fsutil/search.go
+++ b/pkg/fsutil/search.go
@@ -46,5 +46,5 @@ func EachExternal(f func(string)) {
 }
 
 func searchPaths() []string {
-	return strings.Split(os.Getenv(env.PATH), ":")
+	return strings.Split(os.Getenv(env.Path), ":")
 }

--- a/pkg/persistent/hash/hash.go
+++ b/pkg/persistent/hash/hash.go
@@ -27,19 +27,24 @@ func UInt64(u uint64) uint32 {
 }
 
 func Pointer(p unsafe.Pointer) uint32 {
-	if unsafe.Sizeof(p) == 4 {
+	switch unsafe.Sizeof(p) {
+	case 4:
 		return UInt32(uint32(uintptr(p)))
-	} else {
+	case 8:
 		return UInt64(uint64(uintptr(p)))
+	default:
+		panic("unhandled pointer size")
 	}
-	// NOTE: We don't care about 128-bit archs yet.
 }
 
-func UIntPtr(u uintptr) uint32 {
-	if unsafe.Sizeof(u) == 4 {
-		return UInt32(uint32(u))
-	} else {
-		return UInt64(uint64(u))
+func UIntPtr(p uintptr) uint32 {
+	switch unsafe.Sizeof(p) {
+	case 4:
+		return UInt32(uint32(p))
+	case 8:
+		return UInt64(uint64(p))
+	default:
+		panic("unhandled pointer size")
 	}
 }
 

--- a/pkg/shell/paths_test.go
+++ b/pkg/shell/paths_test.go
@@ -43,7 +43,7 @@ func TestMakePaths_RespectsSetSubPaths(t *testing.T) {
 func TestMakePaths_SetsAndCreatesDataDir(t *testing.T) {
 	home, cleanupDir := testutil.TestDir()
 	defer cleanupDir()
-	cleanupEnv := testutil.WithTempEnv(env.HOME, home)
+	cleanupEnv := testutil.WithTempEnv(env.Home, home)
 	defer cleanupEnv()
 
 	paths := MakePaths(os.Stderr, Paths{

--- a/pkg/shell/paths_unix.go
+++ b/pkg/shell/paths_unix.go
@@ -40,8 +40,8 @@ func getSecureRunDir() (string, error) {
 // preference.
 func getRunDirCandidates() []string {
 	tmpDirPath := filepath.Join(os.TempDir(), fmt.Sprintf("elvish-%d", os.Getuid()))
-	if os.Getenv(env.XDG_RUNTIME_DIR) != "" {
-		xdgDirPath := filepath.Join(os.Getenv(env.XDG_RUNTIME_DIR), "elvish")
+	if os.Getenv(env.XdgRuntimeDir) != "" {
+		xdgDirPath := filepath.Join(os.Getenv(env.XdgRuntimeDir), "elvish")
 		return []string{xdgDirPath, tmpDirPath}
 	}
 	return []string{tmpDirPath}

--- a/pkg/shell/paths_unix_test.go
+++ b/pkg/shell/paths_unix_test.go
@@ -46,7 +46,7 @@ func TestGetSecureRunDir_PrefersTmpWhenOnlyItExists(t *testing.T) {
 func TestGetSecureRunDir_PrefersTmpWhenXdgEnvIsEmpty(t *testing.T) {
 	_, tmp, cleanup := setupForSecureRunDir()
 	defer cleanup()
-	os.Setenv(env.XDG_RUNTIME_DIR, "")
+	os.Setenv(env.XdgRuntimeDir, "")
 	testSecureRunDir(t, filepath.Join(tmp, elvishDashUID), false)
 }
 
@@ -61,7 +61,7 @@ func setupForSecureRunDir() (xdgRuntimeDir, tmpDir string, cleanup func()) {
 	xdgRuntimeDir, xdgCleanup := testutil.TestDir()
 	tmpDir, tmpCleanup := testutil.TestDir()
 	envCleanup := withTempEnvs(map[string]string{
-		env.XDG_RUNTIME_DIR: xdgRuntimeDir,
+		env.XdgRuntimeDir: xdgRuntimeDir,
 		"TMPDIR":            tmpDir,
 	})
 	return xdgRuntimeDir, tmpDir, func() {

--- a/pkg/shell/paths_windows.go
+++ b/pkg/shell/paths_windows.go
@@ -11,7 +11,7 @@ import (
 // getSecureRunDir stats elvish-$USERNAME under the default temp dir, creating
 // it if it doesn't yet exist, and return the directory name.
 func getSecureRunDir() (string, error) {
-	username := os.Getenv(env.USERNAME)
+	username := os.Getenv(env.Username)
 
 	runDir := filepath.Join(os.TempDir(), "elvish-"+username)
 	err := os.MkdirAll(runDir, 0700)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -74,13 +74,13 @@ func evalInTTY(ev *eval.Evaler, fds [3]*os.File, src parse.Source) (float64, err
 }
 
 func incSHLVL() func() {
-	restoreSHLVL := saveEnv(env.SHLVL)
+	restoreSHLVL := saveEnv(env.Shlvl)
 
-	i, err := strconv.Atoi(os.Getenv(env.SHLVL))
+	i, err := strconv.Atoi(os.Getenv(env.Shlvl))
 	if err != nil {
 		i = 0
 	}
-	os.Setenv(env.SHLVL, strconv.Itoa(i+1))
+	os.Setenv(env.Shlvl, strconv.Itoa(i+1))
 
 	return restoreSHLVL
 }

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -9,26 +9,26 @@ import (
 )
 
 func TestShell_SHLVL_NormalCase(t *testing.T) {
-	restore := saveEnv(env.SHLVL)
+	restore := saveEnv(env.Shlvl)
 	defer restore()
 
-	os.Setenv(env.SHLVL, "10")
+	os.Setenv(env.Shlvl, "10")
 	testSHLVL(t, "11")
 }
 
 func TestShell_SHLVL_Unset(t *testing.T) {
-	restore := saveEnv(env.SHLVL)
+	restore := saveEnv(env.Shlvl)
 	defer restore()
 
-	os.Unsetenv(env.SHLVL)
+	os.Unsetenv(env.Shlvl)
 	testSHLVL(t, "1")
 }
 
 func TestShell_SHLVL_Invalid(t *testing.T) {
-	restore := saveEnv(env.SHLVL)
+	restore := saveEnv(env.Shlvl)
 	defer restore()
 
-	os.Setenv(env.SHLVL, "invalid")
+	os.Setenv(env.Shlvl, "invalid")
 	testSHLVL(t, "1")
 }
 
@@ -43,10 +43,10 @@ func TestShell_NegativeSHLVL_Increments(t *testing.T) {
 	// 1
 	//
 	// Elvish follows Zsh here.
-	restore := saveEnv(env.SHLVL)
+	restore := saveEnv(env.Shlvl)
 	defer restore()
 
-	os.Setenv(env.SHLVL, "-100")
+	os.Setenv(env.Shlvl, "-100")
 	testSHLVL(t, "-99")
 }
 
@@ -55,14 +55,14 @@ func testSHLVL(t *testing.T, wantSHLVL string) {
 	f := Setup()
 	defer f.Cleanup()
 
-	oldValue, oldOK := os.LookupEnv(env.SHLVL)
+	oldValue, oldOK := os.LookupEnv(env.Shlvl)
 
 	Script(f.Fds(), []string{"print $E:SHLVL"}, &ScriptConfig{Cmd: true})
 	f.TestOut(t, 1, wantSHLVL)
 	f.TestOut(t, 2, "")
 
 	// Test that state of SHLVL is restored.
-	newValue, newOK := os.LookupEnv(env.SHLVL)
+	newValue, newOK := os.LookupEnv(env.Shlvl)
 	if newValue != oldValue {
 		t.Errorf("SHLVL not restored, %q -> %q", oldValue, newValue)
 	}

--- a/pkg/testutil/scaled_ms.go
+++ b/pkg/testutil/scaled_ms.go
@@ -17,7 +17,7 @@ func ScaledMs(ms int) time.Duration {
 }
 
 func getTestTimeScale() float64 {
-	env := os.Getenv(env.ELVISH_TEST_TIME_SCALE)
+	env := os.Getenv(env.ElvishTestTimeScale)
 	if env == "" {
 		return 1
 	}

--- a/pkg/testutil/scaled_ms_test.go
+++ b/pkg/testutil/scaled_ms_test.go
@@ -27,12 +27,12 @@ var scaledMsTests = []struct {
 }
 
 func TestScaledMs(t *testing.T) {
-	envSave := os.Getenv(env.ELVISH_TEST_TIME_SCALE)
-	defer os.Setenv(env.ELVISH_TEST_TIME_SCALE, envSave)
+	envSave := os.Getenv(env.ElvishTestTimeScale)
+	defer os.Setenv(env.ElvishTestTimeScale, envSave)
 
 	for _, test := range scaledMsTests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv(env.ELVISH_TEST_TIME_SCALE, test.env)
+			os.Setenv(env.ElvishTestTimeScale, test.env)
 			got := ScaledMs(test.ms)
 			if got != test.want {
 				t.Errorf("got %v, want %v", got, test.want)

--- a/pkg/testutil/testdir.go
+++ b/pkg/testutil/testdir.go
@@ -53,12 +53,12 @@ func InTestDir() (string, func()) {
 // InTempHome is like InTestDir, but it also sets HOME to the temporary
 // directory and restores the original HOME in cleanup.
 func InTempHome() (string, func()) {
-	oldHome := os.Getenv(env.HOME)
+	oldHome := os.Getenv(env.Home)
 	tmpHome, cleanup := InTestDir()
-	os.Setenv(env.HOME, tmpHome)
+	os.Setenv(env.Home, tmpHome)
 
 	return tmpHome, func() {
-		os.Setenv(env.HOME, oldHome)
+		os.Setenv(env.Home, oldHome)
 		cleanup()
 	}
 }


### PR DESCRIPTION
This cleanup is in one sense slightly pointless. But I've found that
addressing such lint tends to be beneficial as it makes it easier to notice
when real problems are introduced.

pkg/env/env.go:10:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/env/env.go:12:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/env/env.go:18:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/eval/vals/num.go:159:10: if block ends with a return statement, so drop this else and outdent its block
pkg/persistent/hash/hash.go:32:9: if block ends with a return statement, so drop this else and outdent its block
pkg/persistent/hash/hash.go:41:9: if block ends with a return statement, so drop this else and outdent its block