### PR TITLE
No filtering when constructing the candidate list during completion

### DIFF
--- a/pkg/cli/modes/completion.go
+++ b/pkg/cli/modes/completion.go
@@ -22,7 +22,6 @@ type CompletionSpec struct {
 	Replace  diag.Ranging
 	Items    []CompletionItem
 	Filter   FilterSpec
-	Seed     string
 }
 
 // CompletionItem represents a completion item, also known as a candidate.
@@ -55,7 +54,6 @@ func NewCompletion(app cli.App, cfg CompletionSpec) (Completion, error) {
 		CodeArea: tk.CodeAreaSpec{
 			Prompt:      modePrompt(" COMPLETING "+cfg.Name+" ", true),
 			Highlighter: cfg.Filter.Highlighter,
-			State:       tk.CodeAreaState{Buffer: tk.CodeBuffer{Content: cfg.Seed, Dot: len(cfg.Seed)}},
 		},
 		ListBox: tk.ListBoxSpec{
 			Horizontal: true,
@@ -77,7 +75,6 @@ func NewCompletion(app cli.App, cfg CompletionSpec) (Completion, error) {
 			w.ListBox().Reset(filterCompletionItems(cfg.Items, cfg.Filter.makePredicate(p)), 0)
 		},
 	})
-	w.Refilter()
 	return completion{w, codeArea}, nil
 }
 

--- a/pkg/cli/modes/completion.go
+++ b/pkg/cli/modes/completion.go
@@ -22,6 +22,7 @@ type CompletionSpec struct {
 	Replace  diag.Ranging
 	Items    []CompletionItem
 	Filter   FilterSpec
+	Seed     string
 }
 
 // CompletionItem represents a completion item, also known as a candidate.
@@ -54,6 +55,7 @@ func NewCompletion(app cli.App, cfg CompletionSpec) (Completion, error) {
 		CodeArea: tk.CodeAreaSpec{
 			Prompt:      modePrompt(" COMPLETING "+cfg.Name+" ", true),
 			Highlighter: cfg.Filter.Highlighter,
+			State:       tk.CodeAreaState{Buffer: tk.CodeBuffer{Content: cfg.Seed, Dot: len(cfg.Seed)}},
 		},
 		ListBox: tk.ListBoxSpec{
 			Horizontal: true,
@@ -75,6 +77,7 @@ func NewCompletion(app cli.App, cfg CompletionSpec) (Completion, error) {
 			w.ListBox().Reset(filterCompletionItems(cfg.Items, cfg.Filter.makePredicate(p)), 0)
 		},
 	})
+	w.Refilter()
 	return completion{w, codeArea}, nil
 }
 

--- a/pkg/edit/complete/complete.go
+++ b/pkg/edit/complete/complete.go
@@ -45,7 +45,6 @@ type Result struct {
 	Name    string
 	Replace diag.Ranging
 	Items   []modes.CompletionItem
-	Seed    string
 }
 
 // RawItem represents completion items before the quoting pass.
@@ -102,7 +101,7 @@ func Complete(code CodeBuffer, cfg Config) (*Result, error) {
 			return items[i].ToShow < items[j].ToShow
 		})
 		items = dedup(items)
-		return &Result{Name: ctx.name, Seed: ctx.seed, Items: items, Replace: ctx.interval}, nil
+		return &Result{Name: ctx.name, Items: items, Replace: ctx.interval}, nil
 	}
 	return nil, errNoCompletion
 }

--- a/pkg/edit/completion_test.go
+++ b/pkg/edit/completion_test.go
@@ -42,7 +42,7 @@ func TestCompletionAddon_CompletesLongestCommonPrefix(t *testing.T) {
 		"~> echo foo \n", Styles,
 		"   vvvv ____",
 		" COMPLETING argument  ", Styles,
-		"********************* ", term.DotHere, "\n",
+		"********************* ", "fo", term.DotHere, "\n",
 		"foo  foo1  foo2  fox", Styles,
 		"+++                 ",
 	)
@@ -159,7 +159,7 @@ func TestCompletionMatcher(t *testing.T) {
 		"~> echo foo \n", Styles,
 		"   vvvv ____",
 		" COMPLETING argument  ", Styles,
-		"********************* ", term.DotHere, "\n",
+		"********************* ", "f", term.DotHere, "\n",
 		"foo  oof", Styles,
 		"+++     ",
 	)

--- a/website/learn/faq.md
+++ b/website/learn/faq.md
@@ -51,7 +51,7 @@ other interfaces, and the author might explore this space at a later stage.
 
 # Why is Elvish called Elvish?
 
-Elvish is named after **elven** items in in
+Elvish is named after **elven** items in
 [roguelikes](https://en.wikipedia.org/wiki/Roguelike), which has a reputation of
 high quality. You can think of Elvish as an abbreviation of "elven shell".
 


### PR DESCRIPTION
No unit test, though. Only tested completing variables (`$edit:re`) and paths. 

Notes:
1. The initial candidate list is longer filtered by prefix. Filtering is done by `ComboBox` and considers substrings by default. 
2. Smart-start is unchanged. it is triggered iff. all candidates with the same prefix share a longer common prefix. That is, it's possible that smart-start is triggered even if the initial candidate list contains an item not starting with the seed. 