### PR TITLE
Replace ^ with math:pow in the documentation

### DIFF
--- a/website/learn/fundamentals.md
+++ b/website/learn/fundamentals.md
@@ -72,7 +72,7 @@ notations:
 ```elvish-transcript
 ~> * 17 28 # multiplication
 ▶ 476
-~> ^ 2 10 # exponention
+~> math:pow 2 10 # exponention
 ▶ 1024
 ```
 


### PR DESCRIPTION
A new user working through the documentation asked why `^ 2 10` resulted
in an error rather than `1024`.