### PR TITLE
Lint cleanups

### DIFF
--- a/0.16.0-release-notes.md
+++ b/0.16.0-release-notes.md
@@ -95,7 +95,8 @@ New features in the interactive editor:
     listing, location and navigation modes.
 
 -   A new `edit:after-command` hook that is invoked after each interactive
-    command line is run.
+    command line is run ([#1029](https://b.elv.sh/1029)).
 
 -   A new `edit:command-duration` variable that is the number of seconds to
-    execute the most recent interactive command line.
+    execute the most recent interactive command line
+    ([#1029](https://b.elv.sh/1029)).

--- a/pkg/edit/complete_getopt.go
+++ b/pkg/edit/complete_getopt.go
@@ -148,9 +148,8 @@ func completeGetopt(fm *eval.Frame, vArgs, vOpts, vArgHandlers interface{}) erro
 		}
 		if argHandler != nil {
 			return call(argHandler, ctx.Text)
-		} else {
-			// TODO(xiaq): Notify that there is no suitable argument completer.
 		}
+		// TODO(xiaq): Notify that there is no suitable argument completer.
 	case getopt.NewOption:
 		for _, opt := range opts.opts {
 			if opt.Short != 0 {

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -50,7 +50,7 @@ func NewEditor(tty cli.TTY, ev *eval.Evaler, st storedefs.Store) *Editor {
 
 	hs, err := newHistStore(st)
 	if err != nil {
-		// TODO(xiaq): Report the error.
+		_ = err // TODO(xiaq): Report the error.
 	}
 
 	initHighlighter(&appSpec, ev)

--- a/pkg/eval/builtin_fn_io.go
+++ b/pkg/eval/builtin_fn_io.go
@@ -515,8 +515,6 @@ func show(fm *Frame, v diag.Shower) error {
 	return err
 }
 
-const bytesReadBufferSize = 512
-
 //elvdoc:fn only-bytes
 //
 // ```elvish

--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -377,22 +377,22 @@ func useFromFile(fm *Frame, spec, path string, r diag.Ranger) (*Ns, error) {
 			return nil, err
 		}
 		return evalModule(fm, path, parse.Source{Name: path, Code: code, IsFile: true}, r)
-	} else {
-		plug, err := pluginOpen(path + ".so")
-		if err != nil {
-			return nil, noSuchModule{spec}
-		}
-		sym, err := plug.Lookup("Ns")
-		if err != nil {
-			return nil, err
-		}
-		ns, ok := sym.(**Ns)
-		if !ok {
-			return nil, noSuchModule{spec}
-		}
-		fm.Evaler.modules[path] = *ns
-		return *ns, nil
 	}
+
+	plug, err := pluginOpen(path + ".so")
+	if err != nil {
+		return nil, noSuchModule{spec}
+	}
+	sym, err := plug.Lookup("Ns")
+	if err != nil {
+		return nil, err
+	}
+	ns, ok := sym.(**Ns)
+	if !ok {
+		return nil, noSuchModule{spec}
+	}
+	fm.Evaler.modules[path] = *ns
+	return *ns, nil
 }
 
 // TODO: Make access to fm.Evaler.modules concurrency-safe.

--- a/pkg/eval/external_cmd_unix_internal_test.go
+++ b/pkg/eval/external_cmd_unix_internal_test.go
@@ -11,23 +11,22 @@ import (
 	"src.elv.sh/pkg/env"
 	"src.elv.sh/pkg/parse"
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/testutil"
 )
 
 func TestExec_Argv0Argv(t *testing.T) {
-	dir, cleanupFS := InTestDir()
+	dir, cleanupFS := testutil.InTestDir()
 	defer cleanupFS()
-	ApplyDir(Dir{
-		"bin": Dir{
-			"elvish": File{Perm: 0755},
-			"cat":    File{Perm: 0755},
+	testutil.ApplyDir(testutil.Dir{
+		"bin": testutil.Dir{
+			"elvish": testutil.File{Perm: 0755},
+			"cat":    testutil.File{Perm: 0755},
 		},
 	})
 
-	restorePATH := WithTempEnv("PATH", dir+"/bin")
+	restorePATH := testutil.WithTempEnv("PATH", dir+"/bin")
 	defer restorePATH()
 
-	restoreSHLVL := WithTempEnv(env.SHLVL, "1")
+	restoreSHLVL := testutil.WithTempEnv(env.SHLVL, "1")
 	defer restoreSHLVL()
 
 	var tests = []struct {
@@ -91,15 +90,6 @@ func TestExec_Argv0Argv(t *testing.T) {
 			}
 		})
 	}
-}
-
-var execSHLVLTests = []struct {
-	oldValue string
-	newValue string
-}{
-	{"3", "2"},
-	{"1", "0"},
-	{"0", "-1"},
 }
 
 func TestDecSHLVL(t *testing.T) {

--- a/pkg/eval/mods/daemon/daemon.go
+++ b/pkg/eval/mods/daemon/daemon.go
@@ -2,17 +2,12 @@
 package daemon
 
 import (
-	"errors"
 	"strconv"
 
 	"src.elv.sh/pkg/daemon/daemondefs"
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/vars"
 )
-
-// errDontKnowHowToSpawnDaemon is thrown by daemon:spawn when the Evaler's
-// DaemonSpawner field is nil.
-var errDontKnowHowToSpawnDaemon = errors.New("don't know how to spawn daemon")
 
 // Ns makes the daemon: namespace.
 func Ns(d daemondefs.Client) *eval.Ns {

--- a/pkg/eval/mods/math/math.go
+++ b/pkg/eval/mods/math/math.go
@@ -693,12 +693,11 @@ func round(n vals.Num) vals.Num {
 			m = m.Mul(m, big2)
 			if m.CmpAbs(n.Denom()) < 0 {
 				return q
-			} else {
-				if n.Sign() < 0 {
-					return q.Sub(q, big1)
-				}
-				return q.Add(q, big1)
 			}
+			if n.Sign() < 0 {
+				return q.Sub(q, big1)
+			}
+			return q.Add(q, big1)
 		})
 }
 
@@ -741,12 +740,11 @@ func roundToEven(n vals.Num) vals.Num {
 			m = m.Mul(m, big2)
 			if diff := m.CmpAbs(n.Denom()); diff < 0 || diff == 0 && q.Bit(0) == 0 {
 				return q
-			} else {
-				if n.Sign() < 0 {
-					return q.Sub(q, big1)
-				}
-				return q.Add(q, big1)
 			}
+			if n.Sign() < 0 {
+				return q.Sub(q, big1)
+			}
+			return q.Add(q, big1)
 		})
 }
 

--- a/pkg/eval/vals/num.go
+++ b/pkg/eval/vals/num.go
@@ -78,10 +78,6 @@ const (
 	Float64
 )
 
-// PromoteToBigInt converts an int or *big.Int to a *big.Int. It panics if n is
-// any other type.
-// PromoteToBigInt converts an int or *big.Int to a,ig.Int. I or *big.Ratt
-// panics if Rat is any other type.
 // UnifyNums unifies the given slice of numbers into the same type, converting
 // those with lower NumType to the higest NumType present in the slice. The typ
 // argument can be used to force the minimum NumType.
@@ -177,7 +173,7 @@ func PromoteToBigInt(n Num) *big.Int {
 	}
 }
 
-// PromoteToBigInt converts an int, *big.Int or *big.Rat to a *big.Rat. It
+// PromoteToBigRat converts an int, *big.Int or *big.Rat to a *big.Rat. It
 // panics if n is any other type.
 func PromoteToBigRat(n Num) *big.Rat {
 	switch n := n.(type) {
@@ -201,13 +197,11 @@ func ConvertToFloat64(num Num) float64 {
 	case int:
 		return float64(num)
 	case *big.Int:
-		if num.IsInt64() {
-			// Might fit in float64
+		if num.IsInt64() { // might fit in float64
+			// TODO: Make this more robust so the "might fit" is "will fit".
 			return float64(num.Int64())
-		} else {
-			// Definitely won't fit in float64
-			return math.Inf(num.Sign())
 		}
+		return math.Inf(num.Sign()) // definitely won't fit in float64
 	case *big.Rat:
 		f, _ := num.Float64()
 		return f

--- a/pkg/ui/key.go
+++ b/pkg/ui/key.go
@@ -191,6 +191,8 @@ func ParseKey(s string) (Key, error) {
 		k.Rune = rune(s[0])
 		if k.Rune < 0x20 {
 			if k.Mod&Ctrl != 0 {
+				//lint:ignore ST1005 We want this error to begin with "Ctrl" rather than "ctrl"
+				// since the user has to use the capitalized form when creating a key binding.
 				return Key{}, fmt.Errorf("Ctrl modifier with literal control char: %q", k.Rune)
 			}
 			// Convert literal control char to the equivalent canonical form;


### PR DESCRIPTION
This change addresses issues reported by the `staticcheck` tool and a
couple reported by the `golint` tool. It also adds missing issue links
to a couple of entries in the release notes. This change deliberately
does not address these warnings since it is unclear whether the project
owner would prefer to suppress or address them:

    pkg/store/cmd.go:8:2: should not use dot imports (ST1001)
    pkg/store/db_store.go:10:2: should not use dot imports (ST1001)
    pkg/store/dir.go:8:2: should not use dot imports (ST1001)