### PR TITLE
Exercise testutil.MustPipe

### DIFF
--- a/pkg/cli/term/file_reader_unix_test.go
+++ b/pkg/cli/term/file_reader_unix_test.go
@@ -70,10 +70,7 @@ func TestFileReader_Stop(t *testing.T) {
 }
 
 func setupFileReader() (reader fileReader, writer *os.File, cleanup func()) {
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
+	pr, pw := testutil.MustPipe()
 	r, err := newFileReader(pr)
 	if err != nil {
 		panic(err)

--- a/pkg/eval/vals/pipe_test.go
+++ b/pkg/eval/vals/pipe_test.go
@@ -2,25 +2,22 @@ package vals
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"src.elv.sh/pkg/persistent/hash"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestPipe(t *testing.T) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	defer r.Close()
-	defer w.Close()
+	pr, pw := testutil.MustPipe()
+	defer pr.Close()
+	defer pw.Close()
 
-	TestValue(t, NewPipe(r, w)).
+	TestValue(t, NewPipe(pr, pw)).
 		Kind("pipe").
 		Bool(true).
-		Hash(hash.DJB(hash.UIntPtr(r.Fd()), hash.UIntPtr(w.Fd()))).
-		Repr(fmt.Sprintf("<pipe{%v %v}>", r.Fd(), w.Fd())).
-		Equal(NewPipe(r, w)).
-		NotEqual(123, "a string", NewPipe(w, r))
+		Hash(hash.DJB(hash.UIntPtr(pr.Fd()), hash.UIntPtr(pw.Fd()))).
+		Repr(fmt.Sprintf("<pipe{%v %v}>", pr.Fd(), pw.Fd())).
+		Equal(NewPipe(pr, pw)).
+		NotEqual(123, "a string", NewPipe(pw, pr))
 }

--- a/pkg/sys/waitforread_unix_test.go
+++ b/pkg/sys/waitforread_unix_test.go
@@ -4,15 +4,14 @@ package sys
 
 import (
 	"io"
-	"os"
 	"testing"
+
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestWaitForRead(t *testing.T) {
-	r0, w0, err := os.Pipe()
-	mustNil(err)
-	r1, w1, err := os.Pipe()
-	mustNil(err)
+	r0, w0 := testutil.MustPipe()
+	r1, w1 := testutil.MustPipe()
 	defer closeAll(r0, w0, r1, w1)
 
 	w0.WriteString("x")


### PR DESCRIPTION
I noticed that testutit.MustPipe was not covered by any unit tests. This
changes the handful of places that should use it and therefore changes
the coverage of pkg/testutil/must.go from 61.5% to 73.1%. There isn't any
way to increase that further without explicitly testing the panic paths.