### PR TITLE
Replace ErrArgs with more specific errors

### DIFF
--- a/pkg/eval/builtin_fn_cmd.go
+++ b/pkg/eval/builtin_fn_cmd.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"src.elv.sh/pkg/eval/errs"
 )
 
 // Command and process control.
@@ -101,7 +103,7 @@ func exit(fm *Frame, codes ...int) error {
 	case 1:
 		code = codes[0]
 	default:
-		return ErrArgs
+		return errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: len(codes)}
 	}
 
 	preExit(fm)

--- a/pkg/eval/builtin_fn_cmd_unix.go
+++ b/pkg/eval/builtin_fn_cmd_unix.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"src.elv.sh/pkg/env"
+	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vals"
 	"src.elv.sh/pkg/sys"
 )
@@ -65,7 +66,7 @@ func decSHLVL() {
 
 func fg(pids ...int) error {
 	if len(pids) == 0 {
-		return ErrArgs
+		return errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: len(pids)}
 	}
 	var thepgid int
 	for i, pid := range pids {

--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -195,7 +195,7 @@ func rangeFn(fm *Frame, opts rangeOpts, args ...vals.Num) error {
 	case 2:
 		rawNums = []vals.Num{args[0], args[1], opts.Step}
 	default:
-		return ErrArgs
+		return errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: 2, Actual: len(args)}
 	}
 	switch step := opts.Step.(type) {
 	case int:
@@ -656,8 +656,7 @@ func count(fm *Frame, args ...interface{}) (int, error) {
 	default:
 		// The error matches what would be returned if the `Inputs` API was
 		// used. See GoFn.Call().
-		return 0, errs.ArityMismatch{
-			What: "arguments here", ValidLow: 0, ValidHigh: 1, Actual: nargs}
+		return 0, errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: nargs}
 	}
 	return n, nil
 }

--- a/pkg/eval/builtin_fn_container_test.go
+++ b/pkg/eval/builtin_fn_container_test.go
@@ -171,8 +171,7 @@ func TestCount(t *testing.T) {
 		That(`count [(range 100)]`).Puts(100),
 		That(`count 123`).Puts(3),
 		That(`count 1 2 3`).Throws(
-			errs.ArityMismatch{
-				What: "arguments here", ValidLow: 0, ValidHigh: 1, Actual: 3},
+			errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: 3},
 			"count 1 2 3"),
 		That(`count $true`).Throws(ErrorWithMessage("cannot get length of a bool")),
 	)

--- a/pkg/eval/builtin_fn_fs.go
+++ b/pkg/eval/builtin_fn_fs.go
@@ -5,6 +5,8 @@ import (
 
 	"src.elv.sh/pkg/fsutil"
 	"src.elv.sh/pkg/store"
+
+	"src.elv.sh/pkg/eval/errs"
 )
 
 // Filesystem commands.
@@ -65,7 +67,7 @@ func cd(fm *Frame, args ...string) error {
 	case 1:
 		dir = args[0]
 	default:
-		return ErrArgs
+		return errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: len(args)}
 	}
 
 	return fm.Evaler.Chdir(dir)

--- a/pkg/eval/builtin_fn_fs_test.go
+++ b/pkg/eval/builtin_fn_fs_test.go
@@ -10,6 +10,7 @@ import (
 	. "src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/testutil"
 
+	"src.elv.sh/pkg/eval/errs"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/fsutil"
 	"src.elv.sh/pkg/parse"
@@ -46,7 +47,7 @@ func TestCd(t *testing.T) {
 	defer func() { fsutil.CurrentUser = user.Current }()
 
 	Test(t,
-		That(`cd dir1 dir2`).Throws(ErrArgs, "cd dir1 dir2"),
+		That(`cd dir1 dir2`).Throws(ErrorWithType(errs.ArityMismatch{}), "cd dir1 dir2"),
 		// Basic `cd` test and verification that `$pwd` is correct.
 		That(`old = $pwd; cd `+d1Path+`; put $pwd; cd $old; eq $old $pwd`).Puts(d1Path, true),
 		// Verify that `cd` with no arg defaults to the home directory.

--- a/pkg/eval/builtin_fn_io.go
+++ b/pkg/eval/builtin_fn_io.go
@@ -17,6 +17,8 @@ import (
 
 // Input and output.
 
+var ErrInvalidTerminator = errors.New("terminator must be a single ASCII char")
+
 func init() {
 	addBuiltinFns(map[string]interface{}{
 		// Value output
@@ -121,7 +123,7 @@ func put(fm *Frame, args ...interface{}) {
 
 func readUpto(fm *Frame, terminator string) (string, error) {
 	if len(terminator) != 1 || terminator[0] > 127 {
-		return "", ErrArgs
+		return "", ErrInvalidTerminator
 	}
 	in := fm.InputFile()
 	var buf []byte
@@ -714,8 +716,6 @@ func fromJSONInterface(v interface{}) (interface{}, error) {
 // ```
 //
 // @cf from-lines read-upto to-terminated
-
-var ErrInvalidTerminator = errors.New("terminator must be a single ASCII char")
 
 func fromTerminated(fm *Frame, terminator string) error {
 	if len(terminator) != 1 || terminator[0] > 127 {

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -22,6 +22,7 @@ func TestReadUpto(t *testing.T) {
 		That("print abcd | { read-upto c; slurp }").Puts("abc", "d"),
 		// read-upto reads up to EOF
 		That("print abcd | read-upto z").Puts("abcd"),
+		That("print abcd | read-upto cd").Throws(eval.ErrInvalidTerminator),
 	)
 }
 

--- a/pkg/eval/builtin_fn_num.go
+++ b/pkg/eval/builtin_fn_num.go
@@ -1,6 +1,8 @@
 package eval
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"math/rand"
@@ -342,10 +344,7 @@ func add(rawNums ...vals.Num) vals.Num {
 
 func sub(rawNums ...vals.Num) (vals.Num, error) {
 	if len(rawNums) == 0 {
-		return nil, errs.ArityMismatch{
-			What:     "arguments here",
-			ValidLow: 1, ValidHigh: -1, Actual: 0,
-		}
+		return nil, errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0}
 	}
 
 	nums := vals.UnifyNums(rawNums, vals.BigInt)
@@ -588,9 +587,12 @@ func rem(a, b int) (int, error) {
 // ▶ 6
 // ```
 
+var ErrRandIntArgs = errors.New("$low >= $high")
+
 func randint(low, high int) (int, error) {
 	if low >= high {
-		return 0, ErrArgs
+		return 0, errs.BadValue{What: "low value",
+			Valid: fmt.Sprintf("less than %d", high), Actual: fmt.Sprintf("%d", low)}
 	}
 	return low + rand.Intn(high-low), nil
 }

--- a/pkg/eval/builtin_fn_num_test.go
+++ b/pkg/eval/builtin_fn_num_test.go
@@ -220,7 +220,7 @@ func TestRandint(t *testing.T) {
 	Test(t,
 		That("randint 1 2").Puts(1),
 		That("i = (randint 10 100); >= $i 10; < $i 100").Puts(true, true),
-		That("randint 2 1").Throws(ErrArgs, "randint 2 1"),
+		That("randint 2 1").Throws(ErrorWithType(errs.BadValue{}), "randint 2 1"),
 		That("randint").Throws(ErrorWithType(errs.ArityMismatch{}), "randint"),
 		That("randint 1").Throws(ErrorWithType(errs.ArityMismatch{}), "randint 1"),
 		That("randint 1 2 3").Throws(ErrorWithType(errs.ArityMismatch{}), "randint 1 2 3"),

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -201,8 +201,7 @@ func TestFor(t *testing.T) {
 		That("for x [][0] { }").Throws(ErrorWithType(errs.OutOfRange{}), "[][0]"),
 		// More than one iterable.
 		That("for x (put a b) { }").Throws(
-			errs.ArityMismatch{
-				What:     "value being iterated",
+			errs.ArityMismatch{What: "value being iterated",
 				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"(put a b)"),
 	)

--- a/pkg/eval/closure.go
+++ b/pkg/eval/closure.go
@@ -56,14 +56,12 @@ func (c *closure) Call(fm *Frame, args []interface{}, opts map[string]interface{
 	// Check number of arguments.
 	if c.RestArg != -1 {
 		if len(args) < len(c.ArgNames)-1 {
-			return errs.ArityMismatch{
-				What:     "arguments here",
+			return errs.ArityMismatch{What: "arguments",
 				ValidLow: len(c.ArgNames) - 1, ValidHigh: -1, Actual: len(args)}
 		}
 	} else {
 		if len(args) != len(c.ArgNames) {
-			return errs.ArityMismatch{
-				What:     "arguments here",
+			return errs.ArityMismatch{What: "arguments",
 				ValidLow: len(c.ArgNames), ValidHigh: len(c.ArgNames), Actual: len(args)}
 		}
 	}

--- a/pkg/eval/closure_test.go
+++ b/pkg/eval/closure_test.go
@@ -19,19 +19,14 @@ func TestClosureAsValue(t *testing.T) {
 
 		// Argument arity mismatch.
 		That("f = [x]{ }", "$f a b").Throws(
-			errs.ArityMismatch{
-				What:     "arguments here",
+			errs.ArityMismatch{What: "arguments",
 				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"$f a b"),
 		That("f = [x y]{ }", "$f a").Throws(
-			errs.ArityMismatch{
-				What:     "arguments here",
-				ValidLow: 2, ValidHigh: 2, Actual: 1},
+			errs.ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: 2, Actual: 1},
 			"$f a"),
 		That("f = [x y @rest]{ }", "$f a").Throws(
-			errs.ArityMismatch{
-				What:     "arguments here",
-				ValidLow: 2, ValidHigh: -1, Actual: 1},
+			errs.ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: -1, Actual: 1},
 			"$f a"),
 
 		// Unsupported option.

--- a/pkg/eval/compile_effect_test.go
+++ b/pkg/eval/compile_effect_test.go
@@ -46,8 +46,8 @@ func TestCommand(t *testing.T) {
 		That("put foo").Puts("foo"),
 		// Command errors when the head is not a single value.
 		That("{put put} foo").Throws(
-			errs.ArityMismatch{
-				What: "command", ValidLow: 1, ValidHigh: 1, Actual: 2},
+			errs.ArityMismatch{What: "command",
+				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"{put put}"),
 		// Command errors when the head is not callable or string containing slash.
 		That("[] foo").Throws(
@@ -141,18 +141,15 @@ func TestCommand_Assignment(t *testing.T) {
 		That("try { } except nil { }").DoesNothing(),
 		// Arity mismatch.
 		That("x = 1 2").Throws(
-			errs.ArityMismatch{
-				What:     "assignment right-hand-side",
+			errs.ArityMismatch{What: "assignment right-hand-side",
 				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"x = 1 2"),
 		That("x y = 1").Throws(
-			errs.ArityMismatch{
-				What:     "assignment right-hand-side",
+			errs.ArityMismatch{What: "assignment right-hand-side",
 				ValidLow: 2, ValidHigh: 2, Actual: 1},
 			"x y = 1"),
 		That("x y @z = 1").Throws(
-			errs.ArityMismatch{
-				What:     "assignment right-hand-side",
+			errs.ArityMismatch{What: "assignment right-hand-side",
 				ValidLow: 2, ValidHigh: -1, Actual: 1},
 			"x y @z = 1"),
 

--- a/pkg/eval/compile_lvalue.go
+++ b/pkg/eval/compile_lvalue.go
@@ -117,8 +117,7 @@ func (op *assignOp) exec(fm *Frame) Exception {
 
 	if op.lhs.rest == -1 {
 		if len(variables) != len(values) {
-			return fm.errorp(op, errs.ArityMismatch{
-				What:     "assignment right-hand-side",
+			return fm.errorp(op, errs.ArityMismatch{What: "assignment right-hand-side",
 				ValidLow: len(variables), ValidHigh: len(variables), Actual: len(values)})
 		}
 		for i, variable := range variables {
@@ -129,8 +128,7 @@ func (op *assignOp) exec(fm *Frame) Exception {
 		}
 	} else {
 		if len(values) < len(variables)-1 {
-			return fm.errorp(op, errs.ArityMismatch{
-				What:     "assignment right-hand-side",
+			return fm.errorp(op, errs.ArityMismatch{What: "assignment right-hand-side",
 				ValidLow: len(variables) - 1, ValidHigh: -1, Actual: len(values)})
 		}
 		rest := op.lhs.rest

--- a/pkg/eval/compile_value.go
+++ b/pkg/eval/compile_value.go
@@ -573,8 +573,8 @@ func evalForValue(fm *Frame, op valuesOp, what string) (interface{}, Exception) 
 		return nil, exc
 	}
 	if len(values) != 1 {
-		return nil, fm.errorp(op, errs.ArityMismatch{
-			What: what, ValidLow: 1, ValidHigh: 1, Actual: len(values)})
+		return nil, fm.errorp(op, errs.ArityMismatch{What: what,
+			ValidLow: 1, ValidHigh: 1, Actual: len(values)})
 	}
 	return values[0], nil
 }

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -219,8 +219,7 @@ func TestClosure(t *testing.T) {
 		That("[&a=[][0]]{ }").Throws(ErrorWithType(errs.OutOfRange{}), "[][0]"),
 		// Option default value must be one value.
 		That("[&a=(put foo bar)]{ }").Throws(
-			errs.ArityMismatch{
-				What: "option default value", ValidLow: 1, ValidHigh: 1, Actual: 2},
+			errs.ArityMismatch{What: "option default value", ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"(put foo bar)"),
 	)
 }

--- a/pkg/eval/errs/errs_test.go
+++ b/pkg/eval/errs/errs_test.go
@@ -21,16 +21,16 @@ var errorMessageTests = []struct {
 		"bad value: command must be callable, but is number",
 	},
 	{
-		ArityMismatch{What: "arguments here", ValidLow: 2, ValidHigh: 2, Actual: 3},
-		"arity mismatch: arguments here must be 2 values, but is 3 values",
+		ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: 2, Actual: 3},
+		"arity mismatch: arguments must be 2 values, but is 3 values",
 	},
 	{
-		ArityMismatch{What: "arguments here", ValidLow: 2, ValidHigh: -1, Actual: 1},
-		"arity mismatch: arguments here must be 2 or more values, but is 1 value",
+		ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: -1, Actual: 1},
+		"arity mismatch: arguments must be 2 or more values, but is 1 value",
 	},
 	{
-		ArityMismatch{What: "arguments here", ValidLow: 2, ValidHigh: 3, Actual: 1},
-		"arity mismatch: arguments here must be 2 to 3 values, but is 1 value",
+		ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: 3, Actual: 1},
+		"arity mismatch: arguments must be 2 to 3 values, but is 1 value",
 	},
 }
 

--- a/pkg/eval/go_fn.go
+++ b/pkg/eval/go_fn.go
@@ -12,11 +12,6 @@ import (
 )
 
 var (
-	// ErrArgs is thrown when a Go function gets erroneous arguments.
-	//
-	// TODO(xiaq): Replace this single error type with multiple types that carry
-	// richer error information.
-	ErrArgs = errors.New("args error")
 	// ErrNoOptAccepted is thrown when a Go function that does not accept any
 	// options gets passed options.
 	ErrNoOptAccepted = errors.New("function does not accept any options")
@@ -156,19 +151,16 @@ var errorType = reflect.TypeOf((*error)(nil)).Elem()
 func (b *goFn) Call(f *Frame, args []interface{}, opts map[string]interface{}) error {
 	if b.variadicArg != nil {
 		if len(args) < len(b.normalArgs) {
-			return errs.ArityMismatch{
-				What:     "arguments here",
+			return errs.ArityMismatch{What: "arguments",
 				ValidLow: len(b.normalArgs), ValidHigh: -1, Actual: len(args)}
 		}
 	} else if b.inputs {
 		if len(args) != len(b.normalArgs) && len(args) != len(b.normalArgs)+1 {
-			return errs.ArityMismatch{
-				What:     "arguments here",
+			return errs.ArityMismatch{What: "arguments",
 				ValidLow: len(b.normalArgs), ValidHigh: len(b.normalArgs) + 1, Actual: len(args)}
 		}
 	} else if len(args) != len(b.normalArgs) {
-		return errs.ArityMismatch{
-			What:     "arguments here",
+		return errs.ArityMismatch{What: "arguments",
 			ValidLow: len(b.normalArgs), ValidHigh: len(b.normalArgs), Actual: len(args)}
 	}
 	if !b.rawOptions && b.options == nil && len(opts) > 0 {

--- a/pkg/eval/go_fn_test.go
+++ b/pkg/eval/go_fn_test.go
@@ -50,7 +50,7 @@ func TestGoFnCall(t *testing.T) {
 		t.Helper()
 		err := f.Call(fm, args, opts)
 		if !matchErr(wantErr, err) {
-			t.Errorf("Calling f didn't return error")
+			t.Errorf("Calling f returned wrong error:\nexp %v\ngot %v", wantErr, err)
 		}
 	}
 
@@ -197,20 +197,20 @@ func TestGoFnCall(t *testing.T) {
 	f = NewGoFn("f", func() {
 		t.Errorf("Function called when there are too many arguments")
 	})
-	callBad(theFrame, []interface{}{"x"}, theOptions, errs.ArityMismatch{
-		What: "arguments here", ValidLow: 0, ValidHigh: 0, Actual: 1})
+	callBad(theFrame, []interface{}{"x"}, theOptions, errs.ArityMismatch{What: "arguments",
+		ValidLow: 0, ValidHigh: 0, Actual: 1})
 
 	// Too few arguments.
 	f = NewGoFn("f", func(x string) {
 		t.Errorf("Function called when there are too few arguments")
 	})
-	callBad(theFrame, nil, theOptions, errs.ArityMismatch{
-		What: "arguments here", ValidLow: 1, ValidHigh: 1, Actual: 0})
+	callBad(theFrame, nil, theOptions, errs.ArityMismatch{What: "arguments",
+		ValidLow: 1, ValidHigh: 1, Actual: 0})
 	f = NewGoFn("f", func(x string, y ...string) {
 		t.Errorf("Function called when there are too few arguments")
 	})
-	callBad(theFrame, nil, theOptions, errs.ArityMismatch{
-		What: "arguments here", ValidLow: 1, ValidHigh: -1, Actual: 0})
+	callBad(theFrame, nil, theOptions, errs.ArityMismatch{What: "arguments",
+		ValidLow: 1, ValidHigh: -1, Actual: 0})
 
 	// Options when the function does not accept options.
 	f = NewGoFn("f", func() {

--- a/pkg/eval/mods/math/math.go
+++ b/pkg/eval/mods/math/math.go
@@ -455,8 +455,7 @@ func isNaN(n vals.Num) bool {
 
 func max(rawNums ...vals.Num) (vals.Num, error) {
 	if len(rawNums) == 0 {
-		return nil, errs.ArityMismatch{
-			What: "arguments here", ValidLow: 1, ValidHigh: -1, Actual: 0}
+		return nil, errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0}
 	}
 	nums := vals.UnifyNums(rawNums, 0)
 	switch nums := nums.(type) {
@@ -509,7 +508,7 @@ func max(rawNums ...vals.Num) (vals.Num, error) {
 //
 // ```elvish-transcript
 // ~> math:min
-// Exception: arity mismatch: arguments here must be 1 or more values, but is 0 values
+// Exception: arity mismatch: arguments must be 1 or more values, but is 0 values
 // [tty 17], line 1: math:min
 // ~> math:min 3 5 2
 // ▶ (num 2)
@@ -519,8 +518,7 @@ func max(rawNums ...vals.Num) (vals.Num, error) {
 
 func min(rawNums ...vals.Num) (vals.Num, error) {
 	if len(rawNums) == 0 {
-		return nil, errs.ArityMismatch{
-			What: "arguments here", ValidLow: 1, ValidHigh: -1, Actual: 0}
+		return nil, errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0}
 	}
 	nums := vals.UnifyNums(rawNums, 0)
 	switch nums := nums.(type) {

--- a/pkg/eval/mods/math/math_test.go
+++ b/pkg/eval/mods/math/math_test.go
@@ -105,7 +105,7 @@ func TestMath(t *testing.T) {
 		That("math:is-nan 1/2").Puts(false),
 
 		That("math:max").Throws(
-			errs.ArityMismatch{What: "arguments here", ValidLow: 1, ValidHigh: -1, Actual: 0},
+			errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0},
 			"math:max"),
 		That("math:max 42").Puts(42),
 		That("math:max -3 3 10 -4").Puts(10),
@@ -116,7 +116,7 @@ func TestMath(t *testing.T) {
 		That("math:max 3 NaN 5").Puts(math.NaN()),
 
 		That("math:min").Throws(
-			errs.ArityMismatch{What: "arguments here", ValidLow: 1, ValidHigh: -1, Actual: 0},
+			errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0},
 			"math:min"),
 		That("math:min 42").Puts(42),
 		That("math:min -3 3 10 -4").Puts(-4),

--- a/pkg/eval/mods/path/path.go
+++ b/pkg/eval/mods/path/path.go
@@ -243,8 +243,7 @@ func tempDir(opts mktempOpt, args ...string) (string, error) {
 	case 1:
 		pattern = args[0]
 	default:
-		return "", errs.ArityMismatch{
-			What:     "arguments here",
+		return "", errs.ArityMismatch{What: "arguments",
 			ValidLow: 0, ValidHigh: 1, Actual: len(args)}
 	}
 
@@ -299,8 +298,7 @@ func tempFile(opts mktempOpt, args ...string) (*os.File, error) {
 	case 1:
 		pattern = args[0]
 	default:
-		return nil, errs.ArityMismatch{
-			What:     "arguments here",
+		return nil, errs.ArityMismatch{What: "arguments",
 			ValidLow: 0, ValidHigh: 1, Actual: len(args)}
 	}
 

--- a/pkg/eval/mods/path/path_test.go
+++ b/pkg/eval/mods/path/path_test.go
@@ -68,7 +68,7 @@ func TestPath(t *testing.T) {
 		That("x = (path:temp-dir &dir=.)", "rmdir $x", "put $x").Puts(
 			MatchingRegexp{Pattern: `^elvish-.*$`}),
 		That("path:temp-dir a b").Throws(
-			errs.ArityMismatch{What: "arguments here", ValidLow: 0, ValidHigh: 1, Actual: 2},
+			errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: 2},
 			"path:temp-dir a b"),
 
 		That("f = (path:temp-file)", "fclose $f", "put $f[fd]", "rm $f[name]").
@@ -82,7 +82,7 @@ func TestPath(t *testing.T) {
 		That("f = (path:temp-file &dir=.)", "put $f[name]", "fclose $f", "rm $f[name]").
 			Puts(MatchingRegexp{Pattern: `^elvish-.*$`}),
 		That("path:temp-file a b").Throws(
-			errs.ArityMismatch{What: "arguments here", ValidLow: 0, ValidHigh: 1, Actual: 2},
+			errs.ArityMismatch{What: "arguments", ValidLow: 0, ValidHigh: 1, Actual: 2},
 			"path:temp-file a b"),
 	)
 }


### PR DESCRIPTION
This also replaces the slightly awkward "arguments here" reason with
"argument count" as the "what" for a typical errs.ArityMismatch
exception. It also reformats most of the constructors so that the "what"
is on the same line. This makes `grep errs.ArityMismatch **.go` more
useful as a result.