### PR TITLE
Improve "wrong type" error message

### DIFF
--- a/pkg/edit/completion.go
+++ b/pkg/edit/completion.go
@@ -276,7 +276,8 @@ func (c complexItem) IterateKeys(f func(interface{}) bool) {
 	vals.Feed(f, "stem", "code-suffix", "display")
 }
 
-func (c complexItem) Kind() string { return "map" }
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (complexItem) Kind() string { return "map" }
 
 func (c complexItem) Equal(a interface{}) bool {
 	rhs, ok := a.(complexItem)

--- a/pkg/eval/builtin_fn_misc_test.go
+++ b/pkg/eval/builtin_fn_misc_test.go
@@ -14,6 +14,19 @@ import (
 
 func TestKindOf(t *testing.T) {
 	Test(t,
+		That("kind-of x").Puts("string"),
+		That("kind-of []").Puts("list"),
+		That("kind-of [&]").Puts("map"),
+		That("kind-of $true").Puts("bool"),
+		That("kind-of (eq x y)").Puts("bool"),
+		That("kind-of {}").Puts("string"),
+		That("kind-of []{}").Puts("fn"),
+		That("kind-of (float64 1)").Puts("number"),
+		That("kind-of (num 1)").Puts("number"),
+		That("kind-of (num 1/3)").Puts("number"),
+		That("kind-of $buildinfo").Puts("structmap"),
+		That("kind-of (styled x bold)").Puts("ui:text"),
+		That("kind-of (styled-segment x)").Puts("ui:text-segment"),
 		That("kind-of a []").Puts("string", "list"),
 		thatOutputErrorIsBubbled("kind-of a"),
 	)

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -42,6 +42,8 @@ func TestVar(t *testing.T) {
 		// Shadowing.
 		That("var x = old; fn f { put $x }", "var x = new; put $x; f").
 			Puts("new", "old"),
+		// Invalid value for the LHS variable.
+		That("var x~ = $true").Throws(vals.WrongType{WantKind: "fn", GotKind: "bool"}),
 
 		// Variable name that must be quoted after $ must be quoted
 		That("var a/b").DoesNotCompile(),

--- a/pkg/eval/callable.go
+++ b/pkg/eval/callable.go
@@ -4,6 +4,8 @@ package eval
 type Callable interface {
 	// Call calls the receiver in a Frame with arguments and options.
 	Call(fm *Frame, args []interface{}, opts map[string]interface{}) error
+	// Callable also implements the Kinder interface. See vals.Kind() for why this is needed.
+	Kind() string
 }
 
 var (

--- a/pkg/eval/closure.go
+++ b/pkg/eval/closure.go
@@ -31,10 +31,8 @@ type closure struct {
 
 var _ Callable = &closure{}
 
-// Kind returns "fn".
-func (*closure) Kind() string {
-	return "fn"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (*closure) Kind() string { return "fn" }
 
 // Equal compares by address.
 func (c *closure) Equal(rhs interface{}) bool {

--- a/pkg/eval/errs/errs.go
+++ b/pkg/eval/errs/errs.go
@@ -95,3 +95,15 @@ type ReaderGone struct {
 func (e ReaderGone) Error() string {
 	return "reader gone"
 }
+
+// ArgError is used when an argument to a command does not have the expected type or there is some
+// other problem with the argument.
+type ArgError struct {
+	ArgNum int
+	Msg    string
+}
+
+// Error implements the error interface.
+func (err ArgError) Error() string {
+	return fmt.Sprintf("argument %d: %s", err.ArgNum, err.Msg)
+}

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -83,6 +83,9 @@ type Evaler struct {
 	daemonClient daemondefs.Client
 }
 
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (*Evaler) Kind() string { return "fn" }
+
 // Editor is the interface that the line editor has to satisfy. It is needed so
 // that this package does not depend on the edit package.
 type Editor interface {

--- a/pkg/eval/exception.go
+++ b/pkg/eval/exception.go
@@ -109,10 +109,8 @@ func (exc *exception) Show(indent string) string {
 	return buf.String()
 }
 
-// Kind returns "exception".
-func (exc *exception) Kind() string {
-	return "exception"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (*exception) Kind() string { return "exception" }
 
 // Repr returns a representation of the exception. It is lossy in that it does
 // not preserve the stacktrace.

--- a/pkg/eval/external_cmd.go
+++ b/pkg/eval/external_cmd.go
@@ -37,9 +37,13 @@ func NewExternalCmd(name string) Callable {
 	return externalCmd{name}
 }
 
-func (e externalCmd) Kind() string {
-	return "fn"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+//
+// TODO: It's unclear whether this should return the same "kind" as builtin functions given the
+// difference in calling conventions and argument syntax. Document why "fn" is returned or change it
+// to "external". Whichever value is ultimately chosen, thus removing this TODO, the rationale for
+// the choice needs to be documented here as well as user facing documentation.
+func (externalCmd) Kind() string { return "fn" }
 
 func (e externalCmd) Equal(a interface{}) bool {
 	return e == a

--- a/pkg/eval/go_fn.go
+++ b/pkg/eval/go_fn.go
@@ -123,10 +123,8 @@ func NewGoFn(name string, impl interface{}) Callable {
 	return b
 }
 
-// Kind returns "fn".
-func (*goFn) Kind() string {
-	return "fn"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (*goFn) Kind() string { return "fn" }
 
 // Equal compares identity.
 func (b *goFn) Equal(rhs interface{}) bool {
@@ -196,9 +194,8 @@ func (b *goFn) Call(f *Frame, args []interface{}, opts map[string]interface{}) e
 			panic("impossible")
 		}
 		ptr := reflect.New(typ)
-		err := vals.ScanToGo(arg, ptr.Interface())
-		if err != nil {
-			return fmt.Errorf("wrong type of argument %d: %v", i, err)
+		if err := vals.ScanToGo(arg, ptr.Interface()); err != nil {
+			return errs.ArgError{ArgNum: i, Msg: err.Error()}
 		}
 		in = append(in, ptr.Elem())
 	}

--- a/pkg/eval/ns.go
+++ b/pkg/eval/ns.go
@@ -49,10 +49,8 @@ func CombineNs(ns1 *Ns, ns2 *Ns) *Ns {
 	return ns
 }
 
-// Kind returns "ns".
-func (ns *Ns) Kind() string {
-	return "ns"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (*Ns) Kind() string { return "ns" }
 
 // Hash returns a hash of the address of ns.
 func (ns *Ns) Hash() uint32 {

--- a/pkg/eval/ns_test.go
+++ b/pkg/eval/ns_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestNs(t *testing.T) {
 	Test(t,
+		That("ns $true").Throws(errs.ArgError{ArgNum: 0, Msg: "wrong type: need map, got bool"}),
 		That("kind-of (ns [&])").Puts("ns"),
 		// A Ns is only equal to itself
 		That("ns = (ns [&]); eq $ns $ns").Puts(true),

--- a/pkg/eval/vals/conversion.go
+++ b/pkg/eval/vals/conversion.go
@@ -28,13 +28,13 @@ import (
 // entirely go away, as there might always be some mismatch between Elvish's
 // type system and Go's.
 
-type wrongType struct {
-	wantKind string
-	gotKind  string
+type WrongType struct {
+	WantKind string
+	GotKind  string
 }
 
-func (err wrongType) Error() string {
-	return fmt.Sprintf("wrong type: need %s, got %s", err.wantKind, err.gotKind)
+func (err WrongType) Error() string {
+	return fmt.Sprintf("wrong type: need %s, got %s", err.WantKind, err.GotKind)
 }
 
 type cannotParseAs struct {
@@ -90,11 +90,13 @@ func ScanToGo(src interface{}, ptr interface{}) error {
 		// Do a generic `*ptr = src` via reflection
 		ptrType := TypeOf(ptr)
 		if ptrType.Kind() != reflect.Ptr {
+			// TODO: Change this to a panic or explain why it shouldn't panic given this should be a
+			// "can't happen" situation.
 			return fmt.Errorf("internal bug: need pointer to scan to, got %T", ptr)
 		}
 		dstType := ptrType.Elem()
 		if !TypeOf(src).AssignableTo(dstType) {
-			return wrongType{Kind(reflect.Zero(dstType).Interface()), Kind(src)}
+			return WrongType{Kind(ptr), Kind(src)}
 		}
 		ValueOf(ptr).Elem().Set(ValueOf(src))
 		return nil

--- a/pkg/eval/vals/conversion_test.go
+++ b/pkg/eval/vals/conversion_test.go
@@ -52,7 +52,7 @@ func TestScanToGo(t *testing.T) {
 		Args("foo", "").Rets("foo"),
 		Args(someType{"foo"}, someType{}).Rets(someType{"foo"}),
 		Args(nil, nil).Rets(nil),
-		Args("x", someType{}).Rets(Any, wrongType{"!!vals.someType", "string"}),
+		Args("x", someType{}).Rets(Any, WrongType{"!!*vals.someType", "string"}),
 	})
 }
 

--- a/pkg/eval/vals/kind.go
+++ b/pkg/eval/vals/kind.go
@@ -3,6 +3,7 @@ package vals
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 )
 
 // Kinder wraps the Kind method.
@@ -10,37 +11,53 @@ type Kinder interface {
 	Kind() string
 }
 
-// Kind returns the "kind" of the value, a concept similar to type but not yet
-// very well defined. It is implemented for the builtin nil, bool and string,
-// the File, List, Map types, StructMap types, and types satisfying the Kinder
-// interface. For other types, it returns the Go type name of the argument
-// preceded by "!!".
-//
-// TODO: Decide what `kind-of` should report for an external command object
-// and document the rationale for the choice in the doc string for `func
-// (ExternalCmd) Kind()` as well as user facing documentation. It's not
-// obvious why this returns "fn" rather than "external" for that case.
+// Kind returns the "kind" of the value, a concept similar to type but not yet very well defined. It
+// is implemented for the builtin nil, bool string, File, List, Map, StructMap, eval.Callable types,
+// and types satisfying the Kinder interface. For other types, it returns the Go type name of the
+// argument prefaced with "!!".
 func Kind(v interface{}) string {
 	switch v := v.(type) {
 	case nil:
 		return "nil"
-	case bool:
+	case bool, *bool:
 		return "bool"
-	case string:
+	case string, *string:
 		return "string"
-	case int, *big.Int, *big.Rat, float64:
+	case int, *int, *big.Int, *big.Rat, float64, *float64:
 		return "number"
 	case Kinder:
+		// We want to call Kind() if it is available even if the object might otherwise match one of
+		// the other Elvish types below. This isn't first in the list because placing it there hurts
+		// performance but is otherwise benign.
 		return v.Kind()
-	case File:
+	case File, *File:
 		return "file"
-	case List:
+	case List, *List:
 		return "list"
-	case Map:
+	case Map, *Map:
 		return "map"
-	case StructMap:
+	case StructMap, *StructMap, PseudoStructMap, *PseudoStructMap:
 		return "structmap"
 	default:
+		// Try to dynamically invoke the Kind() method if it exists for the object. One such type is
+		// eval.Callable. We can't include a "case eval.Callable:" above since that would create an
+		// import dependency loop. The Kinder case above doesn't handle that type, even though it
+		// implements the Kinder interface, because eval.Callable is an interface rather than
+		// concrete type when used in callback APIs like vars.PtrVar.
+		var m reflect.Value
+		switch reflect.TypeOf(v).Kind() {
+		case reflect.Ptr, reflect.Interface:
+			m = reflect.ValueOf(v).Elem().MethodByName("Kind")
+		default:
+			m = reflect.ValueOf(v).MethodByName("Kind")
+		}
+		if m.IsValid() {
+			retvals := m.Call(nil)
+			return retvals[0].String()
+		}
+		// Fallback to the special "!!" syntax to make it clear something is wrong since we were
+		// unable to provide a meaningful "kind" for the object and had to resort to returning the
+		// symbolic Go type.
 		return fmt.Sprintf("!!%T", v)
 	}
 }

--- a/pkg/eval/vals/kind_test.go
+++ b/pkg/eval/vals/kind_test.go
@@ -8,9 +8,15 @@ import (
 	. "src.elv.sh/pkg/tt"
 )
 
+type structMap struct{}
+
+func (structMap) IsStructMap() {}
+
 type xtype int
 
 func TestKind(t *testing.T) {
+	// This does not exercise the Kinder case. We instead rely on unit tests for the types which
+	// implement that interface to exercise that case.
 	Test(t, Fn("Kind", Kind), Table{
 		Args(nil).Rets("nil"),
 		Args(true).Rets("bool"),
@@ -22,9 +28,7 @@ func TestKind(t *testing.T) {
 		Args(os.Stdin).Rets("file"),
 		Args(EmptyList).Rets("list"),
 		Args(EmptyMap).Rets("map"),
-
+		Args(structMap{}).Rets("structmap"),
 		Args(xtype(0)).Rets("!!vals.xtype"),
-
-		Args(os.Stdin).Rets("file"),
 	})
 }

--- a/pkg/eval/vals/pipe.go
+++ b/pkg/eval/vals/pipe.go
@@ -20,10 +20,8 @@ func NewPipe(r, w *os.File) Pipe {
 	return Pipe{r, w}
 }
 
-// Kind returns "pipe".
-func (Pipe) Kind() string {
-	return "pipe"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (Pipe) Kind() string { return "pipe" }
 
 // Equal compares based on the equality of the two consistuent files.
 func (p Pipe) Equal(rhs interface{}) bool {

--- a/pkg/ui/key.go
+++ b/pkg/ui/key.go
@@ -112,9 +112,8 @@ var keyNames = map[rune]string{
 	Backspace:          "Backspace",
 }
 
-func (k Key) Kind() string {
-	return "edit:key"
-}
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
+func (Key) Kind() string { return "edit:key" }
 
 func (k Key) Equal(other interface{}) bool {
 	return k == other

--- a/pkg/ui/text.go
+++ b/pkg/ui/text.go
@@ -28,7 +28,7 @@ func Concat(texts ...Text) Text {
 	return ret
 }
 
-// Kind returns "styled-text".
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
 func (Text) Kind() string { return "ui:text" }
 
 // Repr returns the representation of the current Text. It is just a wrapper

--- a/pkg/ui/text_segment.go
+++ b/pkg/ui/text_segment.go
@@ -15,7 +15,7 @@ type Segment struct {
 	Text string
 }
 
-// Kind returns "styled-segment".
+// Kind is used by vals.Kind() to cause it to return the correct "kind" for these objects.
 func (*Segment) Kind() string { return "ui:text-segment" }
 
 // Repr returns the representation of this Segment. The string can be used to


### PR DESCRIPTION
Produce correct exception messages caused by statements such as these:

    var x~ = $true
    ns $true

It also adds several explicit tests of the `kind-of` command. Most of
those cases are tested indirectly. Such as by the unit tests of the Go
`vals.Kind()` function. But the duplication is warranted because there
is no guarantee that `$builtin:kind-of~` behaves the same as the
`vals.Kind()` function.

Fixes #715
Fixes #744