### PR TITLE
Build without support for the interactive daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 ELVISH_MAKE_BIN ?= $(shell go env GOPATH)/bin/elvish
+ifdef ELVISH_MAKE_TAGS
+	override ELVISH_MAKE_TAGS := -tags ${ELVISH_MAKE_TAGS}
+endif
 
 default: test get
 
@@ -8,7 +11,7 @@ get:
 		export GOFLAGS=-buildmode=pie; \
 	fi; \
 	mkdir -p $(shell dirname $(ELVISH_MAKE_BIN))
-	go build -o $(ELVISH_MAKE_BIN) -trimpath -ldflags \
+	go build -o $(ELVISH_MAKE_BIN) $(ELVISH_MAKE_TAGS) -trimpath -ldflags \
 		"-X src.elv.sh/pkg/buildinfo.VersionSuffix=-dev.$$(git rev-parse HEAD)$$(git diff HEAD --quiet || printf +%s `uname -n`) \
 		 -X src.elv.sh/pkg/buildinfo.Reproducible=true" ./cmd/elvish
 
@@ -17,12 +20,12 @@ generate:
 
 # Run unit tests, with race detection if the platform supports it.
 test:
-	go test $(shell ./tools/run-race.sh) ./...
+	go test $(shell ./tools/run-race.sh) $(ELVISH_MAKE_TAGS) ./...
 
 # Generate a basic test coverage report, and open it in the browser. See also
 # https://apps.codecov.io/gh/elves/elvish/.
 cover:
-	go test -coverprofile=cover -coverpkg=./pkg/... ./pkg/...
+	go test -coverprofile=cover -coverpkg=./pkg/... $(ELVISH_MAKE_TAGS) ./pkg/...
 	go tool cover -html=cover
 	go tool cover -func=cover | tail -1 | awk '{ print "Overall coverage:", $$NF }'
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ make get ELVISH_MAKE_BIN=./elvish # Install to the repo root
 make get ELVISH_MAKE_BIN=/usr/local/bin/elvish # Install to /usr/local/bin
 ```
 
+To build it without support for the interactive database daemon:
+
+```sh
+make get ELVISH_MAKE_TAGS=elv_daemon_stub
+```
+
 ## Packaging Elvish
 
 See [PACKAGING.md](PACKAGING.md) for notes for packagers.

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (
@@ -15,6 +17,9 @@ var (
 	// ErrDaemonUnreachable is returned when the daemon cannot be reached after
 	// several retries.
 	ErrDaemonUnreachable = errors.New("daemon offline")
+	// This symbol exists so the sole use of this error in pkg/shell/runtime.detectDaemon() doesn't
+	// have to also import the rpc package.
+	ErrShutdown = rpc.ErrShutdown
 )
 
 // Client represents a daemon client.

--- a/pkg/daemon/client_stub.go
+++ b/pkg/daemon/client_stub.go
@@ -1,0 +1,119 @@
+// +build elv_daemon_stub
+
+package daemon
+
+import (
+	"errors"
+
+	"src.elv.sh/pkg/store"
+)
+
+var (
+	// This symbol exists so the sole use of this error in pkg/shell/runtime.detectDaemon() doesn't
+	// have to also import the rpc package.
+	ErrShutdown   = errors.New("should never be used")
+	ErrNoCommands = errors.New("no commands")
+)
+
+// Client represents a daemon client.
+type Client interface {
+	store.Store
+
+	ResetConn() error
+	Close() error
+
+	Pid() (int, error)
+	SockPath() string
+	Version() (int, error)
+}
+
+// Implementation of the Client interface.
+type client struct{}
+
+// NewClient creates a new Client instance that talks to the socket. Connection
+// creation is deferred to the first request.
+func NewClient(sockPath string) Client {
+	return &client{}
+}
+
+// SockPath returns the socket path that the Client talks to. If the client is
+// nil, it returns an empty string.
+func (c *client) SockPath() string {
+	return ""
+}
+
+// ResetConn resets the current connection. A new connection will be established
+// the next time a request is made. If the client is nil, it does nothing.
+func (c *client) ResetConn() error {
+	return nil
+}
+
+// Close waits for all outstanding requests to finish and close the connection.
+// If the client is nil, it does nothing and returns nil.
+func (c *client) Close() error {
+	return nil
+}
+
+// Convenience methods for RPC methods. These are quite repetitive; when the
+// number of RPC calls grow above some threshold, a code generator should be
+// written to generate them.
+
+func (c *client) Version() (int, error) {
+	return 0, nil
+}
+
+func (c *client) Pid() (int, error) {
+	return 0, nil
+}
+
+func (c *client) NextCmdSeq() (int, error) {
+	return 0, nil
+}
+
+func (c *client) AddCmd(text string) (int, error) {
+	return 0, nil
+}
+
+func (c *client) DelCmd(seq int) error {
+	return nil
+}
+
+func (c *client) Cmd(seq int) (string, error) {
+	return "", nil
+}
+
+func (c *client) CmdsWithSeq(from, upto int) ([]store.Cmd, error) {
+	return []store.Cmd{}, ErrNoCommands
+}
+
+func (c *client) NextCmd(from int, prefix string) (store.Cmd, error) {
+	return store.Cmd{}, ErrNoCommands
+}
+
+func (c *client) PrevCmd(upto int, prefix string) (store.Cmd, error) {
+	return store.Cmd{}, ErrNoCommands
+}
+
+func (c *client) AddDir(dir string, incFactor float64) error {
+	return nil
+}
+
+func (c *client) DelDir(dir string) error {
+	return nil
+}
+
+func (c *client) Dirs(blacklist map[string]struct{}) ([]store.Dir, error) {
+	return []store.Dir{}, nil
+}
+
+func (c *client) SharedVar(name string) (string, error) {
+	return "", nil
+}
+
+func (c *client) SetSharedVar(name, value string) error {
+	return nil
+}
+
+func (c *client) DelSharedVar(name string) error {
+	return nil
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 // Package daemon implements a service for mediating access to the data store,
 // and its client.
 //

--- a/pkg/daemon/daemon_stub.go
+++ b/pkg/daemon/daemon_stub.go
@@ -1,0 +1,26 @@
+// +build elv_daemon_stub
+
+// This, and the other *_stub.go files, exists to make it possible to build an elvish binary with no
+// support for an interactive database daemon. Thus producing a smaller program with less overhead.
+// Which is valuable in "busybox" (e.g., u-root) type environments.
+
+package daemon
+
+import (
+	"os"
+
+	"src.elv.sh/pkg/prog"
+)
+
+const Version = 0
+
+// Program is the daemon subprogram.
+var Program prog.Program = program{}
+
+type program struct{}
+
+func (program) ShouldRun(f *prog.Flags) bool { return false }
+
+func (program) Run(fds [3]*os.File, f *prog.Flags, args []string) error {
+	return nil
+}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/internal/api/api.go
+++ b/pkg/daemon/internal/api/api.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 // Package api defines types and constants useful for the API between the daemon
 // service and client.
 package api

--- a/pkg/daemon/serve.go
+++ b/pkg/daemon/serve.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/sock_unix.go
+++ b/pkg/daemon/sock_unix.go
@@ -1,3 +1,4 @@
+// +build !elv_daemon_stub
 // +build !windows,!plan9
 
 package daemon

--- a/pkg/daemon/sock_windows.go
+++ b/pkg/daemon/sock_windows.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/spawn.go
+++ b/pkg/daemon/spawn.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/spawn_stub.go
+++ b/pkg/daemon/spawn_stub.go
@@ -1,0 +1,21 @@
+// +build elv_daemon_stub
+
+package daemon
+
+type SpawnConfig struct {
+	// BinPath is the path to the Elvish binary itself, used when forking. This
+	// field is used only when spawning the daemon. If empty, it is
+	// automatically determined with os.Executable.
+	BinPath string
+	// DbPath is the path to the database.
+	DbPath string
+	// SockPath is the path to the socket on which the daemon will serve
+	// requests.
+	SockPath string
+	// RunDir is the directory in which to place the daemon log file.
+	RunDir string
+}
+
+func Spawn(cfg *SpawnConfig) error {
+	return nil
+}

--- a/pkg/daemon/spawn_unix.go
+++ b/pkg/daemon/spawn_unix.go
@@ -1,3 +1,4 @@
+// +build !elv_daemon_stub
 // +build !windows,!plan9,!js
 
 package daemon

--- a/pkg/daemon/spawn_windows.go
+++ b/pkg/daemon/spawn_windows.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 import (

--- a/pkg/daemon/umask_unix.go
+++ b/pkg/daemon/umask_unix.go
@@ -1,3 +1,4 @@
+// +build !elv_daemon_stub
 // +build !windows,!plan9,!js
 
 package daemon

--- a/pkg/daemon/umask_windows.go
+++ b/pkg/daemon/umask_windows.go
@@ -1,3 +1,5 @@
+// +build !elv_daemon_stub
+
 package daemon
 
 // No-op on Windows.

--- a/pkg/shell/runtime.go
+++ b/pkg/shell/runtime.go
@@ -19,7 +19,6 @@ import (
 	"src.elv.sh/pkg/eval/mods/store"
 	"src.elv.sh/pkg/eval/mods/str"
 	"src.elv.sh/pkg/eval/mods/unix"
-	"src.elv.sh/pkg/rpc"
 )
 
 const (
@@ -180,7 +179,7 @@ func detectDaemon(sockpath string, cl daemon.Client) (daemonStatus, error) {
 	version, err := cl.Version()
 	if err != nil {
 		switch {
-		case err == rpc.ErrShutdown:
+		case err == daemon.ErrShutdown:
 			return connectionShutdown, err
 		case err.Error() == bolt.ErrInvalid.Error():
 			return daemonInvalidDB, err

--- a/pkg/shell/shell_unix_test.go
+++ b/pkg/shell/shell_unix_test.go
@@ -1,3 +1,4 @@
+// +build !elv_daemon_stub
 // +build !windows,!plan9,!js
 
 package shell


### PR DESCRIPTION
This implements a mechanism for building an elvish program without
support for shared interactive history provided by the interactive
database daemon. This is done via a stub implementation of the daemon
client API. Selected at build time via:

    make ELVISH_MAKE_TAGS=elv_daemon_stub

This does not eliminate the overhead of the Bbolt DB code. That
improvement will require a different set of changes. I wanted to keep
this change small and focused on the daemon.