### PR TITLE
Use vals.NumType constants rather than zero

### DIFF
--- a/pkg/eval/builtin_fn_container.go
+++ b/pkg/eval/builtin_fn_container.go
@@ -1119,7 +1119,7 @@ func cmp(a, b interface{}) ordering {
 	case int, *big.Int, *big.Rat, float64:
 		switch b.(type) {
 		case int, *big.Int, *big.Rat, float64:
-			a, b := vals.UnifyNums2(a, b, 0)
+			a, b := vals.UnifyNums2(a, b, vals.Int)
 			switch a := a.(type) {
 			case int:
 				return compareInt(a, b.(int))

--- a/pkg/eval/builtin_fn_num.go
+++ b/pkg/eval/builtin_fn_num.go
@@ -248,7 +248,7 @@ func chainCompare(nums []vals.Num,
 
 	for i := 0; i < len(nums)-1; i++ {
 		var r bool
-		a, b := vals.UnifyNums2(nums[i], nums[i+1], 0)
+		a, b := vals.UnifyNums2(nums[i], nums[i+1], vals.Int)
 		switch a := a.(type) {
 		case int:
 			r = p1(a, b.(int))

--- a/pkg/eval/vals/num.go
+++ b/pkg/eval/vals/num.go
@@ -65,14 +65,15 @@ func ParseNum(s string) Num {
 }
 
 // NumType represents a number type.
-type NumType uint8
+type NumType int8
 
-// PromoteToBigInt converts an int or *big.Int to a *big.Int. It panics if n is
-// any other type.
-// Possible values for NumType, sorted in the order of implicit conversion
-// (lower types can be implicitly converted to higher types).
+// Possible values for NumType, sorted in the order of implicit conversion (lower types can be
+// implicitly converted to higher types). These are used by functions like UnifyNums and UnifyNums2
+// to specify which number type the caller desires all values to be. We use iota-13 rather than iota
+// as the base value to catch mistakes where a caller is using an explicit int (e.g., zero) rather
+// than one of these symbols.
 const (
-	Int NumType = iota
+	Int NumType = iota - 13
 	BigInt
 	BigRat
 	Float64

--- a/pkg/eval/vals/num_test.go
+++ b/pkg/eval/vals/num_test.go
@@ -86,7 +86,7 @@ func TestUnifyNums2(t *testing.T) {
 
 func TestInvalidNumType(t *testing.T) {
 	Test(t, Fn("Recover", testutil.Recover), Table{
-		Args(func() { UnifyNums([]Num{int32(0)}, 0) }).Rets("invalid num type int32"),
+		Args(func() { UnifyNums([]Num{int32(0)}, Int) }).Rets("invalid num type int32"),
 		Args(func() { PromoteToBigInt(int32(0)) }).Rets("invalid num type int32"),
 		Args(func() { PromoteToBigRat(int32(0)) }).Rets("invalid num type int32"),
 		Args(func() { ConvertToFloat64(int32(0)) }).Rets("invalid num type int32"),

--- a/pkg/mods/math/math.go
+++ b/pkg/mods/math/math.go
@@ -456,7 +456,7 @@ func max(rawNums ...vals.Num) (vals.Num, error) {
 	if len(rawNums) == 0 {
 		return nil, errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0}
 	}
-	nums := vals.UnifyNums(rawNums, 0)
+	nums := vals.UnifyNums(rawNums, vals.Int)
 	switch nums := nums.(type) {
 	case []int:
 		n := nums[0]
@@ -519,7 +519,7 @@ func min(rawNums ...vals.Num) (vals.Num, error) {
 	if len(rawNums) == 0 {
 		return nil, errs.ArityMismatch{What: "arguments", ValidLow: 1, ValidHigh: -1, Actual: 0}
 	}
-	nums := vals.UnifyNums(rawNums, 0)
+	nums := vals.UnifyNums(rawNums, vals.Int)
 	switch nums := nums.(type) {
 	case []int:
 		n := nums[0]


### PR DESCRIPTION
While working on my implementation of unix:ulimit I realized I needed
to use vals.UnifyNums(). Looking at the existing uses I was dismayed to
find several instances that pass a literal zero (a magic value) rather
than the symbolic vals.Int constant. This replaces those literal zeros
with Vals.Int and modifies the implementation to make using a literal
int where a const symbol is expected more difficult.