### PR TITLE
Implement case insensitive command and file completion for Windows

### DIFF
--- a/pkg/cli/lscolors/feature.go
+++ b/pkg/cli/lscolors/feature.go
@@ -2,6 +2,8 @@ package lscolors
 
 import (
 	"os"
+
+	"src.elv.sh/pkg/fsutil"
 )
 
 type feature int
@@ -37,8 +39,7 @@ const (
 // Weirdly, permission masks for group and other are missing on platforms other
 // than linux, darwin and netbsd. So we replicate some of them here.
 const (
-	worldWritable = 02   // Writable by other
-	executable    = 0111 // Executable
+	worldWritable = 02 // Writable by other
 )
 
 func determineFeature(fname string, mh bool) (feature, error) {
@@ -105,7 +106,7 @@ func determineFeature(fname string, mh bool) (feature, error) {
 		return featureSetuid, nil
 	case is(m, os.ModeSetgid):
 		return featureSetgid, nil
-	case m&executable != 0:
+	case fsutil.IsExecutableByInfo(stat):
 		return featureExecutable, nil
 	}
 

--- a/pkg/edit/complete/complete.go
+++ b/pkg/edit/complete/complete.go
@@ -50,6 +50,7 @@ type Result struct {
 // RawItem represents completion items before the quoting pass.
 type RawItem interface {
 	String() string
+	HasPrefix(seed string) bool
 	Cook(parse.PrimaryType) modes.CompletionItem
 }
 

--- a/pkg/edit/complete/filterers.go
+++ b/pkg/edit/complete/filterers.go
@@ -1,13 +1,11 @@
 package complete
 
-import "strings"
-
 // FilterPrefix filters raw items by prefix. It can be used as a Filterer in
 // Config.
 func FilterPrefix(ctxName, seed string, items []RawItem) []RawItem {
 	var filtered []RawItem
 	for _, cand := range items {
-		if strings.HasPrefix(cand.String(), seed) {
+		if cand.HasPrefix(seed) {
 			filtered = append(filtered, cand)
 		}
 	}

--- a/pkg/edit/complete/raw_item.go
+++ b/pkg/edit/complete/raw_item.go
@@ -1,6 +1,8 @@
 package complete
 
 import (
+	"strings"
+
 	"src.elv.sh/pkg/cli/modes"
 	"src.elv.sh/pkg/parse"
 	"src.elv.sh/pkg/ui"
@@ -11,8 +13,49 @@ type PlainItem string
 
 func (p PlainItem) String() string { return string(p) }
 
+func (p PlainItem) HasPrefix(seed string) bool { return strings.HasPrefix(string(p), seed) }
+
 func (p PlainItem) Cook(q parse.PrimaryType) modes.CompletionItem {
 	s := string(p)
+	quoted, _ := parse.QuoteAs(s, q)
+	return modes.CompletionItem{ToInsert: quoted, ToShow: s}
+}
+
+// ExternalCommand implements RawItem for external commands. On Windows, this
+// will be case insensitive
+type ExternalCommand struct {
+	Name         string
+	IsNamespaced bool
+}
+
+func (e ExternalCommand) String() string {
+	if e.IsNamespaced {
+		return "e:" + e.Name
+	} else {
+		return e.Name
+	}
+}
+
+func (e ExternalCommand) HasPrefix(seed string) bool {
+	if IsCaseInsensitiveOs {
+		if e.IsNamespaced {
+			return strings.HasPrefix(seed, "e:") &&
+				strings.HasPrefix(strings.ToLower(e.Name), strings.ToLower(seed[2:]))
+		} else {
+			return strings.HasPrefix(strings.ToLower(e.Name), strings.ToLower(seed))
+		}
+	} else {
+		if e.IsNamespaced {
+			return strings.HasPrefix(seed, "e:") &&
+				strings.HasPrefix(e.Name, seed[2:])
+		} else {
+			return strings.HasPrefix(e.Name, seed)
+		}
+	}
+}
+
+func (e ExternalCommand) Cook(q parse.PrimaryType) modes.CompletionItem {
+	s := e.String()
 	quoted, _ := parse.QuoteAs(s, q)
 	return modes.CompletionItem{ToInsert: quoted, ToShow: s}
 }
@@ -23,6 +66,8 @@ type noQuoteItem string
 
 func (nq noQuoteItem) String() string { return string(nq) }
 
+func (nq noQuoteItem) HasPrefix(seed string) bool { return strings.HasPrefix(string(nq), seed) }
+
 func (nq noQuoteItem) Cook(parse.PrimaryType) modes.CompletionItem {
 	s := string(nq)
 	return modes.CompletionItem{ToInsert: s, ToShow: s}
@@ -30,13 +75,22 @@ func (nq noQuoteItem) Cook(parse.PrimaryType) modes.CompletionItem {
 
 // ComplexItem is an implementation of RawItem that offers customization options.
 type ComplexItem struct {
-	Stem         string   // Used in the code and the menu.
-	CodeSuffix   string   // Appended to the code.
-	Display      string   // How the item is displayed. If empty, defaults to Stem.
-	DisplayStyle ui.Style // Use for displaying.
+	Stem            string   // Used in the code and the menu.
+	CaseInsensitive bool     // Whether to also match casing
+	CodeSuffix      string   // Appended to the code.
+	Display         string   // How the item is displayed. If empty, defaults to Stem.
+	DisplayStyle    ui.Style // Use for displaying.
 }
 
 func (c ComplexItem) String() string { return c.Stem }
+
+func (c ComplexItem) HasPrefix(seed string) bool {
+	if c.CaseInsensitive {
+		return strings.HasPrefix(strings.ToLower(c.Stem), strings.ToLower(seed))
+	} else {
+		return strings.HasPrefix(c.Stem, seed)
+	}
+}
 
 func (c ComplexItem) Cook(q parse.PrimaryType) modes.CompletionItem {
 	quoted, _ := parse.QuoteAs(c.Stem, q)

--- a/pkg/edit/complete/util_unix.go
+++ b/pkg/edit/complete/util_unix.go
@@ -1,0 +1,5 @@
+// +build !windows,!plan9
+
+package complete
+
+const IsCaseInsensitiveOs bool = false

--- a/pkg/edit/complete/util_windows.go
+++ b/pkg/edit/complete/util_windows.go
@@ -1,0 +1,3 @@
+package complete
+
+const IsCaseInsensitiveOs bool = true

--- a/pkg/edit/completion_test.go
+++ b/pkg/edit/completion_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/cli/term"
+	"src.elv.sh/pkg/edit/complete"
 	"src.elv.sh/pkg/eval"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
@@ -57,8 +58,8 @@ func TestCompleteFilename(t *testing.T) {
 	testGlobal(t, f.Evaler,
 		"cands",
 		vals.MakeList(
-			complexItem{Stem: "./d/a", CodeSuffix: " "},
-			complexItem{Stem: "./d/b", CodeSuffix: " "}))
+			complexItem{Stem: "./d/a", CodeSuffix: " ", CaseInsensitive: complete.IsCaseInsensitiveOs},
+			complexItem{Stem: "./d/b", CodeSuffix: " ", CaseInsensitive: complete.IsCaseInsensitiveOs}))
 
 	testThatOutputErrorIsBubbled(t, f, "edit:complete-filename ls ''")
 }
@@ -68,9 +69,9 @@ func TestComplexCandidate(t *testing.T) {
 		ev.AddGlobal(eval.NsBuilder{}.AddGoFn("", "cc", complexCandidate).Ns())
 	},
 		That("kind-of (cc stem)").Puts("map"),
-		That("keys (cc stem)").Puts("stem", "code-suffix", "display"),
-		That("repr (cc a/b &code-suffix=' ' &display=A/B)").Prints(
-			"(edit:complex-candidate a/b &code-suffix=' ' &display=A/B)\n"),
+		That("keys (cc stem)").Puts("stem", "case-insensitive", "code-suffix", "display"),
+		That("repr (cc a/b &code-suffix=' ' &display=A/B &case-insensitive=$false)").Prints(
+			"(edit:complex-candidate a/b &code-suffix=' ' &display=A/B &case-insensitive=$false)\n"),
 		That("eq (cc stem) (cc stem)").Puts(true),
 		That("eq (cc stem &code-suffix=' ') (cc stem)").Puts(false),
 		That("eq (cc stem &display=STEM) (cc stem)").Puts(false),

--- a/pkg/edit/highlight.go
+++ b/pkg/edit/highlight.go
@@ -100,7 +100,7 @@ func hasFn(ns *eval.Ns, name string) bool {
 
 func isDirOrExecutable(fname string) bool {
 	stat, err := os.Stat(fname)
-	return err == nil && (stat.IsDir() || stat.Mode()&0111 != 0)
+	return err == nil && (stat.IsDir() || fsutil.IsExecutableByInfo(stat))
 }
 
 func hasExternalCommand(cmd string) bool {

--- a/pkg/fsutil/fsutil_unix.go
+++ b/pkg/fsutil/fsutil_unix.go
@@ -1,0 +1,19 @@
+// +build !windows,!plan9
+
+package fsutil
+
+import "os"
+
+// IsExecutable determines whether path refers to an executable file.
+func IsExecutable(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return IsExecutableByInfo(fi)
+}
+
+func IsExecutableByInfo(info os.FileInfo) bool {
+	fm := info.Mode()
+	return !fm.IsDir() && (fm&0111 != 0)
+}

--- a/pkg/fsutil/fsutil_windows.go
+++ b/pkg/fsutil/fsutil_windows.go
@@ -1,0 +1,16 @@
+package fsutil
+
+import (
+	"os"
+	"path"
+)
+
+// IsExecutable determines whether path refers to an executable file.
+func IsExecutable(pathStr string) bool {
+	ext := path.Ext(pathStr)
+	return ext == ".exe" || ext == ".cmd" || ext == ".bat"
+}
+
+func IsExecutableByInfo(info os.FileInfo) bool {
+	return IsExecutable(info.Name())
+}

--- a/pkg/fsutil/search.go
+++ b/pkg/fsutil/search.go
@@ -15,38 +15,26 @@ func DontSearch(exe string) bool {
 		strings.ContainsRune(exe, '/')
 }
 
-// IsExecutable determines whether path refers to an executable file.
-func IsExecutable(path string) bool {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	fm := fi.Mode()
-	return !fm.IsDir() && (fm&0111 != 0)
-}
-
 // EachExternal calls f for each name that can resolve to an external command.
 //
 // BUG: EachExternal may generate the same command multiple command it it
 // appears in multiple directories in PATH.
-//
-// BUG: EachExternal doesn't work on Windows since it relies on the execution
-// permission bit, which doesn't exist on Windows.
 func EachExternal(f func(string)) {
 	for _, dir := range searchPaths() {
+		// TODO(xiaq): Ignore error.
 		files, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}
 		for _, file := range files {
 			info, err := file.Info()
-			if err == nil && !info.IsDir() && (info.Mode()&0111 != 0) {
-				f(file.Name())
+			if err == nil && IsExecutableByInfo(info) {
+				f(info.Name())
 			}
 		}
 	}
 }
 
 func searchPaths() []string {
-	return strings.Split(os.Getenv(env.PATH), ":")
+	return strings.Split(os.Getenv(env.PATH), string(filepath.ListSeparator))
 }

--- a/pkg/fsutil/search_windows_test.go
+++ b/pkg/fsutil/search_windows_test.go
@@ -1,6 +1,3 @@
-//go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
-
 package fsutil
 
 import (
@@ -14,18 +11,18 @@ import (
 func TestEachExternal(t *testing.T) {
 	binPath := testutil.InTempDir(t)
 
-	testutil.Setenv(t, "PATH", "/foo:"+binPath+":/bar")
+	testutil.Setenv(t, "PATH", "Z:\\foo;"+binPath+";Z:\\bar")
 
 	testutil.ApplyDir(testutil.Dir{
-		"dir":  testutil.Dir{},
-		"file": "",
-		"cmdx": "#!/bin/sh",
-		"cmd1": testutil.File{Perm: 0755, Content: "#!/bin/sh"},
-		"cmd2": testutil.File{Perm: 0755, Content: "#!/bin/sh"},
-		"cmd3": testutil.File{Perm: 0755, Content: ""},
+		"dir":      testutil.Dir{},
+		"file.txt": "",
+		"cmd.bat":  testutil.File{Perm: 0755, Content: ""},
+		"cmd.cmd":  testutil.File{Perm: 0755, Content: ""},
+		"cmd.exe":  "",
+		"cmd.txt":  testutil.File{Perm: 0755, Content: ""},
 	})
 
-	wantCmds := []string{"cmd1", "cmd2", "cmd3"}
+	wantCmds := []string{"cmd.bat", "cmd.cmd", "cmd.exe"}
 	gotCmds := []string{}
 	EachExternal(func(cmd string) { gotCmds = append(gotCmds, cmd) })
 


### PR DESCRIPTION
This changes the following core mechanics:

- Determining file executability: On UNIXoids this still looks at the executable bit. On Windows, it checks the file extension for `.exe`, `.bat` and `.cmd`
- Filtering completion candidates: Prefix checking has been moved into `RawItem` to enable case insensitive matching for commands and files on Windows.
  - This also introduced the option `CaseInsensitive` to `ComplexItem` to facilitate file name matching, but it can be used for various other purposes, too.

Caveat: At least Linux supports mounting with case insensitivity. This hasn't been implemented here, as this would require to somehow check if the directory to be enumerated is mounted that way. It's also probably used very seldomly.