### PR TITLE
`make cover` now ignores same files as Codecov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test:
 # https://apps.codecov.io/gh/elves/elvish/.
 cover:
 	go test -coverprofile=cover -coverpkg=./pkg/... ./pkg/...
+	tools/cover-prune.sh .codecov.yml cover
 	go tool cover -html=cover
 	go tool cover -func=cover | tail -1 | awk '{ print "Overall coverage:", $$NF }'
 

--- a/tools/cover-prune.sh
+++ b/tools/cover-prune.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+# Prune the same objects from the "make cover" report that we tell Codecov
+# (https://codecov.io/gh/elves/elvish/) to ignore.
+
+if test $# != 2
+then
+    echo 'Usage: cover_prune.sh ${codecov.yml} $cover' >&2
+    exit 1
+fi
+yaml="$1"
+data="$2"
+
+# This approach to ignoring code from the "make cover" report is suboptimal
+# but efficient enough for our purposes. Especially when weighed against a
+# more complicated approach that constructs a single regexp that is used to
+# filter the data just once since the number of exclusions is small.
+sed -ne '/^ignore:/,/^[^ \t]/s/^[ \t]*- "\(.*\)"/\1/p' $yaml |
+    while read pattern
+    do
+        grep -v "$pattern" $data > $data.tmp
+        mv $data.tmp $data
+    done


### PR DESCRIPTION
Running `make cover` includes code in its report that is explicitly
excluded from the https://codecov.io/gh/elves/elvish/ report. This change
causes both reports to include/exclude the same source files.