### PR TITLE
Fix oldest command being ignored in `edit:command-history &dedup`

### DIFF
--- a/pkg/edit/store_api.go
+++ b/pkg/edit/store_api.go
@@ -76,7 +76,7 @@ func dedupCmds(allCmds []store.Cmd, newestFirst bool) []store.Cmd {
 	// Capacity allocation below is based on some personal empirical observation.
 	uniqCmds := make([]store.Cmd, 0, len(allCmds)/4)
 	seenCmds := make(map[string]bool, len(allCmds)/4)
-	for i := len(allCmds) - 1; i != 0; i-- {
+	for i := len(allCmds) - 1; i >= 0; i-- {
 		if !seenCmds[allCmds[i].Text] {
 			seenCmds[allCmds[i].Text] = true
 			uniqCmds = append(uniqCmds, allCmds[i])

--- a/pkg/edit/store_api_test.go
+++ b/pkg/edit/store_api_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestCommandHistory(t *testing.T) {
 	f := setup(storeOp(func(s store.Store) {
+		s.AddCmd("echo 0")
 		s.AddCmd("echo 1")
 		s.AddCmd("echo 2")
 		s.AddCmd("echo 2")
@@ -25,42 +26,46 @@ func TestCommandHistory(t *testing.T) {
 	testGlobal(t, f.Evaler,
 		"cmds",
 		vals.MakeList(
-			cmdMap(1, "echo 1"),
-			cmdMap(2, "echo 2"),
+			cmdMap(1, "echo 0"),
+			cmdMap(2, "echo 1"),
 			cmdMap(3, "echo 2"),
-			cmdMap(4, "echo 1"),
-			cmdMap(5, "echo 3"),
-			cmdMap(6, "echo 1"),
+			cmdMap(4, "echo 2"),
+			cmdMap(5, "echo 1"),
+			cmdMap(6, "echo 3"),
+			cmdMap(7, "echo 1"),
 		))
 
 	evals(f.Evaler, `@cmds = (edit:command-history &newest-first)`)
 	testGlobal(t, f.Evaler,
 		"cmds",
 		vals.MakeList(
-			cmdMap(6, "echo 1"),
-			cmdMap(5, "echo 3"),
-			cmdMap(4, "echo 1"),
+			cmdMap(7, "echo 1"),
+			cmdMap(6, "echo 3"),
+			cmdMap(5, "echo 1"),
+			cmdMap(4, "echo 2"),
 			cmdMap(3, "echo 2"),
-			cmdMap(2, "echo 2"),
-			cmdMap(1, "echo 1"),
+			cmdMap(2, "echo 1"),
+			cmdMap(1, "echo 0"),
 		))
 
 	evals(f.Evaler, `@cmds = (edit:command-history &dedup)`)
 	testGlobal(t, f.Evaler,
 		"cmds",
 		vals.MakeList(
-			cmdMap(3, "echo 2"),
-			cmdMap(5, "echo 3"),
-			cmdMap(6, "echo 1"),
+			cmdMap(1, "echo 0"),
+			cmdMap(4, "echo 2"),
+			cmdMap(6, "echo 3"),
+			cmdMap(7, "echo 1"),
 		))
 
 	evals(f.Evaler, `@cmds = (edit:command-history &dedup &newest-first)`)
 	testGlobal(t, f.Evaler,
 		"cmds",
 		vals.MakeList(
-			cmdMap(6, "echo 1"),
-			cmdMap(5, "echo 3"),
-			cmdMap(3, "echo 2"),
+			cmdMap(7, "echo 1"),
+			cmdMap(6, "echo 3"),
+			cmdMap(4, "echo 2"),
+			cmdMap(1, "echo 0"),
 		))
 
 	evals(f.Evaler, `@cmds = (edit:command-history &dedup &newest-first &cmd-only)`)
@@ -70,6 +75,7 @@ func TestCommandHistory(t *testing.T) {
 			"echo 1",
 			"echo 3",
 			"echo 2",
+			"echo 0",
 		))
 }
 


### PR DESCRIPTION
The loop iteration was stopping at i == 0 and so allCmds[0] was never
examined.