### PR TITLE
pkg/edit: Don't call AddDir on storedefs if it is not ready

### DIFF
--- a/pkg/edit/listing.go
+++ b/pkg/edit/listing.go
@@ -124,9 +124,12 @@ func initLocation(ed *Editor, ev *eval.Evaler, st storedefs.Store, commonBinding
 			// TODO(xiaq): Surface the error.
 			return
 		}
-		st.AddDir(wd, 1)
+		// If st is not ready - don't try to call it
+		if st != nil {
+			st.AddDir(wd, 1)
+		}
 		kind, root := workspaceIterator.Parse(wd)
-		if kind != "" {
+		if kind != "" && st != nil {
 			st.AddDir(kind+wd[len(root):], 1)
 		}
 	})


### PR DESCRIPTION
If storedef.store is not initialized i.e. == nil this leads to a panic. Before calling we should check if it is save to call storedef.store or not.

Signed-off-by: Christian Walter <christian.walter@9elements.com>