### PR TITLE
On Windows, handle SIGTERM and exit immediately when conhost window was closed.

### DIFF
--- a/pkg/shell/signal_windows.go
+++ b/pkg/shell/signal_windows.go
@@ -3,7 +3,12 @@ package shell
 import (
 	"io"
 	"os"
+	"syscall"
 )
 
-func handleSignal(os.Signal, io.Writer) {
+func handleSignal(sig os.Signal, stderr io.Writer) {
+	switch sig {
+	case syscall.SIGTERM:
+		os.Exit(0)
+	}
 }


### PR DESCRIPTION
On conhost window (command prompt window, not Windows Terminal) on Windows, when I open elvish and push close button, window stop a while until it close.
This PR will fix this by calling exit manually when SIGTERM is received.

[Signal docs that have the description of that behavior on Windows](https://pkg.go.dev/os/signal#hdr-Windows)