### PR TITLE
On Windows, implement sanitize in pkg/cli/term/setup_windows.

### DIFF
--- a/pkg/cli/term/setup.go
+++ b/pkg/cli/term/setup.go
@@ -16,8 +16,8 @@ func Setup(in, out *os.File) (func() error, error) {
 }
 
 // SetupGlobal sets up the terminal for the entire Elvish session.
-func SetupGlobal() func() {
-	return setupGlobal()
+func SetupGlobal(in, out *os.File) func() {
+	return setupGlobal(in, out)
 }
 
 // Sanitize sanitizes the terminal after an external command has executed.

--- a/pkg/cli/term/setup_unix.go
+++ b/pkg/cli/term/setup_unix.go
@@ -52,7 +52,7 @@ func setup(in, out *os.File) (func() error, error) {
 	return restore, errSetupVT
 }
 
-func setupGlobal() func() {
+func setupGlobal(in, out *os.File) func() {
 	return func() {}
 }
 

--- a/pkg/cli/term/setup_windows_test.go
+++ b/pkg/cli/term/setup_windows_test.go
@@ -1,0 +1,109 @@
+package term
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestSetupGlobalTerminal(t *testing.T) {
+	in, out, release, err := createStdInOut()
+	if err != nil {
+		t.Errorf("cannot open stdin/stdout %v", err)
+		return
+	}
+	defer release()
+
+	initialOutMode, _ := getConsoleMode(out)
+	initialOutMode = initialOutMode &^ windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	setConsoleMode(out, initialOutMode)
+
+	// check that mode is for control sequences
+	restore := setupGlobal(in, out)
+	err = assertConsoleMode(
+		out,
+		initialOutMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	if err != nil {
+		t.Errorf("got err %v, want nil", err)
+		return
+	}
+
+	// check that mode is restored
+	restore()
+	err = assertConsoleMode(
+		out,
+		initialOutMode)
+	if err != nil {
+		t.Errorf("got err %v, want nil", err)
+		return
+	}
+}
+
+func TestSanitizeTerminal(t *testing.T) {
+	in, out, release, err := createStdInOut()
+	if err != nil {
+		t.Errorf("cannot open stdin/stdout %v", err)
+		return
+	}
+	defer release()
+
+	initialOutMode, _ := getConsoleMode(out)
+	setConsoleMode(out, initialOutMode)
+
+	setupGlobal(in, out)
+
+	// break console mode
+	setConsoleMode(out, initialOutMode&^windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+
+	sanitize(in, out)
+
+	// check that sanitized
+	err = assertConsoleMode(
+		out,
+		initialOutMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	if err != nil {
+		t.Errorf("got err %v, want nil", err)
+		return
+	}
+}
+
+func assertConsoleMode(file *os.File, want uint32) error {
+	got, err := getConsoleMode(file)
+	if err != nil {
+		return err
+	} else if got != want {
+		return fmt.Errorf("got %b, want %b", got, want)
+	} else {
+		return nil
+	}
+}
+
+// open stdin/stdout manually because os.Stdin/os.Stdout cannot use in testing
+func createStdInOut() (*os.File, *os.File, func(), error) {
+	in, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	out, err := os.OpenFile("CONOUT$", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	release := func() {
+		in.Close()
+		out.Close()
+	}
+	return in, out, release, nil
+}
+
+func setConsoleMode(file *os.File, mode uint32) error {
+	err := windows.SetConsoleMode(windows.Handle(file.Fd()), mode)
+	return err
+}
+
+func getConsoleMode(file *os.File) (uint32, error) {
+	var mode uint32
+	err := windows.GetConsoleMode(windows.Handle(file.Fd()), &mode)
+	return mode, err
+}

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -30,7 +30,7 @@ type Program struct {
 func (p Program) Run(fds [3]*os.File, f *prog.Flags, args []string) error {
 	cleanup1 := IncSHLVL()
 	defer cleanup1()
-	cleanup2 := initTTYAndSignal(fds[2])
+	cleanup2 := initTTYAndSignal(fds)
 	defer cleanup2()
 
 	ev := MakeEvaler(fds[2])
@@ -105,14 +105,14 @@ func IncSHLVL() func() {
 	}
 }
 
-func initTTYAndSignal(stderr io.Writer) func() {
-	restoreTTY := term.SetupGlobal()
+func initTTYAndSignal(fds [3]*os.File) func() {
+	restoreTTY := term.SetupGlobal(fds[0], fds[2])
 
 	sigCh := sys.NotifySignals()
 	go func() {
 		for sig := range sigCh {
 			logger.Println("signal", sig)
-			handleSignal(sig, stderr)
+			handleSignal(sig, fds[2])
 		}
 	}()
 


### PR DESCRIPTION
This PR will fixes a part of (not all) #1182, and the last of #798.
I tested on the case in #1005.

I tested with vim in Git for Windows 2.34.1.windows.1 that changes stdout's console modes.
1. Open vim
2. Close vim
3. Cause a error in elvish

Before this PR, the indent in output after this will broken.