### PR TITLE
Fix typo in command.md.

### DIFF
--- a/website/ref/command.md
+++ b/website/ref/command.md
@@ -46,8 +46,8 @@ history. Its path is determined as follows:
 
 -   Otherwise:
 
-    -   On UNIX (including macOS), `$XDG_DATA_HOME/elvish/db.bolt` is used,
-        defaulting to `~/.local/state/elvish/db.bolt` if `$XDG_DATA_HOME` is
+    -   On UNIX (including macOS), `$XDG_STATE_HOME/elvish/db.bolt` is used,
+        defaulting to `~/.local/state/elvish/db.bolt` if `$XDG_STATE_HOME` is
         unset or empty.
 
     -   On Windows, `%LocalAppData%\elvish\db.bolt` is used.


### PR DESCRIPTION
Source code uses $XDG_**STATE**_HOME for database file:
https://github.com/elves/elvish/blob/ab699bae8703af6fd7332aaa61e56072b1b0bb7b/pkg/shell/paths_unix.go#L46

Documentation incorrectly mentions $XDG_**DATA**_HOME:
https://github.com/elves/elvish/blob/ab699bae8703af6fd7332aaa61e56072b1b0bb7b/website/ref/command.md?plain=1#L49-L51