### PR TITLE
Bump the version to 0.16.3

### DIFF
--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -16,7 +16,7 @@ import (
 
 // Version identifies the version of Elvish. On development commits, it
 // identifies the next release.
-const Version = "0.16.1"
+const Version = "0.16.3"
 
 // VersionSuffix is appended to Version to build the full version string. It is public so it can be
 // overridden when building Elvish; see PACKAGING.md for details.


### PR DESCRIPTION
Latest "0.16.2" release had this version constant left unchanged at "0.16.1".

Fixes #1392