### PR TITLE
Be consistent about sync.WaitGroup var naming

### DIFF
--- a/pkg/eval/compile_lvalue.go
+++ b/pkg/eval/compile_lvalue.go
@@ -90,7 +90,7 @@ func (cp *compiler) parseIndexingLValue(n *parse.Indexing) lvaluesGroup {
 	if sigil == "@" {
 		restIndex = 0
 	}
-	// TODO: Deal with other sigils when they exist.
+	// TODO: Support % (and other sigils?) if https://b.elv.sh/584 is implemented for map explosion.
 	return lvaluesGroup{[]lvalue{lv}, restIndex}
 }
 

--- a/pkg/eval/frame.go
+++ b/pkg/eval/frame.go
@@ -112,22 +112,22 @@ func (fm *Frame) ErrorFile() *os.File {
 
 // IterateInputs calls the passed function for each input element.
 func (fm *Frame) IterateInputs(f func(interface{})) {
-	var w sync.WaitGroup
+	var wg sync.WaitGroup
 	inputs := make(chan interface{})
 
-	w.Add(2)
+	wg.Add(2)
 	go func() {
 		linesToChan(fm.InputFile(), inputs)
-		w.Done()
+		wg.Done()
 	}()
 	go func() {
 		for v := range fm.ports[0].Chan {
 			inputs <- v
 		}
-		w.Done()
+		wg.Done()
 	}()
 	go func() {
-		w.Wait()
+		wg.Wait()
 		close(inputs)
 	}()
 

--- a/pkg/eval/mods/re/re_test.go
+++ b/pkg/eval/mods/re/re_test.go
@@ -39,10 +39,11 @@ func TestRe(t *testing.T) {
 		That("re:find '(' x").Throws(AnyError),
 
 		// Without any flag, finds ax
-		That("put (re:find 'a(x|xy)' axy)[text]").Puts("ax"),
+		That("put (re:find 'a(x|xy)' AaxyZ)[text]").Puts("ax"),
 		// With &longest, finds axy
-		That("put (re:find &longest 'a(x|xy)' axy)[text]").Puts("axy"),
-		// TODO: Test &posix
+		That("put (re:find &longest 'a(x|xy)' AaxyZ)[text]").Puts("axy"),
+		// Basic verification of &posix behavior.
+		That("put (re:find &posix 'a(x|xy)+' AaxyxxxyZ)[text]").Puts("axyxxxy"),
 
 		That("re:replace '(ba|z)sh' '${1}SH' 'bash and zsh'").Puts("baSH and zSH"),
 		That("re:replace &literal '(ba|z)sh' '$sh' 'bash and zsh'").Puts("$sh and $sh"),
@@ -50,6 +51,7 @@ func TestRe(t *testing.T) {
 
 		// Invalid pattern in re:replace
 		That("re:replace '(' x bash").Throws(AnyError),
+		That("re:replace &posix '[[:argle:]]' x bash").Throws(AnyError),
 		// Replacement function outputs more than one value
 		That("re:replace x [x]{ put a b } xx").Throws(AnyError),
 		// Replacement function outputs non-string value

--- a/pkg/eval/mods/unix/umask.go
+++ b/pkg/eval/mods/unix/umask.go
@@ -93,11 +93,9 @@ func (UmaskVariable) Set(v interface{}) error {
 	}
 
 	if umask < 0 || umask > 0o777 {
-		// TODO: Switch to `%O` when Go 1.15 is the minimum acceptable version.
-		// Until then the formatting of negative numbers will be weird.
 		return errs.OutOfRange{
 			What: "umask", ValidLow: "0", ValidHigh: "0o777",
-			Actual: fmt.Sprintf("0o%o", umask)}
+			Actual: fmt.Sprintf("%O", umask)}
 	}
 
 	umaskMutex.Lock()

--- a/pkg/eval/mods/unix/umask_test.go
+++ b/pkg/eval/mods/unix/umask_test.go
@@ -53,13 +53,9 @@ func TestUmask(t *testing.T) {
 			What: "umask", Valid: validUmaskMsg, Actual: "[1]"}),
 
 		// Values outside the legal range should raise the expected exception.
-		//
-		// TODO: Switch to `%O` when Go 1.15 is the minimum acceptable version.
-		// Until then the formatting of negative numbers will be weird.
 		That(`unix:umask = 0o1000`).Throws(errs.OutOfRange{
 			What: "umask", ValidLow: "0", ValidHigh: "0o777", Actual: "0o1000"}),
-
 		That(`unix:umask = -1`).Throws(errs.OutOfRange{
-			What: "umask", ValidLow: "0", ValidHigh: "0o777", Actual: "0o-1"}),
+			What: "umask", ValidLow: "0", ValidHigh: "0o777", Actual: "-0o1"}),
 	)
 }

--- a/pkg/eval/var_parse.go
+++ b/pkg/eval/var_parse.go
@@ -7,9 +7,9 @@ func SplitSigil(ref string) (sigil string, qname string) {
 	if ref == "" {
 		return "", ""
 	}
+	// TODO: Support % (and other sigils?) if https://b.elv.sh/584 is implemented for map explosion.
 	switch ref[0] {
 	case '@':
-		// TODO(xiaq): Support % later.
 		return ref[:1], ref[1:]
 	default:
 		return "", ref


### PR DESCRIPTION
Also, remove the unused dbStore.Waits() method. This came to my
attention while writing `peach` unit tests.