### PR TITLE
Add syntax for string capturing outputs

### DIFF
--- a/pkg/edit/complete/completers.go
+++ b/pkg/edit/complete/completers.go
@@ -76,7 +76,7 @@ func completeCommand(n parse.Node, cfg Config) (*context, []RawItem, error) {
 			return generateForEmpty(n.Range().To)
 		case is(parent, aPrimary):
 			ptype := parent.(*parse.Primary).Type
-			if ptype == parse.OutputCapture || ptype == parse.ExceptionCapture || ptype == parse.Lambda {
+			if ptype == parse.OutputCapture || ptype == parse.ExceptionCapture || ptype == parse.StringOutputCapture || ptype == parse.Lambda {
 				// Case 3: At the beginning of output, exception capture or lambda.
 				//
 				// TODO: Don't trigger after "{|".

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -120,6 +120,14 @@ func TestExceptionCapture(t *testing.T) {
 	)
 }
 
+func TestStringOutputCapture(t *testing.T) {
+	Test(t,
+		// String output capture
+		That("put $(print \"\")").Puts(""),
+		That("put $(print \"lorem\nipsum\")").Puts("lorem\nipsum"),
+	)
+}
+
 func TestVariableUse(t *testing.T) {
 	Test(t,
 		That("x = foo", "put $x").Puts("foo"),

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -408,6 +408,17 @@ var testCases = []struct {
 			}}),
 	},
 	{
+		name: "string output capture",
+		code: "a $() $(b;c)",
+		node: &Chunk{},
+		want: a(
+			ast{"Compound/Indexing/Primary", fs{
+				"Type": StringOutputCapture, "Chunk": ""}},
+			ast{"Compound/Indexing/Primary", fs{
+				"Type": StringOutputCapture, "Chunk": "b;c",
+			}}),
+	},
+	{
 		name: "braced list",
 		code: "{,a,c\ng\n}",
 		node: &Primary{},

--- a/pkg/parse/string.go
+++ b/pkg/parse/string.go
@@ -17,15 +17,16 @@ func _() {
 	_ = x[Tilde-6]
 	_ = x[ExceptionCapture-7]
 	_ = x[OutputCapture-8]
-	_ = x[List-9]
-	_ = x[Lambda-10]
-	_ = x[Map-11]
-	_ = x[Braced-12]
+	_ = x[StringOutputCapture-9]
+	_ = x[List-10]
+	_ = x[Lambda-11]
+	_ = x[Map-12]
+	_ = x[Braced-13]
 }
 
-const _PrimaryType_name = "BadPrimaryBarewordSingleQuotedDoubleQuotedVariableWildcardTildeExceptionCaptureOutputCaptureListLambdaMapBraced"
+const _PrimaryType_name = "BadPrimaryBarewordSingleQuotedDoubleQuotedVariableWildcardTildeExceptionCaptureOutputCaptureStringOutputCaptureListLambdaMapBraced"
 
-var _PrimaryType_index = [...]uint8{0, 10, 18, 30, 42, 50, 58, 63, 79, 92, 96, 102, 105, 111}
+var _PrimaryType_index = [...]uint8{0, 10, 18, 30, 42, 50, 58, 63, 79, 92, 111, 115, 121, 124, 130}
 
 func (i PrimaryType) String() string {
 	if i < 0 || i >= PrimaryType(len(_PrimaryType_index)-1) {


### PR DESCRIPTION
This is more of a proposal for discussion, but this introduces `$(cmd)` which stringifies the output. Originally I was intending to use something like `s(cmd)` to mirror `==s` and such, but realized that that's currently valid as a compounding and so feels like a poor choice.

Docs are TODO since this was more of a quick implementation for my own use anyway.