### PR TITLE
Fix bug identified by staticcheck

### DIFF
--- a/pkg/cli/term/file_reader_unix.go
+++ b/pkg/cli/term/file_reader_unix.go
@@ -70,9 +70,9 @@ func (r *bReader) ReadByteWithTimeout(timeout time.Duration) (byte, error) {
 }
 
 func (r *bReader) Stop() error {
-	_, err := r.wStop.Write([]byte{'q'})
 	r.mutex.Lock()
-	r.mutex.Unlock()
+	defer r.mutex.Unlock()
+	_, err := r.wStop.Write([]byte{'q'})
 	return err
 }
 


### PR DESCRIPTION
This resolves this staticcheck warning:

    pkg/cli/term/file_reader_unix.go:75:2: empty critical section (SA2001)