### PR TITLE
Update run-parallel example

### DIFF
--- a/pkg/eval/builtin_fn_flow.go
+++ b/pkg/eval/builtin_fn_flow.go
@@ -42,22 +42,29 @@ func init() {
 // except that it does not perform any redirections.
 //
 // Here is an example that lets you pipe the stdout and stderr of a command to two
-// different commands:
+// different commands in order to independently capture the output of each byte stream:
 //
-// ```elvish
-// pout = (pipe)
-// perr = (pipe)
-// run-parallel {
-// foo > $pout 2> $perr
-// pwclose $pout
-// pwclose $perr
-// } {
-// bar < $pout
-// prclose $pout
-// } {
-// bar2 < $perr
-// prclose $perr
-// }
+// ```elvish-transcript
+// ~> fn capture [f]{
+//      var pout = (file:pipe)
+//      var perr = (file:pipe)
+//      var out err
+//      run-parallel {
+//        $f > $pout[w] 2> $perr[w]
+//        file:close $pout[w]
+//        file:close $perr[w]
+//      } {
+//        set out = (slurp < $pout[r])
+//        file:close $pout[r]
+//      } {
+//        set err = (slurp < $perr[r])
+//        file:close $perr[r]
+//      }
+//      put $out $err
+//    }
+// ~> capture { echo stdout-test; echo stderr-test >&2 }
+// ▶ "stdout-test\n"
+// ▶ "stderr-test\n"
 // ```
 //
 // This command is intended for doing a fixed number of heterogeneous things in

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -947,6 +947,10 @@ and byte output might not agree with the order in which they happened:
 ▶ a
 ```
 
+If you want to capture the stdout and stderr byte streams independent of each
+other see the example in the [run-parallel](./builtin.html#run-parallel)
+documentation.
+
 ## Exception capture
 
 An **exception capture** expression is formed by putting `?()` around a code


### PR DESCRIPTION
Courtesy of @zzamboni this updates the example of how to use the
`run-parallel` command to capture the stdout and stderr byte streams
independent of each other.

Resolves #1357