### PR TITLE
Add an example of using fn created variable for function name

### DIFF
--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -2019,6 +2019,15 @@ recursive functions:
 Under the hood, `fn` defines a variable with the given name plus `~` (see
 [variable suffix](#variable-suffix)).
 
+```elvish-transcript
+~> fn f []{ echo hello from f }
+~> f
+hello from f
+~> ff = $f~
+~> $ff
+hello from f
+```
+
 # Pipeline
 
 A **pipeline** is formed by joining one or more commands together with the pipe


### PR DESCRIPTION
I was trying to add a `fn` created function to a list but was unable to
get it working. I suspected using just `name` wasn't correct and tried
`$name` and other attempts but was not successful. Finally was pointed to
`$name~` by @krader1961. I was able to find where this was documented in the
spec, but I missed it since it was just one line at the bottom of the section.
I think an example would have called out the special variable name better and
is just good to have anyway.