### PR TITLE
epm: fix for xdg-dir

### DIFF
--- a/pkg/eval/mods/bundled/epm.elv.go
+++ b/pkg/eval/mods/bundled/epm.elv.go
@@ -109,7 +109,14 @@ debug-mode = $false
 ]
 
 # Internal configuration
--data-dir = ~/.elvish
+-data-dir = (
+  if (not-eq $E:XDG_DATA_HOME '') {
+    put $E:XDG_DATA_HOME/elvish
+  }  else {
+    put ~/.local/share/elvish
+  }
+)
+
 -lib-dir = $-data-dir/lib
 
 # General utility functions


### PR DESCRIPTION
This fixes the bundled `epm` module to respect the new XDG support.