### PR TITLE
Replace legacy lambda with new lambda examples

### DIFF
--- a/0.17.0-release-notes.md
+++ b/0.17.0-release-notes.md
@@ -22,7 +22,7 @@ or compiled, even if it is not executed:
 -   The lambda syntax that declares arguments and options within `[]` before `{`
     has been deprecated. The new syntax now declares arguments and options
     within a pair of `|`, after `{`. Use the [upgrader](https://go.elv.sh/u0.17)
-    to migrate scripts.
+    to migrate scripts. See ([#664](https://b.elv.sh/664)).
 
 -   Use of the special namespace `local:` is deprecated.
 

--- a/pkg/edit/complete_getopt.go
+++ b/pkg/edit/complete_getopt.go
@@ -63,12 +63,12 @@ import (
 // Example:
 //
 // ```elvish-transcript
-// ~> fn complete [@args]{
+// ~> fn complete {|@args|
 //      opt-specs = [ [&short=a &long=all &desc="Show all"]
 //                    [&short=n &desc="Set name" &arg-required=$true
-//                     &completer= [_]{ put name1 name2 }] ]
-//      arg-handlers = [ [_]{ put first1 first2 }
-//                       [_]{ put second1 second2 } ... ]
+//                     &completer= {|_| put name1 name2 }] ]
+//      arg-handlers = [ {|_| put first1 first2 }
+//                       {|_| put second1 second2 } ... ]
 //      edit:complete-getopt $args $opt-specs $arg-handlers
 //    }
 // ~> complete ''

--- a/pkg/edit/complete_getopt_test.go
+++ b/pkg/edit/complete_getopt_test.go
@@ -11,13 +11,13 @@ import (
 func setupCompleteGetopt(ev *eval.Evaler) {
 	ev.ExtendBuiltin(eval.BuildNs().AddGoFn("complete-getopt", completeGetopt))
 
-	code := `fn complete [@args]{
+	code := `fn complete {|@args|
 	           opt-specs = [ [&short=a &long=all &desc="Show all"]
 	                         [&short=n &long=name &desc="Set name"
 	                          &arg-required=$true &arg-desc='new-name'
-	                          &completer= [_]{ put name1 name2 }] ]
-	           arg-handlers = [ [_]{ put first1 first2 }
-	                            [_]{ put second1 second2 } ... ]
+	                          &completer= {|_| put name1 name2 }] ]
+	           arg-handlers = [ {|_|  put first1 first2 }
+	                            {|_|  put second1 second2 } ... ]
 	           complete-getopt $args $opt-specs $arg-handlers
 	         }`
 	ev.Eval(parse.Source{Name: "[test init]", Code: code}, eval.EvalCfg{})

--- a/pkg/edit/completion.go
+++ b/pkg/edit/completion.go
@@ -118,8 +118,8 @@ func complexCandidate(fm *eval.Frame, opts complexCandidateOpts, stem string) co
 //
 // ```elvish
 // use str
-// fn match-prefix [seed @input]{
-//   each [x]{ str:has-prefix (to-string $x) $seed } $@input
+// fn match-prefix {|seed @input|
+//   each {|x| str:has-prefix (to-string $x) $seed } $@input
 // }
 // ```
 
@@ -146,8 +146,8 @@ func complexCandidate(fm *eval.Frame, opts complexCandidateOpts, stem string) co
 //
 // ```elvish
 // use str
-// fn match-substr [seed @input]{
-//   each [x]{ str:has-contains (to-string $x) $seed } $@input
+// fn match-substr {|seed @input|
+//   each {|x| str:has-contains (to-string $x) $seed } $@input
 // }
 // ```
 

--- a/pkg/edit/completion_test.go
+++ b/pkg/edit/completion_test.go
@@ -95,7 +95,7 @@ func TestCompletionArgCompleter_ArgsAndValueOutput(t *testing.T) {
 	evals(f.Evaler,
 		`foo-args = []`,
 		`fn foo { }`,
-		`edit:completion:arg-completer[foo] = [@args]{
+		`edit:completion:arg-completer[foo] = {|@args|
 		   foo-args = $args
 		   put 1val
 		   edit:complex-candidate 2val &display=2VAL
@@ -119,7 +119,7 @@ func TestCompletionArgCompleter_BytesOutput(t *testing.T) {
 
 	evals(f.Evaler,
 		`fn foo { }`,
-		`edit:completion:arg-completer[foo] = [@args]{
+		`edit:completion:arg-completer[foo] = {|@args|
 		   echo 1val
 		   echo 2val
 		 }`)
@@ -140,7 +140,7 @@ func TestCompleteSudo(t *testing.T) {
 
 	evals(f.Evaler,
 		`fn foo { }`,
-		`edit:completion:arg-completer[foo] = [@args]{
+		`edit:completion:arg-completer[foo] = {|@args|
 		   echo val1
 		   echo val2
 		 }`,

--- a/pkg/edit/config_api_test.go
+++ b/pkg/edit/config_api_test.go
@@ -27,7 +27,7 @@ func TestAfterReadline(t *testing.T) {
 		`called = 0`,
 		`called-with = ''`,
 		`edit:after-readline = [
-	             [code]{ called = (+ $called 1); called-with = $code } ]`)
+		{|code| called = (+ $called 1); called-with = $code } ]`)
 
 	// Wait for UI to stabilize so that we can be sure that after-readline hooks
 	// are *not* called.
@@ -61,43 +61,43 @@ func TestAddCmdFilters(t *testing.T) {
 		// },
 		// {
 		// 	name:        "callback outputs nothing",
-		// 	rc:          "edit:add-cmd-filters = [[_]{}]",
+		// 	rc:          "edit:add-cmd-filters = [{|_| }]",
 		// 	input:       "echo\n",
 		// 	wantHistory: []string{"echo"},
 		// },
 		{
 			name:        "callback outputs true",
-			rc:          "edit:add-cmd-filters = [[_]{ put $true }]",
+			rc:          "edit:add-cmd-filters = [{|_| put $true }]",
 			input:       "echo\n",
 			wantHistory: []storedefs.Cmd{{Text: "echo", Seq: 1}},
 		},
 		{
 			name:        "callback outputs false",
-			rc:          "edit:add-cmd-filters = [[_]{ put $false }]",
+			rc:          "edit:add-cmd-filters = [{|_| put $false }]",
 			input:       "echo\n",
 			wantHistory: nil,
 		},
 		{
 			name:        "false-true chain",
-			rc:          "edit:add-cmd-filters = [[_]{ put $false } [_]{ put $true }]",
+			rc:          "edit:add-cmd-filters = [{|_| put $false } {|_|  put $true }]",
 			input:       "echo\n",
 			wantHistory: nil,
 		},
 		{
 			name:        "true-false chain",
-			rc:          "edit:add-cmd-filters = [[_]{ put $true } [_]{ put $false }]",
+			rc:          "edit:add-cmd-filters = [{|_|  put $true } {|_|  put $false }]",
 			input:       "echo\n",
 			wantHistory: nil,
 		},
 		{
 			name:        "positive",
-			rc:          "edit:add-cmd-filters = [[cmd]{ ==s $cmd echo }]",
+			rc:          "edit:add-cmd-filters = [{|cmd| ==s $cmd echo }]",
 			input:       "echo\n",
 			wantHistory: []storedefs.Cmd{{Text: "echo", Seq: 1}},
 		},
 		{
 			name:        "negative",
-			rc:          "edit:add-cmd-filters = [[cmd]{ ==s $cmd echo }]",
+			rc:          "edit:add-cmd-filters = [{|cmd| ==s $cmd echo }]",
 			input:       "echo x\n",
 			wantHistory: nil,
 		},
@@ -124,7 +124,7 @@ func TestAddCmdFilters(t *testing.T) {
 func TestAddCmdFilters_SkipsRemainingOnFalse(t *testing.T) {
 	f := setup(t, rc(
 		`called = $false`,
-		`@edit:add-cmd-filters = [_]{ put $false } [_]{ called = $true; put $true }`,
+		`@edit:add-cmd-filters = {|_|  put $false } {|_|  called = $true; put $true }`,
 	))
 
 	feedInput(f.TTYCtrl, "echo\n")

--- a/pkg/edit/listing_test.go
+++ b/pkg/edit/listing_test.go
@@ -14,7 +14,7 @@ func TestListingBuiltins(t *testing.T) {
 
 	f := setup(t)
 	evals(f.Evaler,
-		`fn item [x]{ put [&to-show=$x &to-accept=$x &to-filter=$x] }`,
+		`fn item {|x|  put [&to-show=$x &to-accept=$x &to-filter=$x] }`,
 		`edit:listing:start-custom [(item 1) (item 2) (item 3)]`)
 	buf1 := f.MakeBuffer(
 		"~> \n",
@@ -175,7 +175,7 @@ func TestCustomListing_PassingValueCallback(t *testing.T) {
 	f := setup(t)
 
 	evals(f.Evaler,
-		`f = [q]{ put [&to-accept='q '$q &to-show=(styled 'q '$q blue)] }`,
+		`f = {|q|  put [&to-accept='q '$q &to-show=(styled 'q '$q blue)] }`,
 		`edit:listing:start-custom $f &caption=A`)
 	// Query.
 	f.TTYCtrl.Inject(term.K('x'))
@@ -195,7 +195,7 @@ func TestCustomListing_PassingBytesCallback(t *testing.T) {
 	f := setup(t)
 
 	evals(f.Evaler,
-		`f = [q]{ echo '# '$q }`,
+		`f = {|q|  echo '# '$q }`,
 		`edit:listing:start-custom $f &accept=$edit:insert-at-dot~ &caption=A `+
 			`&binding=(edit:binding-table [&Ctrl-X=$edit:listing:accept~])`)
 	// Test that the query function is used to generate candidates. Also test

--- a/pkg/edit/prompt_test.go
+++ b/pkg/edit/prompt_test.go
@@ -91,7 +91,7 @@ func TestPromptStaleTransform(t *testing.T) {
 		`pipe = (file:pipe)`,
 		`edit:prompt = { nop (slurp < $pipe); put '> ' }`,
 		`edit:prompt-stale-threshold = `+scaledMsAsSec(50),
-		`edit:prompt-stale-transform = [a]{ put S; put $a; put S }`))
+		`edit:prompt-stale-transform = {|a|  put S; put $a; put S }`))
 
 	f.TestTTY(t, "S???> S", term.DotHere)
 	evals(f.Evaler, `file:close $pipe[w]`)
@@ -103,7 +103,7 @@ func TestPromptStaleTransform_Exception(t *testing.T) {
 		`pipe = (file:pipe)`,
 		`edit:prompt = { nop (slurp < $pipe); put '> ' }`,
 		`edit:prompt-stale-threshold = `+scaledMsAsSec(50),
-		`edit:prompt-stale-transform = [_]{ fail ERROR }`))
+		`edit:prompt-stale-transform = {|_|  fail ERROR }`))
 
 	f.TestTTYNotes(t,
 		"[prompt stale transform error] ERROR\n",

--- a/pkg/eval/benchmarks_test.go
+++ b/pkg/eval/benchmarks_test.go
@@ -23,7 +23,7 @@ func BenchmarkEval_ForLoop100WithEmptyBody(b *testing.B) {
 }
 
 func BenchmarkEval_EachLoop100WithEmptyBody(b *testing.B) {
-	benchmarkEval(b, "range 100 | each [x]{ }")
+	benchmarkEval(b, "range 100 | each {|_| }")
 }
 
 func BenchmarkEval_LocalVariableAccess(b *testing.B) {

--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -777,7 +777,7 @@ func keys(fm *Frame, v interface{}) error {
 // ▶ c
 // ▶ b
 // ▶ a
-// ~> order &less-than=[a b]{ eq $a x } [l x o r x e x m]
+// ~> order &less-than={|a b|  eq $a x } [l x o r x e x m]
 // ▶ x
 // ▶ x
 // ▶ x
@@ -796,7 +796,7 @@ func keys(fm *Frame, v interface{}) error {
 // ▶ 1
 // ▶ 10
 // ▶ 5
-// ~> order &less-than=[a b]{ < $a $b } [5 1 10]
+// ~> order &less-than={|a b|  < $a $b } [5 1 10]
 // ▶ 1
 // ▶ 5
 // ▶ 10

--- a/pkg/eval/builtin_fn_container_test.go
+++ b/pkg/eval/builtin_fn_container_test.go
@@ -241,38 +241,38 @@ func TestOrder(t *testing.T) {
 		That("put foo bar ipsum | order &reverse").Puts("ipsum", "foo", "bar"),
 
 		// &less-than
-		That("put 1 10 2 5 | order &less-than=[a b]{ < $a $b }").
+		That("put 1 10 2 5 | order &less-than={|a b| < $a $b }").
 			Puts("1", "2", "5", "10"),
 
 		// &less-than writing more than one value
-		That("put 1 10 2 5 | order &less-than=[a b]{ put $true $false }").
+		That("put 1 10 2 5 | order &less-than={|a b| put $true $false }").
 			Throws(
 				errs.BadValue{
 					What:  "output of the &less-than callback",
 					Valid: "a single boolean", Actual: "2 values"},
-				"order &less-than=[a b]{ put $true $false }"),
+				"order &less-than={|a b| put $true $false }"),
 
 		// &less-than writing non-boolean value
-		That("put 1 10 2 5 | order &less-than=[a b]{ put x }").
+		That("put 1 10 2 5 | order &less-than={|a b| put x }").
 			Throws(
 				errs.BadValue{
 					What:  "output of the &less-than callback",
 					Valid: "boolean", Actual: "string"},
-				"order &less-than=[a b]{ put x }"),
+				"order &less-than={|a b| put x }"),
 
 		// &less-than throwing an exception
-		That("put 1 10 2 5 | order &less-than=[a b]{ fail bad }").
+		That("put 1 10 2 5 | order &less-than={|a b| fail bad }").
 			Throws(
 				FailError{"bad"},
-				"fail bad ", "order &less-than=[a b]{ fail bad }"),
+				"fail bad ", "order &less-than={|a b| fail bad }"),
 
 		// &less-than and &reverse
-		That("put 1 10 2 5 | order &reverse &less-than=[a b]{ < $a $b }").
+		That("put 1 10 2 5 | order &reverse &less-than={|a b| < $a $b }").
 			Puts("10", "5", "2", "1"),
 
 		// Sort should be stable - test by pretending that all values but one
 		// are equal, an check that the order among them has not changed.
-		That("put l x o x r x e x m | order &less-than=[a b]{ eq $a x }").
+		That("put l x o x r x e x m | order &less-than={|a b| eq $a x }").
 			Puts("x", "x", "x", "x", "l", "o", "r", "e", "m"),
 
 		thatOutputErrorIsBubbled("order [foo]"),

--- a/pkg/eval/builtin_fn_flow.go
+++ b/pkg/eval/builtin_fn_flow.go
@@ -45,7 +45,7 @@ func init() {
 // different commands in order to independently capture the output of each byte stream:
 //
 // ```elvish-transcript
-// ~> fn capture [f]{
+// ~> fn capture {|f|
 //      var pout = (file:pipe)
 //      var perr = (file:pipe)
 //      var out err
@@ -108,11 +108,11 @@ func runParallel(fm *Frame, functions ...Callable) error {
 // Examples:
 //
 // ```elvish-transcript
-// ~> range 5 8 | each [x]{ * $x $x }
+// ~> range 5 8 | each {|x|  * $x $x }
 // ▶ 25
 // ▶ 36
 // ▶ 49
-// ~> each [x]{ put $x[:3] } [lorem ipsum]
+// ~> each {|x|  put $x[:3] } [lorem ipsum]
 // ▶ lor
 // ▶ ips
 // ```
@@ -167,7 +167,7 @@ func each(fm *Frame, f Callable, inputs Inputs) error {
 // Example (your output will differ):
 //
 // ```elvish-transcript
-// ~> range 1 10 | peach [x]{ + $x 10 }
+// ~> range 1 10 | peach {|x|  + $x 10 }
 // ▶ (num 12)
 // ▶ (num 13)
 // ▶ (num 11)
@@ -178,7 +178,7 @@ func each(fm *Frame, f Callable, inputs Inputs) error {
 // ▶ (num 15)
 // ▶ (num 19)
 // ~> range 1 101 |
-//    peach [x]{ if (== 50 $x) { break } else { put $x } } |
+//    peach {|x|  if (== 50 $x) { break } else { put $x } } |
 //    + (all) # 1+...+49 = 1225; 1+...+100 = 5050
 // ▶ (num 1328)
 // ```
@@ -341,7 +341,7 @@ func returnFn() error {
 //
 // ```elvish-transcript
 // ~> use builtin
-// ~> fn break []{ put 'break'; builtin:break; put 'should not appear' }
+// ~> fn break { put 'break'; builtin:break; put 'should not appear' }
 // ~> for x [a b c] { put $x; break; put 'unexpected' }
 // ▶ a
 // ▶ break
@@ -368,7 +368,7 @@ func breakFn() error {
 //
 // ```elvish-transcript
 // ~> use builtin
-// ~> fn continue []{ put 'continue'; builtin:continue; put 'should not appear' }
+// ~> fn continue { put 'continue'; builtin:continue; put 'should not appear' }
 // ~> for x [a b c] { put $x; continue; put 'unexpected' }
 // ▶ a
 // ▶ continue

--- a/pkg/eval/builtin_fn_flow_test.go
+++ b/pkg/eval/builtin_fn_flow_test.go
@@ -23,11 +23,11 @@ func TestEach(t *testing.T) {
 		That(`echo "1\n233" | each $put~`).Puts("1", "233"),
 		That(`echo "1\r\n233" | each $put~`).Puts("1", "233"),
 		That(`each $put~ [1 233]`).Puts("1", "233"),
-		That(`range 10 | each [x]{ if (== $x 4) { break }; put $x }`).
+		That(`range 10 | each {|x| if (== $x 4) { break }; put $x }`).
 			Puts(0, 1, 2, 3),
-		That(`range 10 | each [x]{ if (== $x 4) { continue }; put $x }`).
+		That(`range 10 | each {|x| if (== $x 4) { continue }; put $x }`).
 			Puts(0, 1, 2, 3, 5, 6, 7, 8, 9),
-		That(`range 10 | each [x]{ if (== $x 4) { fail haha }; put $x }`).
+		That(`range 10 | each {|x| if (== $x 4) { fail haha }; put $x }`).
 			Puts(0, 1, 2, 3).Throws(AnyError),
 		// TODO(xiaq): Test that "each" does not close the stdin.
 	)
@@ -38,10 +38,10 @@ func TestPeach(t *testing.T) {
 	// undefined.
 	Test(t,
 		// Verify the output has the expected values when sorted.
-		That(`range 5 | peach [x]{ * 2 $x } | order`).Puts(0, 2, 4, 6, 8),
+		That(`range 5 | peach {|x| * 2 $x } | order`).Puts(0, 2, 4, 6, 8),
 
 		// Handling of "continue".
-		That(`range 5 | peach [x]{ if (== $x 2) { continue }; * 2 $x } | order`).
+		That(`range 5 | peach {|x| if (== $x 2) { continue }; * 2 $x } | order`).
 			Puts(0, 2, 6, 8),
 
 		// Test that the order of output does not necessarily match the order of
@@ -56,7 +56,7 @@ func TestPeach(t *testing.T) {
 		That(`
 			var @in = (range 100)
 			while $true {
-				var @out = (all $in | peach [x]{ sleep (* (rand) 0.01); put $x })
+				var @out = (all $in | peach {|x| sleep (* (rand) 0.01); put $x })
 				if (not-eq $in $out) {
 					put $true
 					break
@@ -64,14 +64,14 @@ func TestPeach(t *testing.T) {
 			}
 		`).Puts(true),
 		// Verify that exceptions are propagated.
-		That(`peach [x]{ fail $x } [a]`).
-			Throws(FailError{"a"}, "fail $x ", "peach [x]{ fail $x } [a]"),
+		That(`peach {|x| fail $x } [a]`).
+			Throws(FailError{"a"}, "fail $x ", "peach {|x| fail $x } [a]"),
 		// Verify that `break` works by terminating the `peach` before the entire sequence is
 		// consumed.
 		That(`
 			var tot = 0
 			range 1 101 |
-				peach [x]{ if (== 50 $x) { break } else { put $x } } |
+				peach {|x| if (== 50 $x) { break } else { put $x } } |
 				< (+ (all)) (+ (range 1 101))
 		`).Puts(true),
 	)

--- a/pkg/eval/builtin_fn_misc.go
+++ b/pkg/eval/builtin_fn_misc.go
@@ -115,7 +115,7 @@ func kindOf(fm *Frame, args ...interface{}) error {
 // ▶ ipsum
 // ```
 //
-// The above example is actually equivalent to simply `f = []{ put lorem ipsum }`;
+// The above example is actually equivalent to simply `f = { put lorem ipsum }`;
 // it is most useful when the argument is **not** a literal value, e.g.
 //
 // ```elvish-transcript
@@ -126,7 +126,7 @@ func kindOf(fm *Frame, args ...interface{}) error {
 // ▶ Darwin
 // ```
 //
-// The above code only calls `uname` once, while if you do `f = []{ put (uname) }`,
+// The above code only calls `uname` once, while if you do `f = { put (uname) }`,
 // every time you invoke `$f`, `uname` will be called.
 //
 // Etymology: [Clojure](https://clojuredocs.org/clojure.core/constantly).
@@ -232,7 +232,7 @@ func resolve(fm *Frame, head string) string {
 // compilation error: variable $z not found
 // [ttz 2], line 1: put $z
 // ~> saved-ns = $nil
-// ~> eval &on-end=[ns]{ saved-ns = $ns } 'z = lorem'
+// ~> eval &on-end={|ns|  saved-ns = $ns } 'z = lorem'
 // ~> put $saved-ns[z]
 // ▶ lorem
 // ```
@@ -459,10 +459,10 @@ func sleep(fm *Frame, duration interface{}) error {
 // ~> time { sleep 0.01 }
 // 1.288977ms
 // ~> t = ''
-// ~> time &on-end=[x]{ t = $x } { sleep 1 }
+// ~> time &on-end={|x| t = $x } { sleep 1 }
 // ~> put $t
 // ▶ (float64 1.000925004)
-// ~> time &on-end=[x]{ t = $x } { sleep 0.01 }
+// ~> time &on-end={|x| t = $x } { sleep 0.01 }
 // ~> put $t
 // ▶ (float64 0.011030208)
 // ```

--- a/pkg/eval/builtin_fn_misc_test.go
+++ b/pkg/eval/builtin_fn_misc_test.go
@@ -46,7 +46,7 @@ func TestEval(t *testing.T) {
 			Throws(vals.NoSuchKey("x"), "$n[x]"),
 		// However, newly created variable can be accessed in the final
 		// namespace using &on-end.
-		That("eval &on-end=[n]{ put $n[x] } 'x = foo'").Puts("foo"),
+		That("eval &on-end={|n| put $n[x] } 'x = foo'").Puts("foo"),
 		// Parse error.
 		That("eval '['").Throws(AnyError),
 		// Compilation error.
@@ -74,13 +74,13 @@ func TestTime(t *testing.T) {
 		// checks here.
 		That("time { echo foo } | a _ = (all)", "put $a").Puts("foo"),
 		That("duration = ''",
-			"time &on-end=[x]{ duration = $x } { echo foo } | out = (all)",
+			"time &on-end={|x| duration = $x } { echo foo } | out = (all)",
 			"put $out", "kind-of $duration").Puts("foo", "number"),
 		That("time { fail body } | nop (all)").Throws(FailError{"body"}),
-		That("time &on-end=[_]{ fail on-end } { }").Throws(
+		That("time &on-end={|_|  fail on-end } { }").Throws(
 			FailError{"on-end"}),
 
-		That("time &on-end=[_]{ fail on-end } { fail body }").Throws(
+		That("time &on-end={|_|  fail on-end } { fail body }").Throws(
 			FailError{"body"}),
 
 		thatOutputErrorIsBubbled("time { }"),

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -161,8 +161,8 @@ var eawkWordSep = regexp.MustCompile("[ \t]+")
 // It should behave the same as the following functions:
 //
 // ```elvish
-// fn eawk [f @rest]{
-//   each [line]{
+// fn eawk {|f @rest|
+//   each {|line|
 //     @fields = (re:split '[ \t]+'
 //     (re:replace '^[ \t]+|[ \t]+$' '' $line))
 //     $f $line $@fields
@@ -179,7 +179,7 @@ var eawkWordSep = regexp.MustCompile("[ \t]+")
 // lorem
 // 1
 // ~> echo ' lorem ipsum
-// 1 2' | eawk [line a b]{ put $a }
+// 1 2' | eawk {|line a b| put $a }
 // ▶ lorem
 // ▶ 1
 // ```

--- a/pkg/eval/builtin_fn_str_test.go
+++ b/pkg/eval/builtin_fn_str_test.go
@@ -53,14 +53,14 @@ func TestWcswidth(t *testing.T) {
 
 func TestEawk(t *testing.T) {
 	Test(t,
-		That(`echo "  ax  by cz  \n11\t22 33" | eawk [@a]{ put $a[-1] }`).
+		That(`echo "  ax  by cz  \n11\t22 33" | eawk {|@a| put $a[-1] }`).
 			Puts("cz", "33"),
 		// Bad input type
-		That(`num 42 | eawk [@a]{ fail "this should not run" }`).
+		That(`num 42 | eawk {|@a| fail "this should not run" }`).
 			Throws(ErrInputOfEawkMustBeString),
 		// Propagation of exception
 		That(`
-			to-lines [1 2 3 4] | eawk [@a]{
+			to-lines [1 2 3 4] | eawk {|@a|
 				if (==s 3 $a[1]) {
 					fail "stop eawk"
 				}
@@ -69,7 +69,7 @@ func TestEawk(t *testing.T) {
 		`).Puts("1", "2").Throws(FailError{"stop eawk"}),
 		// break
 		That(`
-			to-lines [" a" "b\tc " "d" "e"] | eawk [@a]{
+			to-lines [" a" "b\tc " "d" "e"] | eawk {|@a|
 				if (==s d $a[1]) {
 					break
 				} else {
@@ -79,7 +79,7 @@ func TestEawk(t *testing.T) {
 		`).Puts("a", "c"),
 		// continue
 		That(`
-			to-lines [" a" "b\tc " "d" "e"] | eawk [@a]{
+			to-lines [" a" "b\tc " "d" "e"] | eawk {|@a|
 				if (==s d $a[1]) {
 					continue
 				} else {

--- a/pkg/eval/builtin_fn_styled.go
+++ b/pkg/eval/builtin_fn_styled.go
@@ -29,7 +29,7 @@ func init() {
 // Probably the only reason to use it is to build custom style transformers:
 //
 // ```elvish
-// fn my-awesome-style-transformer [seg]{ styled-segment $seg &bold=(not $seg[dim]) &dim=(not $seg[italic]) &italic=$seg[bold] }
+// fn my-awesome-style-transformer {|seg|  styled-segment $seg &bold=(not $seg[dim]) &dim=(not $seg[italic]) &italic=$seg[bold] }
 // styled abc $my-awesome-style-transformer~
 // ```
 //

--- a/pkg/eval/builtin_fn_styled_test.go
+++ b/pkg/eval/builtin_fn_styled_test.go
@@ -49,14 +49,14 @@ func TestStyled(t *testing.T) {
 		That("print (styled (styled abc inverse) toggle-inverse toggle-inverse)").Prints("\033[7mabc\033[m"),
 
 		// Function as transformer
-		That("print (styled abc [s]{ put $s })").Prints("abc"),
-		That("print (styled abc [s]{ styled-segment $s &bold=$true &italic=$false })").Prints("\033[1mabc\033[m"),
-		That("print (styled abc italic [s]{ styled-segment $s &bold=$true &italic=$false })").Prints("\033[1mabc\033[m"),
+		That("print (styled abc {|s| put $s })").Prints("abc"),
+		That("print (styled abc {|s| styled-segment $s &bold=$true &italic=$false })").Prints("\033[1mabc\033[m"),
+		That("print (styled abc italic {|s| styled-segment $s &bold=$true &italic=$false })").Prints("\033[1mabc\033[m"),
 
-		That("styled abc [s]{ fail bad }").Throws(eval.FailError{"bad"}),
-		That("styled abc [s]{ put a b }").Throws(ErrorWithMessage(
+		That("styled abc {|_| fail bad }").Throws(eval.FailError{"bad"}),
+		That("styled abc {|_| put a b }").Throws(ErrorWithMessage(
 			"styling function must return a single segment; got 2 values")),
-		That("styled abc [s]{ put [] }").Throws(ErrorWithMessage(
+		That("styled abc {|_| put [] }").Throws(ErrorWithMessage(
 			"styling function must return a segment; got list")),
 
 		// Bad usage

--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -229,7 +229,7 @@ func (op *delElemOp) exec(fm *Frame) Exception {
 
 // FnForm = 'fn' StringPrimary LambdaPrimary
 //
-// fn f []{foobar} is a shorthand for set '&'f = []{foobar}.
+// fn f { foobar } is a shorthand for set '&'f = { foobar }.
 func compileFn(cp *compiler, fn *parse.Form) effectOp {
 	args := cp.walkArgs(fn)
 	nameNode := args.next()

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -291,16 +291,16 @@ func TestFor(t *testing.T) {
 
 func TestFn(t *testing.T) {
 	Test(t,
-		That("fn f [x]{ put x=$x'.' }; f lorem; f ipsum").
+		That("fn f {|x| put x=$x'.' }; f lorem; f ipsum").
 			Puts("x=lorem.", "x=ipsum."),
 		// Recursive functions with fn. Regression test for #1206.
-		That("fn f [n]{ if (== $n 0) { num 1 } else { * $n (f (- $n 1)) } }; f 3").
+		That("fn f {|n| if (== $n 0) { num 1 } else { * $n (f (- $n 1)) } }; f 3").
 			Puts(6),
 		// Exception thrown by return is swallowed by a fn-defined function.
-		That("fn f []{ put a; return; put b }; f").Puts("a"),
+		That("fn f { put a; return; put b }; f").Puts("a"),
 
 		// Error when evaluating the lambda
-		That("fn f [&opt=(fail x)]{ }").Throws(FailError{"x"}, "fail x"),
+		That("fn f {|&opt=(fail x)| }").Throws(FailError{"x"}, "fail x"),
 	)
 }
 

--- a/pkg/eval/chdir_test.go
+++ b/pkg/eval/chdir_test.go
@@ -52,8 +52,8 @@ func TestChdirElvishHooks(t *testing.T) {
 	Test(t,
 		That(`
 			dir-in-before dir-in-after = '' ''
-			@before-chdir = [dst]{ dir-in-before = $dst }
-			@after-chdir  = [dst]{ dir-in-after  = $dst }
+			@before-chdir = {|dst| dir-in-before = $dst }
+			@after-chdir  = {|dst| dir-in-after  = $dst }
 			cd `+parse.Quote(dst)+`
 			put $dir-in-before $dir-in-after
 			`).Puts(dst, dst),

--- a/pkg/eval/closure_test.go
+++ b/pkg/eval/closure_test.go
@@ -18,28 +18,28 @@ func TestClosureAsValue(t *testing.T) {
 		That("x = { }; put [&$x= foo][$x]").Puts("foo"),
 
 		// Argument arity mismatch.
-		That("f = [x]{ }", "$f a b").Throws(
+		That("f = {|x| }", "$f a b").Throws(
 			errs.ArityMismatch{What: "arguments",
 				ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"$f a b"),
-		That("f = [x y]{ }", "$f a").Throws(
+		That("f = {|x y| }", "$f a").Throws(
 			errs.ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: 2, Actual: 1},
 			"$f a"),
-		That("f = [x y @rest]{ }", "$f a").Throws(
+		That("f = {|x y @rest| }", "$f a").Throws(
 			errs.ArityMismatch{What: "arguments", ValidLow: 2, ValidHigh: -1, Actual: 1},
 			"$f a"),
 
 		// Unsupported option.
-		That("f = [&valid1=1 &valid2=2]{ }; $f &bad1=1 &bad2=2").Throws(
+		That("f = {|&valid1=1 &valid2=2| }; $f &bad1=1 &bad2=2").Throws(
 			eval.UnsupportedOptionsError{[]string{"bad1", "bad2"}},
 			"$f &bad1=1 &bad2=2"),
 
-		That("all [a b]{ }[arg-names]").Puts("a", "b"),
-		That("put [@r]{ }[rest-arg]").Puts("0"),
-		That("all [&opt=def]{ }[opt-names]").Puts("opt"),
-		That("all [&opt=def]{ }[opt-defaults]").Puts("def"),
+		That("all {|a b| }[arg-names]").Puts("a", "b"),
+		That("put {|@r| }[rest-arg]").Puts("0"),
+		That("all {|&opt=def| }[opt-names]").Puts("opt"),
+		That("all {|&opt=def| }[opt-defaults]").Puts("def"),
 		That("put { body }[body]").Puts("body "),
-		That("put [x @y]{ body }[def]").Puts("[x @y]{ body }"),
+		That("put {|x @y| body }[def]").Puts("{|x @y| body }"),
 		That("put { body }[src][code]").
 			Puts("put { body }[src][code]"),
 

--- a/pkg/eval/compile_effect_test.go
+++ b/pkg/eval/compile_effect_test.go
@@ -29,7 +29,7 @@ func TestPipeline(t *testing.T) {
 		That(`echo "Albert\nAllan\nAlbraham\nBerlin" | sed s/l/1/g | grep e`).
 			Prints("A1bert\nBer1in\n"),
 		// Pure value pipeline
-		That(`put 233 42 19 | each [x]{+ $x 10}`).Puts(243, 52, 29),
+		That(`put 233 42 19 | each {|x|+ $x 10}`).Puts(243, 52, 29),
 		// Pipeline draining.
 		That(`range 100 | put x`).Puts("x"),
 		// TODO: Add a useful hybrid pipeline sample

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -185,12 +185,12 @@ func TestVariableUse_DeprecatedSpecialNamespaces(t *testing.T) {
 
 func TestClosure(t *testing.T) {
 	Test(t,
-		That("[]{ }").DoesNothing(),
-		That("[x]{put $x} foo").Puts("foo"),
+		That("{|| }").DoesNothing(),
+		That("{|x| put $x} foo").Puts("foo"),
 
 		// Assigning to captured variable
-		That("var x = lorem; []{set x = ipsum}; put $x").Puts("ipsum"),
-		That("var x = lorem; []{ put $x; set x = ipsum }; put $x").
+		That("var x = lorem; {|| set x = ipsum}; put $x").Puts("ipsum"),
+		That("var x = lorem; {|| put $x; set x = ipsum }; put $x").
 			Puts("lorem", "ipsum"),
 
 		// Assigning to element of captured variable
@@ -198,46 +198,46 @@ func TestClosure(t *testing.T) {
 		That("x = [a]; { x[0] = b }; put $x[0]").Puts("b"),
 
 		// Shadowing
-		That("var x = ipsum; []{ var x = lorem; put $x }; put $x").
+		That("var x = ipsum; { var x = lorem; put $x }; put $x").
 			Puts("lorem", "ipsum"),
 
 		// Shadowing by argument
-		That("var x = ipsum; [x]{ put $x; set x = BAD } lorem; put $x").
+		That("var x = ipsum; {|x| put $x; set x = BAD } lorem; put $x").
 			Puts("lorem", "ipsum"),
 
 		// Closure captures new local variables every time
-		That("fn f []{ var x = (num 0); put { set x = (+ $x 1) } { put $x } }",
+		That("fn f { var x = (num 0); put { set x = (+ $x 1) } { put $x } }",
 			"var inc1 put1 = (f); $put1; $inc1; $put1",
 			"var inc2 put2 = (f); $put2; $inc2; $put2").Puts(0, 1, 0, 1),
 
 		// Rest argument.
-		That("[x @xs]{ put $x $xs } a b c").Puts("a", vals.MakeList("b", "c")),
-		That("[a @b c]{ put $a $b $c } a b c d").
+		That("{|x @xs| put $x $xs } a b c").Puts("a", vals.MakeList("b", "c")),
+		That("{|a @b c| put $a $b $c } a b c d").
 			Puts("a", vals.MakeList("b", "c"), "d"),
 		// Options.
-		That("[a &k=v]{ put $a $k } foo &k=bar").Puts("foo", "bar"),
+		That("{|a &k=v| put $a $k } foo &k=bar").Puts("foo", "bar"),
 		// Option default value.
-		That("[a &k=v]{ put $a $k } foo").Puts("foo", "v"),
+		That("{|a &k=v| put $a $k } foo").Puts("foo", "v"),
 		// Option must have default value
-		That("[&k]{ }").DoesNotCompile(),
+		That("{|&k| }").DoesNotCompile(),
 		// Exception when evaluating option default value.
-		That("[&a=[][0]]{ }").Throws(ErrorWithType(errs.OutOfRange{}), "[][0]"),
+		That("{|&a=[][0]| }").Throws(ErrorWithType(errs.OutOfRange{}), "[][0]"),
 		// Option default value must be one value.
-		That("[&a=(put foo bar)]{ }").Throws(
+		That("{|&a=(put foo bar)| }").Throws(
 			errs.ArityMismatch{What: "option default value", ValidLow: 1, ValidHigh: 1, Actual: 2},
 			"(put foo bar)"),
 
 		// Argument name must be unqualified.
-		That("[a:b]{ }").DoesNotCompile(),
+		That("{|a:b| }").DoesNotCompile(),
 		// Argument name must not be empty.
-		That("['']{ }").DoesNotCompile(),
-		That("[@]{ }").DoesNotCompile(),
+		That("{|''| }").DoesNotCompile(),
+		That("{|@| }").DoesNotCompile(),
 		// Option name must be unqualified.
-		That("[&a:b=1]{ }").DoesNotCompile(),
+		That("{|&a:b=1| }").DoesNotCompile(),
 		// Option name must not be empty.
-		That("[&''=b]{ }").DoesNotCompile(),
+		That("{|&''=b| }").DoesNotCompile(),
 		// Should not have multiple rest arguments.
-		That("[@a @b]{ }").DoesNotCompile(),
+		That("{|@a @b| }").DoesNotCompile(),
 	)
 }
 

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -96,8 +96,8 @@ type Evaler struct {
 // following example also shows `$before-chdir`:
 //
 // ```elvish-transcript
-// ~> before-chdir = [[dir]{ echo "Going to change to "$dir", pwd is "$pwd }]
-// ~> after-chdir = [[dir]{ echo "Changed to "$dir", pwd is "$pwd }]
+// ~> before-chdir = [{|dir| echo "Going to change to "$dir", pwd is "$pwd }]
+// ~> after-chdir = [{|dir| echo "Changed to "$dir", pwd is "$pwd }]
 // ~> cd /usr
 // Going to change to /usr, pwd is /Users/xiaq
 // Changed to /usr, pwd is /usr

--- a/pkg/mods/re/re.go
+++ b/pkg/mods/re/re.go
@@ -165,7 +165,7 @@ func find(fm *eval.Frame, opts findOpts, argPattern, source string) error {
 // ▶ 'baSH and zSH'
 // ~> re:replace '(ba|z)sh' elvish 'bash and zsh rock'
 // ▶ 'elvish and elvish rock'
-// ~> re:replace '(ba|z)sh' [x]{ put [&bash=BaSh &zsh=ZsH][$x] } 'bash and zsh'
+// ~> re:replace '(ba|z)sh' {|x| put [&bash=BaSh &zsh=ZsH][$x] } 'bash and zsh'
 // ▶ 'BaSh and ZsH'
 // ```
 

--- a/pkg/mods/re/re_test.go
+++ b/pkg/mods/re/re_test.go
@@ -50,19 +50,19 @@ func TestRe(t *testing.T) {
 
 		That("re:replace '(ba|z)sh' '${1}SH' 'bash and zsh'").Puts("baSH and zSH"),
 		That("re:replace &literal '(ba|z)sh' '$sh' 'bash and zsh'").Puts("$sh and $sh"),
-		That("re:replace '(ba|z)sh' [x]{ put [&bash=BaSh &zsh=ZsH][$x] } 'bash and zsh'").Puts("BaSh and ZsH"),
+		That("re:replace '(ba|z)sh' {|x| put [&bash=BaSh &zsh=ZsH][$x] } 'bash and zsh'").Puts("BaSh and ZsH"),
 
 		// Invalid pattern in re:replace
 		That("re:replace '(' x bash").Throws(AnyError),
 		That("re:replace &posix '[[:argle:]]' x bash").Throws(AnyError),
 		// Replacement function outputs more than one value
-		That("re:replace x [x]{ put a b } xx").Throws(AnyError),
+		That("re:replace x {|x| put a b } xx").Throws(AnyError),
 		// Replacement function outputs non-string value
-		That("re:replace x [x]{ put [] } xx").Throws(AnyError),
+		That("re:replace x {|x| put [] } xx").Throws(AnyError),
 		// Replacement is not string or function
 		That("re:replace x [] xx").Throws(AnyError),
 		// Replacement is function when &literal is set
-		That("re:replace &literal x [_]{ put y } xx").Throws(AnyError),
+		That("re:replace &literal x {|_| put y } xx").Throws(AnyError),
 
 		That("re:split : /usr/sbin:/usr/bin:/bin").Puts("/usr/sbin", "/usr/bin", "/bin"),
 		That("re:split &max=2 : /usr/sbin:/usr/bin:/bin").Puts("/usr/sbin", "/usr/bin:/bin"),

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -477,7 +477,7 @@ type Primary struct {
 	node
 	ExprCtx ExprCtx
 	Type    PrimaryType
-	// Legacy lambda uses [args]{ body } instead of { |args| body }
+	// Legacy lambda uses {|args| body } instead of { |args| body }
 	LegacyLambda bool
 	// The unquoted string value. Valid for Bareword, SingleQuoted,
 	// DoubleQuoted, Variable, Wildcard and Tilde.


### PR DESCRIPTION
I was surprised to see so many legacy lambda syntax examples in the
documentation. This replaces all of them with the new syntax -- excluding
the handful of cases meant to explicitly verify the legacy form is still
valid. This also adds a link to the issue in the release notes which
documents the change in syntax.

Related #664