### PR TITLE
Add a `&null` option to `from-lines` and `to-lines`

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -68,6 +68,10 @@ New features in the standard library:
 -   New options to the `edit:command-history` command: `&dedup`,
     `&newest-first`, and `&cmd-only` ([#1053](https://b.elv.sh/1053)).
 
+-   New `from-terminated` and `to-terminated` commands to allow efficient
+    streaming of lines terminated by ASCII NUL or other line terminators
+    ([#1070](https://b.elv.sh/1070)).
+
 New features in the interactive editor:
 
 -   The editor now supports setting global bindings via `$edit:global-binding`.

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -3,6 +3,7 @@ package eval_test
 import (
 	"testing"
 
+	"src.elv.sh/pkg/eval"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
 )
@@ -87,6 +88,14 @@ func TestFromLines(t *testing.T) {
 	)
 }
 
+func TestFromTerminated(t *testing.T) {
+	Test(t,
+		That(`print "a\nb\x00\x00c\x00d" | from-terminated "\x00"`).Puts("a\nb", "", "c", "d"),
+		That(`print aXbXcXXd | from-terminated "X"`).Puts("a", "b", "c", "", "d"),
+		That(`from-terminated "xyz"`).Throws(eval.ErrInvalidTerminator),
+	)
+}
+
 func TestFromJson(t *testing.T) {
 	Test(t,
 		That(`echo '{"k": "v", "a": [1, 2]}' '"foo"' | from-json`).
@@ -101,6 +110,14 @@ func TestFromJson(t *testing.T) {
 func TestToLines(t *testing.T) {
 	Test(t,
 		That(`put "l\norem" ipsum | to-lines`).Prints("l\norem\nipsum\n"),
+	)
+}
+
+func TestToTerminated(t *testing.T) {
+	Test(t,
+		That(`put "l\norem" ipsum | to-terminated "\x00"`).Prints("l\norem\x00ipsum\x00"),
+		That(`to-terminated "X" [a b c]`).Prints("aXbXcX"),
+		That(`to-terminated "XYZ" [a b c]`).Throws(eval.ErrInvalidTerminator),
 	)
 }
 

--- a/pkg/eval/frame.go
+++ b/pkg/eval/frame.go
@@ -152,6 +152,22 @@ func linesToChan(r io.Reader, ch chan<- interface{}) {
 	}
 }
 
+func terminatedToChan(r io.Reader, ch chan<- interface{}, terminator byte) {
+	filein := bufio.NewReader(r)
+	for {
+		line, err := filein.ReadString(terminator)
+		if line != "" {
+			ch <- strutil.ChopTerminator(line, terminator)
+		}
+		if err != nil {
+			if err != io.EOF {
+				logger.Println("error on reading:", err)
+			}
+			break
+		}
+	}
+}
+
 // fork returns a modified copy of ec. The ports are forked, and the name is
 // changed to the given value. Other fields are copied shallowly.
 func (fm *Frame) fork(name string) *Frame {

--- a/pkg/strutil/chop.go
+++ b/pkg/strutil/chop.go
@@ -1,11 +1,20 @@
 package strutil
 
-// ChopLineEnding removes a line ending ("\r\n" or "\n") from the end of s. It
-// returns itself if it doesn't end with a line ending.
+// ChopLineEnding removes a line ending ("\r\n" or "\n") from the end of `s`. It returns `s` if it
+// doesn't end with a line ending.
 func ChopLineEnding(s string) string {
-	if len(s) >= 2 && s[len(s)-2:] == "\r\n" {
+	if len(s) >= 2 && s[len(s)-2:] == "\r\n" { // Windows line ending
 		return s[:len(s)-2]
-	} else if len(s) >= 1 && s[len(s)-1] == '\n' {
+	} else if len(s) >= 1 && s[len(s)-1] == '\n' { // UNIX line ending
+		return s[:len(s)-1]
+	}
+	return s
+}
+
+// ChopTerminator removes a specific `terminator` byte from the end of `s`. It returns `s` if it
+// doesn't end with the specified terminator.
+func ChopTerminator(s string, terminator byte) string {
+	if len(s) >= 1 && s[len(s)-1] == terminator {
 		return s[:len(s)-1]
 	}
 	return s


### PR DESCRIPTION
This change, combined with other changes to `edit:command-history`,
makes feeding its output into `fzf` extremely fast. Which makes it a
practical alternative to using the builtin Ctrl-R binding for searching
command history. It's also just generally useful to have efficient ways
to process "lines" that are null terminated rather than newline (or
cr-nl on Windows).

Resolves #1070
Related #1053