### PR TITLE
Test output

### DIFF
--- a/pkg/cli/app_test.go
+++ b/pkg/cli/app_test.go
@@ -28,7 +28,7 @@ func TestReadCode_AbortsWhenTTYSetupReturnsError(t *testing.T) {
 	_, err := f.Wait()
 
 	if err != ttySetupErr {
-		t.Errorf("ReadCode returns error %v, want %v", err, ttySetupErr)
+		t.Errorf("ReadCode unexpected error\nWanted: %v\nActual: %v", ttySetupErr, err)
 	}
 }
 
@@ -41,7 +41,7 @@ func TestReadCode_RestoresTTYBeforeReturning(t *testing.T) {
 	f.Stop()
 
 	if restoreCalled != 1 {
-		t.Errorf("Restore callback called %d times, want once", restoreCalled)
+		t.Errorf("Restore callback called:\nWanted: %d\nActual: %d", 1, restoreCalled)
 	}
 }
 
@@ -53,7 +53,7 @@ func TestReadCode_ResetsStateBeforeReturning(t *testing.T) {
 	f.Stop()
 
 	if code := f.App.ActiveWidget().(tk.CodeArea).CopyState().Buffer; code != (tk.CodeBuffer{}) {
-		t.Errorf("Editor state has CodeBuffer %v, want empty", code)
+		t.Errorf("Editor state CodeBuffer:\nWanted: (empty)\nActual: %v", code)
 	}
 }
 
@@ -98,8 +98,8 @@ func TestReadCode_CallsAfterReadline(t *testing.T) {
 	case calledWith := <-callCh:
 		wantCalledWith := "abc"
 		if calledWith != wantCalledWith {
-			t.Errorf("AfterReadline hook called with %v, want %v",
-				calledWith, wantCalledWith)
+			t.Errorf("AfterReadline hook called with:\nWanted: %v\nActual: %v",
+				wantCalledWith, calledWith)
 		}
 	case <-time.After(time.Second):
 		t.Errorf("AfterReadline not called")
@@ -523,7 +523,7 @@ func TestReadCode_ShowNotes(t *testing.T) {
 
 	// Test that notes are flushed after being rendered.
 	if n := len(f.App.CopyState().Notes); n > 0 {
-		t.Errorf("State.Notes has %d elements after redrawing, want 0", n)
+		t.Errorf("State.Notes element count after redrawing:\nWanted: %d\nActual: %d", 0, n)
 	}
 }
 
@@ -560,10 +560,11 @@ func TestReadCode_DoesNotReadMoreEventsThanNeeded(t *testing.T) {
 	f.TTY.Inject(term.K('a'), term.K('\n'), term.K('b'))
 	code, err := f.Wait()
 	if code != "a" || err != nil {
-		t.Errorf("got (%q, %v), want (%q, nil)", code, err, "a")
+		t.Errorf("ReadCode got unexpected event:\nWanted: %q, %v\nActual: %q, %v",
+			"a", nil, code, err)
 	}
 	if event := <-f.TTY.EventCh(); event != term.K('b') {
-		t.Errorf("got event %v, want %v", event, term.K('b'))
+		t.Errorf("ReadCode got unexpected event:\nWanted: %v\nActual: %v", term.K('b'), event)
 	}
 }
 

--- a/pkg/cli/clitest/fake_tty_test.go
+++ b/pkg/cli/clitest/fake_tty_test.go
@@ -16,7 +16,7 @@ func TestFakeTTY_Setup(t *testing.T) {
 
 	restore, err := tty.Setup()
 	if err != nil {
-		t.Errorf("Setup -> error %v, want nil", err)
+		t.Errorf("FakeTTY Setup():\nWanted: %v\nActual: %v", nil, err)
 	}
 	restore()
 	if restoreCalled != 1 {
@@ -29,7 +29,7 @@ func TestFakeTTY_Size(t *testing.T) {
 	ttyCtrl.SetSize(20, 30)
 	h, w := tty.Size()
 	if h != 20 || w != 30 {
-		t.Errorf("Size -> (%v, %v), want (20, 30)", h, w)
+		t.Errorf("FakeTTY Size():\nWanted: 20, 30\nActual: %v, %v", h, w)
 	}
 }
 
@@ -37,7 +37,7 @@ func TestFakeTTY_SetRawInput(t *testing.T) {
 	tty, ttyCtrl := NewFakeTTY()
 	tty.SetRawInput(2)
 	if raw := ttyCtrl.RawInput(); raw != 2 {
-		t.Errorf("RawInput() -> %v, want 2", raw)
+		t.Errorf("FakeTTY RawInput():\nWanted: %v\nActual: %v", 2, raw)
 	}
 }
 
@@ -45,10 +45,11 @@ func TestFakeTTY_Events(t *testing.T) {
 	tty, ttyCtrl := NewFakeTTY()
 	ttyCtrl.Inject(term.K('a'), term.K('b'))
 	if event, err := tty.ReadEvent(); event != term.K('a') || err != nil {
-		t.Errorf("Got (%v, %v), want (%v, nil)", event, err, term.K('a'))
+		t.Errorf("FakeTTY ReadEvent():\nWanted: %v, %v\nActual: %v, %v",
+			term.K('a'), nil, event, err)
 	}
 	if event := <-ttyCtrl.EventCh(); event != term.K('b') {
-		t.Errorf("Got event %v, want K('b')", event)
+		t.Errorf("FakeTTY event:\nWanted: %v\nActual: %v", term.K('b'), event)
 	}
 }
 
@@ -58,11 +59,11 @@ func TestFakeTTY_Signals(t *testing.T) {
 	ttyCtrl.InjectSignal(os.Interrupt, os.Kill)
 	signal := <-signals
 	if signal != os.Interrupt {
-		t.Errorf("Got signal %v, want %v", signal, os.Interrupt)
+		t.Errorf("FakeTTY unexpected signal:\nWanted: %v\nActual: %v", os.Interrupt, signal)
 	}
 	signal = <-signals
 	if signal != os.Kill {
-		t.Errorf("Got signal %v, want %v", signal, os.Kill)
+		t.Errorf("FakeTTY unexpected signal:\nWanted: %v\nActual: %v", os.Kill, signal)
 	}
 }
 
@@ -77,28 +78,34 @@ func TestFakeTTY_Buffer(t *testing.T) {
 	tty, ttyCtrl := NewFakeTTY()
 
 	if ttyCtrl.LastNotesBuffer() != nil {
-		t.Errorf("LastNotesBuffer -> %v, want nil", ttyCtrl.LastNotesBuffer())
+		t.Errorf("FakeTTY LastNotesBuffer():\nWanted: %v\nActual: %v",
+			nil, ttyCtrl.LastNotesBuffer())
 	}
 	if ttyCtrl.LastBuffer() != nil {
-		t.Errorf("LastBuffer -> %v, want nil", ttyCtrl.LastBuffer())
+		t.Errorf("FakeTTY LastBuffer():\nWanted: %v\nActual: %v",
+			nil, ttyCtrl.LastBuffer())
 	}
 
 	tty.UpdateBuffer(bufNotes1, buf1, true)
 	if ttyCtrl.LastNotesBuffer() != bufNotes1 {
-		t.Errorf("LastBuffer -> %v, want %v", ttyCtrl.LastNotesBuffer(), bufNotes1)
+		t.Errorf("FakeTTY LastNotesBuffer():\nWanted: %v\nActual: %v",
+			bufNotes1, ttyCtrl.LastNotesBuffer())
 	}
 	if ttyCtrl.LastBuffer() != buf1 {
-		t.Errorf("LastBuffer -> %v, want %v", ttyCtrl.LastBuffer(), buf1)
+		t.Errorf("FakeTTY LastBuffer():\nWanted: %v\nActual: %v",
+			buf1, ttyCtrl.LastBuffer())
 	}
 	ttyCtrl.TestBuffer(t, buf1)
 	ttyCtrl.TestNotesBuffer(t, bufNotes1)
 
 	tty.UpdateBuffer(bufNotes2, buf2, true)
 	if ttyCtrl.LastNotesBuffer() != bufNotes2 {
-		t.Errorf("LastBuffer -> %v, want %v", ttyCtrl.LastNotesBuffer(), bufNotes2)
+		t.Errorf("FakeTTY LastNotesBuffer():\nWanted: %v\nActual: %v",
+			bufNotes2, ttyCtrl.LastNotesBuffer())
 	}
 	if ttyCtrl.LastBuffer() != buf2 {
-		t.Errorf("LastBuffer -> %v, want %v", ttyCtrl.LastBuffer(), buf2)
+		t.Errorf("FakeTTY LastBuffer():\nWanted: %v\nActual: %v",
+			buf2, ttyCtrl.LastBuffer())
 	}
 	ttyCtrl.TestBuffer(t, buf2)
 	ttyCtrl.TestNotesBuffer(t, bufNotes2)
@@ -123,7 +130,7 @@ func TestFakeTTY_ClearScreen(t *testing.T) {
 	fakeTTY, ttyCtrl := NewFakeTTY()
 	for i := 0; i < 5; i++ {
 		if cleared := ttyCtrl.ScreenCleared(); cleared != i {
-			t.Errorf("ScreenCleared -> %v, want %v", cleared, i)
+			t.Errorf("FakeTTY ScreenCleared():\nWanted: %v\nActual: %v", i, cleared)
 		}
 		fakeTTY.ClearScreen()
 	}
@@ -132,13 +139,13 @@ func TestFakeTTY_ClearScreen(t *testing.T) {
 func TestGetTTYCtrl_FakeTTY(t *testing.T) {
 	fakeTTY, ttyCtrl := NewFakeTTY()
 	if got, ok := GetTTYCtrl(fakeTTY); got != ttyCtrl || !ok {
-		t.Errorf("-> %v, %v, want %v, %v", got, ok, ttyCtrl, true)
+		t.Errorf("GetTTYCtrl():\nWanted: %v, %v\nActual: %v, %v", ttyCtrl, true, got, ok)
 	}
 }
 
 func TestGetTTYCtrl_RealTTY(t *testing.T) {
 	realTTY := cli.NewTTY(os.Stdin, os.Stderr)
 	if _, ok := GetTTYCtrl(realTTY); ok {
-		t.Errorf("-> _, true, want _, false")
+		t.Errorf("GetTTYCtrl() error:\nWanted: %v\nActual: %v", false, true)
 	}
 }

--- a/pkg/cli/loop_test.go
+++ b/pkg/cli/loop_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -34,7 +33,8 @@ func TestLoop_RunReturnsAfterReturnCalled(t *testing.T) {
 	supplyInputs(lp, "x")
 	buf, err := lp.Run()
 	if buf != "buffer" || err != io.EOF {
-		fmt.Printf("Run -> (%v, %v), want (%v, %v)", buf, err, "buffer", io.EOF)
+		t.Errorf("CLI continued after 'return'\nWanted: %v, %v\nActual: %v, %v",
+			buf, io.EOF, buf, err)
 	}
 }
 

--- a/pkg/eval/evaltest/evaltest.go
+++ b/pkg/eval/evaltest/evaltest.go
@@ -154,36 +154,36 @@ func TestWithSetup(t *testing.T, setup func(*eval.Evaler), tests ...Case) {
 				tc.verify(t)
 			}
 			if !matchOut(tc.want.ValueOut, r.ValueOut) {
-				t.Errorf("got value out (-want +got):\n%s",
-					cmp.Diff(r.ValueOut, tc.want.ValueOut, tt.CommonCmpOpt))
+				t.Errorf("value out (-Wanted +Actual):\n%s",
+					cmp.Diff(tc.want.ValueOut, r.ValueOut, tt.CommonCmpOpt))
 			}
 			if !bytes.Equal(tc.want.BytesOut, r.BytesOut) {
-				t.Errorf("got bytes out %q, want %q", r.BytesOut, tc.want.BytesOut)
+				t.Errorf("bytes out:\nWanted: %q\nActual: %q", tc.want.BytesOut, r.BytesOut)
 			}
 			if tc.want.StderrOut == nil {
 				if len(r.StderrOut) > 0 {
-					t.Errorf("got stderr out %q, want empty", r.StderrOut)
+					t.Errorf("stderr out):\nWanted: %q\nActual: %q", "", r.StderrOut)
 				}
 			} else {
 				if !bytes.Contains(r.StderrOut, tc.want.StderrOut) {
-					t.Errorf("got stderr out %q, want output containing %q",
-						r.StderrOut, tc.want.StderrOut)
+					t.Errorf("stderr out contains):\nWanted: %q\nActual: %q",
+						tc.want.StderrOut, r.StderrOut)
 				}
 			}
 			if !matchErr(tc.want.CompilationError, r.CompilationError) {
-				t.Errorf("got compilation error %v, want %v",
-					r.CompilationError, tc.want.CompilationError)
+				t.Errorf("compilation error:\nWanted: %v\nActual: %v",
+					tc.want.CompilationError, r.CompilationError)
 			}
 			if !matchErr(tc.want.Exception, r.Exception) {
-				t.Errorf("unexpected exception")
 				if exc, ok := r.Exception.(eval.Exception); ok {
 					// For an eval.Exception report the type of the underlying error.
-					t.Logf("got: %T: %v", exc.Reason(), exc)
-					t.Logf("stack trace: %#v", getStackTexts(exc.StackTrace()))
+					t.Errorf("unexpected exception:\nWanted: %v\nActual: %T: %v",
+						tc.want.Exception, exc.Reason(), exc)
+					t.Logf("Stack Trace:\n%#v", getStackTexts(exc.StackTrace()))
 				} else {
-					t.Logf("got: %T: %v", r.Exception, r.Exception)
+					t.Errorf("unexpected exception:\nWanted: %v\nActual: %T: %v",
+						tc.want.Exception, r.Exception, r.Exception)
 				}
-				t.Errorf("want: %v", tc.want.Exception)
 			}
 		})
 	}

--- a/pkg/tt/tt.go
+++ b/pkg/tt/tt.go
@@ -88,7 +88,7 @@ func Test(t T, fn *FnToTest, tests Table) {
 				} else {
 					diff = cmp.Diff(retsMatcher, rets, cmpopt)
 				}
-				t.Errorf("%s(%s) returns (-want +got):\n%s", fn.name, args, diff)
+				t.Errorf("%s(%s) returns (-Wanted +Actual):\n%s", fn.name, args, diff)
 			}
 		}
 	}

--- a/pkg/tt/tt_test.go
+++ b/pkg/tt/tt_test.go
@@ -42,7 +42,7 @@ func TestTTFailDefaultFmtOneReturn(t *testing.T) {
 		Fn("add", add),
 		Table{Args(1, 10).Rets(12)},
 	)
-	assertOneError(t, testT, "add(1, 10) returns (-want +got):\n")
+	assertOneError(t, testT, "add(1, 10) returns (-Wanted +Actual):\n")
 }
 
 func TestTTFailDefaultFmtMultiReturn(t *testing.T) {
@@ -51,7 +51,7 @@ func TestTTFailDefaultFmtMultiReturn(t *testing.T) {
 		Fn("addsub", addsub),
 		Table{Args(1, 10).Rets(11, -90)},
 	)
-	assertOneError(t, testT, "addsub(1, 10) returns (-want +got):\n")
+	assertOneError(t, testT, "addsub(1, 10) returns (-Wanted +Actual):\n")
 }
 
 func TestTTFailCustomFmt(t *testing.T) {
@@ -61,17 +61,17 @@ func TestTTFailCustomFmt(t *testing.T) {
 		Table{Args(1, 10).Rets(11, -90)},
 	)
 	assertOneError(t, testT,
-		"addsub(x = 1, y = 10) returns (-want +got):\n")
+		"addsub(x = 1, y = 10) returns (-Wanted +Actual):\n")
 }
 
 func assertOneError(t *testing.T, testT testT, wantPrefix string) {
 	t.Helper()
 	switch len(testT) {
 	case 0:
-		t.Errorf("Test didn't error when it should")
+		t.Errorf("Test didn't error when it should have done so")
 	case 1:
 		if !strings.HasPrefix(testT[0], wantPrefix) {
-			t.Errorf("Test wrote message:\ngot:  %q\nwant: %q...", testT[0], wantPrefix)
+			t.Errorf("Test wrote message:\nWanted: %q...\nActual: %q", wantPrefix, testT[0])
 		}
 	default:
 		t.Errorf("Test wrote too many error messages")


### PR DESCRIPTION
FWIW, I recognize that most of this change, and the changes it proposes, are in some sense pointless since we don't expect existing tests to fail and therefore the changes to those error messages will not be relevant. However, I think it's important to establish a better idiom for test failures. Changing the existing examples is necessary to establish a new idiom that is used by new unit tests.