### PR TITLE
Implement edit:command-history &dedup

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -62,6 +62,9 @@ New features in the standard library:
 -   Commands for creating temporary files and directories, `path:temp-file` and
     `path:temp-dir` ([#1255](https://b.elv.sh/1255)).
 
+-   New options to the `edit:command-history` command: `&dedup`,
+    `&newest-first`, and `&cmd-only` ([#1053](https://b.elv.sh/1053)).
+
 New features in the interactive editor:
 
 -   The editor now supports setting global bindings via `$edit:global-binding`.

--- a/pkg/edit/hist_store.go
+++ b/pkg/edit/hist_store.go
@@ -26,6 +26,7 @@ func (s *histStore) AddCmd(cmd store.Cmd) (int, error) {
 	return s.hs.AddCmd(cmd)
 }
 
+// AllCmds returns a slice of all interactive commands in oldest to newest order.
 func (s *histStore) AllCmds() ([]store.Cmd, error) {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/pkg/edit/store_api.go
+++ b/pkg/edit/store_api.go
@@ -10,24 +10,36 @@ import (
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/vals"
 	"src.elv.sh/pkg/parse/parseutil"
+	"src.elv.sh/pkg/store"
 )
 
 var errStoreOffline = errors.New("store offline")
 
 //elvdoc:fn command-history
 //
-// Outputs the entire command history as a stream of maps. Each map has a `id`
-// key that identifies the sequence number of the entry, and a `cmd` key that
-// identifies the content.
+// ```elvish
+// edit:command-history &dedup &newest-first
+// ```
 //
-// Use indexing to extract individual entries. For example, to extract the
-// content of the last command, do this:
+// Outputs the command history as a stream of maps. Each map has a `id` key for the sequence number
+// of the command, and a `cmd` key for the text of the command. If `&dedup` is true only the most
+// recent instance of each command (when comparing just the `cmd` key) is output. If `&newest-first`
+// is true the output is in newest to oldest order (default is oldest to newest).
+//
+// Use indexing to extract individual entries. For example, to extract the text of the most recent
+// command do this:
 //
 // ```elvish
 // edit:command-history | put [(all)][-1][cmd]
 // ```
+//
+// @cf builtin:dir-history
 
-func commandHistory(fuser histutil.Store, ch chan<- interface{}) error {
+type cmdhistOpt struct{ Dedup, NewestFirst bool }
+
+func (o *cmdhistOpt) SetDefaultOptions() {}
+
+func commandHistory(opts cmdhistOpt, fuser histutil.Store, ch chan<- interface{}) error {
 	if fuser == nil {
 		return errStoreOffline
 	}
@@ -35,10 +47,40 @@ func commandHistory(fuser histutil.Store, ch chan<- interface{}) error {
 	if err != nil {
 		return err
 	}
+	if opts.Dedup {
+		cmds = uniqCmds(cmds, opts.NewestFirst)
+	} else if opts.NewestFirst {
+		reverse(cmds)
+	}
 	for _, cmd := range cmds {
 		ch <- vals.MakeMap("id", strconv.Itoa(cmd.Seq), "cmd", cmd.Text)
 	}
 	return nil
+}
+
+func uniqCmds(allCmds []store.Cmd, newestFirst bool) []store.Cmd {
+	// The division by four is based on the empirical observation that my personal command history
+	// tends to be only 25% unique commands. This is merely a hint to minimize allocations.
+	uniqCmds := make([]store.Cmd, 0, len(allCmds)/4)
+	seenCmds := make(map[string]bool, len(allCmds)/4)
+	for i := len(allCmds) - 1; i != 0; i-- {
+		if !seenCmds[allCmds[i].Text] {
+			seenCmds[allCmds[i].Text] = true
+			uniqCmds = append(uniqCmds, allCmds[i])
+		}
+	}
+	if !newestFirst {
+		reverse(uniqCmds)
+	}
+	return uniqCmds
+}
+
+// Reverse the order of commands, in place, in the slice. This reorders the command history between
+// oldest or newest command being first in the slice.
+func reverse(cmds []store.Cmd) {
+	for i, j := 0, len(cmds)-1; i < j; i, j = i+1, j-1 {
+		cmds[i], cmds[j] = cmds[j], cmds[i]
+	}
 }
 
 //elvdoc:fn insert-last-word
@@ -63,8 +105,8 @@ func insertLastWord(app cli.App, histStore histutil.Store) error {
 
 func initStoreAPI(app cli.App, nb eval.NsBuilder, fuser histutil.Store) {
 	nb.AddGoFns("<edit>", map[string]interface{}{
-		"command-history": func(fm *eval.Frame) error {
-			return commandHistory(fuser, fm.OutputChan())
+		"command-history": func(fm *eval.Frame, opts cmdhistOpt) error {
+			return commandHistory(opts, fuser, fm.OutputChan())
 		},
 		"insert-last-word": func() { insertLastWord(app, fuser) },
 	})

--- a/pkg/edit/store_api_test.go
+++ b/pkg/edit/store_api_test.go
@@ -62,6 +62,15 @@ func TestCommandHistory(t *testing.T) {
 			vals.MakeMap("id", "5", "cmd", "echo 3"),
 			vals.MakeMap("id", "3", "cmd", "echo 2"),
 		))
+
+	evals(f.Evaler, `@cmds = (edit:command-history &dedup &newest-first &cmd-only)`)
+	testGlobal(t, f.Evaler,
+		"cmds",
+		vals.MakeList(
+			"echo 1",
+			"echo 3",
+			"echo 2",
+		))
 }
 
 func TestInsertLastWord(t *testing.T) {

--- a/pkg/edit/store_api_test.go
+++ b/pkg/edit/store_api_test.go
@@ -12,16 +12,56 @@ func TestCommandHistory(t *testing.T) {
 	f := setup(storeOp(func(s store.Store) {
 		s.AddCmd("echo 1")
 		s.AddCmd("echo 2")
+		s.AddCmd("echo 2")
+		s.AddCmd("echo 1")
+		s.AddCmd("echo 3")
+		s.AddCmd("echo 1")
 	}))
 	defer f.Cleanup()
 
-	// TODO(xiaq): Test session history too.
+	// TODO(xiaq): Test session history too. See NewHybridStore and NewMemStore.
+
 	evals(f.Evaler, `@cmds = (edit:command-history)`)
 	testGlobal(t, f.Evaler,
 		"cmds",
 		vals.MakeList(
 			vals.MakeMap("id", "1", "cmd", "echo 1"),
-			vals.MakeMap("id", "2", "cmd", "echo 2")))
+			vals.MakeMap("id", "2", "cmd", "echo 2"),
+			vals.MakeMap("id", "3", "cmd", "echo 2"),
+			vals.MakeMap("id", "4", "cmd", "echo 1"),
+			vals.MakeMap("id", "5", "cmd", "echo 3"),
+			vals.MakeMap("id", "6", "cmd", "echo 1"),
+		))
+
+	evals(f.Evaler, `@cmds = (edit:command-history &newest-first)`)
+	testGlobal(t, f.Evaler,
+		"cmds",
+		vals.MakeList(
+			vals.MakeMap("id", "6", "cmd", "echo 1"),
+			vals.MakeMap("id", "5", "cmd", "echo 3"),
+			vals.MakeMap("id", "4", "cmd", "echo 1"),
+			vals.MakeMap("id", "3", "cmd", "echo 2"),
+			vals.MakeMap("id", "2", "cmd", "echo 2"),
+			vals.MakeMap("id", "1", "cmd", "echo 1"),
+		))
+
+	evals(f.Evaler, `@cmds = (edit:command-history &dedup)`)
+	testGlobal(t, f.Evaler,
+		"cmds",
+		vals.MakeList(
+			vals.MakeMap("id", "3", "cmd", "echo 2"),
+			vals.MakeMap("id", "5", "cmd", "echo 3"),
+			vals.MakeMap("id", "6", "cmd", "echo 1"),
+		))
+
+	evals(f.Evaler, `@cmds = (edit:command-history &dedup &newest-first)`)
+	testGlobal(t, f.Evaler,
+		"cmds",
+		vals.MakeList(
+			vals.MakeMap("id", "6", "cmd", "echo 1"),
+			vals.MakeMap("id", "5", "cmd", "echo 3"),
+			vals.MakeMap("id", "3", "cmd", "echo 2"),
+		))
 }
 
 func TestInsertLastWord(t *testing.T) {

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -77,8 +77,8 @@ func cd(fm *Frame, args ...string) error {
 // dir-history
 // ```
 //
-// Return a list containing the directory history. Each element is a map with two
-// keys: `path` and `score`. The list is sorted by descending score.
+// Return a list containing the interactive directory history. Each element is a map with two keys:
+// `path` and `score`. The list is sorted by descending score.
 //
 // Example:
 //
@@ -86,6 +86,8 @@ func cd(fm *Frame, args ...string) error {
 // ~> dir-history | take 1
 // ▶ [&path=/Users/foo/.elvish &score=96.79928]
 // ```
+//
+// @cf edit:command-history
 
 type dirHistoryEntry struct {
 	Path  string


### PR DESCRIPTION
This implements `&dedup` and `&newest-first` options for
`edit:command-history`. This makes it noticably cheaper to feed unique
command history into external commands like `fzf`.

Related #1053
Fixes #568