### PR TITLE
Update unit tests that use p[rw]close

### DIFF
--- a/pkg/edit/prompt_test.go
+++ b/pkg/edit/prompt_test.go
@@ -88,9 +88,9 @@ func TestPromptStaleThreshold(t *testing.T) {
 		"???> ", Styles,
 		"+++++", term.DotHere)
 
-	evals(f.Evaler, `pwclose $pipe`)
+	evals(f.Evaler, `file:close $pipe[w]`)
 	f.TestTTY(t, "> ", term.DotHere)
-	evals(f.Evaler, `prclose $pipe`)
+	evals(f.Evaler, `file:close $pipe[r]`)
 }
 
 func TestPromptStaleTransform(t *testing.T) {
@@ -102,8 +102,8 @@ func TestPromptStaleTransform(t *testing.T) {
 	defer f.Cleanup()
 
 	f.TestTTY(t, "S???> S", term.DotHere)
-	evals(f.Evaler, `pwclose $pipe`)
-	evals(f.Evaler, `prclose $pipe`)
+	evals(f.Evaler, `file:close $pipe[w]`)
+	evals(f.Evaler, `file:close $pipe[r]`)
 }
 
 func TestPromptStaleTransform_Exception(t *testing.T) {

--- a/pkg/edit/testutils_test.go
+++ b/pkg/edit/testutils_test.go
@@ -8,6 +8,7 @@ import (
 	"src.elv.sh/pkg/cli/term"
 	"src.elv.sh/pkg/cli/tk"
 	"src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval/mods/file"
 	"src.elv.sh/pkg/eval/vals"
 	"src.elv.sh/pkg/eval/vars"
 	"src.elv.sh/pkg/parse"
@@ -58,6 +59,7 @@ func setup(fns ...func(*fixture)) *fixture {
 
 	tty, ttyCtrl := clitest.NewFakeTTY()
 	ev := eval.NewEvaler()
+	ev.AddGlobal(eval.NsBuilder{}.AddNs("file", file.Ns).Ns())
 	ed := NewEditor(tty, ev, st)
 	ev.AddBuiltin(eval.NsBuilder{}.AddNs("edit", ed.Ns()).Ns())
 	evals(ev,

--- a/pkg/eval/evaltest/evaltest.go
+++ b/pkg/eval/evaltest/evaltest.go
@@ -145,9 +145,12 @@ func TestWithSetup(t *testing.T, setup func(*eval.Evaler), tests ...TestCase) {
 			}
 			if !matchErr(tt.want.Exception, r.Exception) {
 				t.Errorf("unexpected exception")
-				t.Logf("got: %v", r.Exception)
 				if exc, ok := r.Exception.(eval.Exception); ok {
+					// For an eval.Exception report the type of the underlying error.
+					t.Logf("got: %T: %v", exc.Reason(), exc)
 					t.Logf("stack trace: %#v", getStackTexts(exc.StackTrace()))
+				} else {
+					t.Logf("got: %T: %v", r.Exception, r.Exception)
 				}
 				t.Errorf("want: %v", tt.want.Exception)
 			}

--- a/pkg/eval/mods/file/file_test.go
+++ b/pkg/eval/mods/file/file_test.go
@@ -43,8 +43,11 @@ func TestFile(t *testing.T) {
 			slurp < $p
 		`).Throws(AnyError),
 
-		That(`p = (file:pipe)`, `echo Legolas > $p`, `file:prclose $p`,
-			`slurp < $p`).Throws(AnyError),
+		// Verify that input redirection from a closed pipe throws an exception. That exception is a
+		// Go stdlib error whose stringified form looks something like "read |0: file already
+		// closed".
+		That(`p = (file:pipe)`, `echo Legolas > $p`, `file:close $p[r]`,
+			`slurp < $p`).Throws(ErrorWithType(&os.PathError{})),
 
 		// Side effect checked below
 		That("echo > file100", "file:truncate file100 100").DoesNothing(),


### PR DESCRIPTION
Replaces uses of the deprecated builtin `prclose` and `pwclose` commands
with `file close` in unit tests.

This also fixes one test that was not verifying what it intended due to
it's use of `.Throws(AnyError)` which was matching an Elvish error caused
by invalid command `file:prclose $p`.