### PR TITLE
Use `src.elv.sh/pkg/rpc` instead of `net/rpc`.

### DIFF
--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -7,7 +7,6 @@ package daemon
 
 import (
 	"net"
-	"net/rpc"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,6 +14,7 @@ import (
 	"src.elv.sh/pkg/daemon/internal/api"
 	"src.elv.sh/pkg/logutil"
 	"src.elv.sh/pkg/prog"
+	"src.elv.sh/pkg/rpc"
 	"src.elv.sh/pkg/store"
 )
 


### PR DESCRIPTION
The `net/rpc` was removed (72fc2dbe4ac8f783f45f317326382880fcd5e431) but added again (8e117a287586bbce63ed132f21fafcff0c0e8344).
This PR removes it again to reduce binary size. (about 9,605 KB -> 8,391 KB, with `go build cmd\elvish\main.go`, on Windows)