### PR TITLE
Add plugin support

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -93,3 +93,5 @@ New features in the interactive editor:
 
 -   A new `edit:command-duration` variable that is the number of seconds to
     execute the most recent interactive command line.
+
+-   Support for loading go plugins with `use`.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 ELVISH_MAKE_BIN ?= $(shell go env GOPATH)/bin/elvish
+ELVISH_PLUGINS ?= 0
 
 default: test get
 
 get:
-	export CGO_ENABLED=0; \
+	export CGO_ENABLED=$(ELVISH_PLUGINS); \
 	if go env GOOS GOARCH | egrep -qx '(windows .*|linux (amd64|arm64))'; then \
 		export GOFLAGS=-buildmode=pie; \
 	fi; \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ make get ELVISH_MAKE_BIN=./elvish # Install to the repo root
 make get ELVISH_MAKE_BIN=/usr/local/bin/elvish # Install to /usr/local/bin
 ```
 
+To install with plugin support, override `ELVISH_PLUGINS` in the `make` command:
+
+```sh
+make get ELVISH_PLUGINS=1 # Install with plugin support
+```
+
 ## Packaging Elvish
 
 See [PACKAGING.md](PACKAGING.md) for notes for packagers.

--- a/pkg/eval/plugin.go
+++ b/pkg/eval/plugin.go
@@ -1,0 +1,7 @@
+//+build !gccgo
+
+package eval
+
+import "plugin"
+
+var pluginOpen = plugin.Open

--- a/pkg/eval/plugin_gccgo.go
+++ b/pkg/eval/plugin_gccgo.go
@@ -1,0 +1,17 @@
+//+build gccgo
+
+package eval
+
+import "errors"
+
+var errPluginNotImplemented = errors.New("plugin not implemented")
+
+type pluginStub struct{}
+
+func pluginOpen(name string) (pluginStub, error) {
+	return pluginStub{}, errPluginNotImplemented
+}
+
+func (pluginStub) Lookup(symName string) (interface{}, error) {
+	return nil, errPluginNotImplemented
+}

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -2227,6 +2227,9 @@ fn f {
 }
 ```
 
+Note: If you build elvish with `ELVISH_PLUGINS=1` you can use go plugins with
+the extension `.so`.
+
 This module can now be imported by `use a`:
 
 ```elvish-transcript


### PR DESCRIPTION
Adds golang plugin support to the `use` keyword.

With this change, `use` prioritizes loading modules with the extension `.so`.

A plugin module must contain a symbol called `Ns` of type `*eval.Ns`.