### PR TITLE
Dot imports

### DIFF
--- a/pkg/cli/app_test.go
+++ b/pkg/cli/app_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	. "src.elv.sh/pkg/cli"
+	"src.elv.sh/pkg/cli"
 	. "src.elv.sh/pkg/cli/clitest"
 	"src.elv.sh/pkg/cli/term"
 	"src.elv.sh/pkg/cli/tk"
@@ -46,7 +46,7 @@ func TestReadCode_RestoresTTYBeforeReturning(t *testing.T) {
 }
 
 func TestReadCode_ResetsStateBeforeReturning(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.CodeAreaState.Buffer.Content = "some code"
 	}))
 
@@ -59,7 +59,7 @@ func TestReadCode_ResetsStateBeforeReturning(t *testing.T) {
 
 func TestReadCode_CallsBeforeReadline(t *testing.T) {
 	callCh := make(chan bool, 1)
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.BeforeReadline = []func(){func() { callCh <- true }}
 	}))
 	defer f.Stop()
@@ -74,7 +74,7 @@ func TestReadCode_CallsBeforeReadline(t *testing.T) {
 
 func TestReadCode_CallsBeforeReadlineBeforePromptTrigger(t *testing.T) {
 	callCh := make(chan string, 2)
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.BeforeReadline = []func(){func() { callCh <- "hook" }}
 		spec.Prompt = testPrompt{trigger: func(bool) { callCh <- "prompt" }}
 	}))
@@ -87,7 +87,7 @@ func TestReadCode_CallsBeforeReadlineBeforePromptTrigger(t *testing.T) {
 
 func TestReadCode_CallsAfterReadline(t *testing.T) {
 	callCh := make(chan string, 1)
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.AfterReadline = []func(string){func(s string) { callCh <- s }}
 	}))
 
@@ -107,7 +107,7 @@ func TestReadCode_CallsAfterReadline(t *testing.T) {
 }
 
 func TestReadCode_FinalRedraw(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.CodeAreaState.Buffer.Content = "code"
 		spec.State.Addons = []tk.Widget{tk.Label{Content: ui.T("addon")}}
 	}))
@@ -237,13 +237,13 @@ func TestReadCode_RedrawsOnLateUpdateFromHighlighter(t *testing.T) {
 	f.TTY.TestBuffer(t, bb().Write("code", ui.FgRed).SetDotHere().Buffer())
 }
 
-func withHighlighter(hl Highlighter) func(*AppSpec, TTYCtrl) {
-	return WithSpec(func(spec *AppSpec) { spec.Highlighter = hl })
+func withHighlighter(hl cli.Highlighter) func(*cli.AppSpec, TTYCtrl) {
+	return WithSpec(func(spec *cli.AppSpec) { spec.Highlighter = hl })
 }
 
 func TestReadCode_ShowsPrompt(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
-		spec.Prompt = NewConstPrompt(ui.T("> "))
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
+		spec.Prompt = cli.NewConstPrompt(ui.T("> "))
 	}))
 	defer f.Stop()
 
@@ -253,7 +253,7 @@ func TestReadCode_ShowsPrompt(t *testing.T) {
 
 func TestReadCode_CallsPromptTrigger(t *testing.T) {
 	triggerCh := make(chan bool, 1)
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.Prompt = testPrompt{trigger: func(bool) { triggerCh <- true }}
 	}))
 	defer f.Stop()
@@ -272,7 +272,7 @@ func TestReadCode_RedrawsOnLateUpdateFromPrompt(t *testing.T) {
 		get:         func() ui.Text { return ui.T(promptContent) },
 		lateUpdates: make(chan struct{}),
 	}
-	f := Setup(WithSpec(func(spec *AppSpec) { spec.Prompt = prompt }))
+	f := Setup(WithSpec(func(spec *cli.AppSpec) { spec.Prompt = prompt }))
 	defer f.Stop()
 
 	// Wait until old prompt is rendered
@@ -284,8 +284,8 @@ func TestReadCode_RedrawsOnLateUpdateFromPrompt(t *testing.T) {
 }
 
 func TestReadCode_ShowsRPrompt(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
-		spec.RPrompt = NewConstPrompt(ui.T("R"))
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
+		spec.RPrompt = cli.NewConstPrompt(ui.T("R"))
 	}))
 	defer f.Stop()
 
@@ -299,9 +299,9 @@ func TestReadCode_ShowsRPrompt(t *testing.T) {
 }
 
 func TestReadCode_ShowsRPromptInFinalRedrawIfPersistent(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.CodeAreaState.Buffer.Content = "code"
-		spec.RPrompt = NewConstPrompt(ui.T("R"))
+		spec.RPrompt = cli.NewConstPrompt(ui.T("R"))
 		spec.RPromptPersistent = func() bool { return true }
 	}))
 	defer f.Stop()
@@ -316,9 +316,9 @@ func TestReadCode_ShowsRPromptInFinalRedrawIfPersistent(t *testing.T) {
 }
 
 func TestReadCode_HidesRPromptInFinalRedrawIfNotPersistent(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.CodeAreaState.Buffer.Content = "code"
-		spec.RPrompt = NewConstPrompt(ui.T("R"))
+		spec.RPrompt = cli.NewConstPrompt(ui.T("R"))
 		spec.RPromptPersistent = func() bool { return false }
 	}))
 	defer f.Stop()
@@ -335,7 +335,7 @@ func TestReadCode_HidesRPromptInFinalRedrawIfNotPersistent(t *testing.T) {
 // Addon.
 
 func TestReadCode_LetsLastWidgetHandleEvents(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.State.Addons = []tk.Widget{
 			tk.NewCodeArea(tk.CodeAreaSpec{
 				Prompt: func() ui.Text { return ui.T("addon1> ") },
@@ -357,7 +357,7 @@ func TestReadCode_LetsLastWidgetHandleEvents(t *testing.T) {
 }
 
 func TestReadCode_PutsCursorOnLastWidgetWithFocus(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.State.Addons = []tk.Widget{
 			testAddon{tk.Label{Content: ui.T("addon1> ")}, true},
 			testAddon{tk.Label{Content: ui.T("addon2> ")}, false},
@@ -407,7 +407,7 @@ func TestPushAddonPopAddon(t *testing.T) {
 
 func TestReadCode_HidesAddonsWhenNotEnoughSpace(t *testing.T) {
 	f := Setup(
-		func(spec *AppSpec, tty TTYCtrl) {
+		func(spec *cli.AppSpec, tty TTYCtrl) {
 			spec.State.Addons = []tk.Widget{
 				tk.Label{Content: ui.T("addon1> ")},
 				tk.Label{Content: ui.T("addon2> ")}, // no space for this
@@ -440,7 +440,7 @@ func TestReadCode_UsesGlobalBindingsWithAddonTarget(t *testing.T) {
 
 func testGlobalBindings(t *testing.T, addons []tk.Widget) {
 	gotWidgetCh := make(chan tk.Widget, 1)
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.GlobalBindings = tk.MapBindings{
 			term.K('X', ui.Ctrl): func(w tk.Widget) {
 				gotWidgetCh <- w
@@ -462,7 +462,7 @@ func testGlobalBindings(t *testing.T, addons []tk.Widget) {
 }
 
 func TestReadCode_DoesNotUseGlobalBindingsIfHandledByWidget(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.GlobalBindings = tk.MapBindings{
 			term.K('a'): func(w tk.Widget) {},
 		}
@@ -476,7 +476,7 @@ func TestReadCode_DoesNotUseGlobalBindingsIfHandledByWidget(t *testing.T) {
 }
 
 func TestReadCode_TrimsBufferToMaxHeight(t *testing.T) {
-	f := Setup(func(spec *AppSpec, tty TTYCtrl) {
+	f := Setup(func(spec *cli.AppSpec, tty TTYCtrl) {
 		spec.MaxHeight = func() int { return 2 }
 		// The code needs 3 lines to completely show.
 		spec.CodeAreaState.Buffer.Content = strings.Repeat("a", 15)
@@ -495,7 +495,7 @@ func TestReadCode_ShowNotes(t *testing.T) {
 	// for testing the behavior of writing multiple notes.
 	inHandler := make(chan struct{})
 	unblock := make(chan struct{})
-	f := Setup(WithSpec(func(spec *AppSpec) {
+	f := Setup(WithSpec(func(spec *cli.AppSpec) {
 		spec.CodeAreaBindings = tk.MapBindings{
 			term.K('a'): func(tk.Widget) {
 				inHandler <- struct{}{}
@@ -528,7 +528,7 @@ func TestReadCode_ShowNotes(t *testing.T) {
 }
 
 func TestReadCode_DoesNotCrashWithNilTTY(t *testing.T) {
-	f := Setup(WithSpec(func(spec *AppSpec) { spec.TTY = nil }))
+	f := Setup(WithSpec(func(spec *cli.AppSpec) { spec.TTY = nil }))
 	defer f.Stop()
 }
 

--- a/pkg/cli/histutil/dedup_cursor.go
+++ b/pkg/cli/histutil/dedup_cursor.go
@@ -1,6 +1,8 @@
 package histutil
 
-import "src.elv.sh/pkg/store/storedefs"
+import (
+	"src.elv.sh/pkg/store/storedefs"
+)
 
 // NewDedupCursor returns a cursor that skips over all duplicate entries.
 func NewDedupCursor(c Cursor) Cursor {

--- a/pkg/cli/histutil/hybrid_store.go
+++ b/pkg/cli/histutil/hybrid_store.go
@@ -1,6 +1,8 @@
 package histutil
 
-import "src.elv.sh/pkg/store/storedefs"
+import (
+	"src.elv.sh/pkg/store/storedefs"
+)
 
 // NewHybridStore returns a store that provides a view of all the commands that
 // exists in the database, plus a in-memory session history.

--- a/pkg/cli/term/event.go
+++ b/pkg/cli/term/event.go
@@ -1,6 +1,8 @@
 package term
 
-import "src.elv.sh/pkg/ui"
+import (
+	"src.elv.sh/pkg/ui"
+)
 
 // Event represents an event that can be read from the terminal.
 type Event interface {

--- a/pkg/cli/tty_unix_test.go
+++ b/pkg/cli/tty_unix_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"golang.org/x/sys/unix"
-	. "src.elv.sh/pkg/cli"
+	"src.elv.sh/pkg/cli"
 )
 
 func TestTTYSignal(t *testing.T) {
-	tty := NewTTY(os.Stdin, os.Stderr)
+	tty := cli.NewTTY(os.Stdin, os.Stderr)
 	sigch := tty.NotifySignals()
 
 	err := unix.Kill(unix.Getpid(), unix.SIGUSR1)

--- a/pkg/edit/highlight/theme.go
+++ b/pkg/edit/highlight/theme.go
@@ -1,6 +1,8 @@
 package highlight
 
-import "src.elv.sh/pkg/ui"
+import (
+	"src.elv.sh/pkg/ui"
+)
 
 var stylingFor = map[string]ui.Styling{
 	barewordRegion:     nil,

--- a/pkg/eval/builtin_fn_container_test.go
+++ b/pkg/eval/builtin_fn_container_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"unsafe"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 
 	. "src.elv.sh/pkg/eval/evaltest"
@@ -255,9 +255,9 @@ func TestCompare(t *testing.T) {
 		That("compare [x, y] [x, y]").Puts(0),
 
 		// Uncomparable values.
-		That("compare 1 (num 1)").Throws(ErrUncomparable),
-		That("compare x [x]").Throws(ErrUncomparable),
-		That("compare a [&a=x]").Throws(ErrUncomparable),
+		That("compare 1 (num 1)").Throws(eval.ErrUncomparable),
+		That("compare x [x]").Throws(eval.ErrUncomparable),
+		That("compare a [&a=x]").Throws(eval.ErrUncomparable),
 	)
 }
 
@@ -302,15 +302,15 @@ func TestOrder(t *testing.T) {
 
 		// Attempting to order uncomparable values
 		That("put (num 1) 1 | order").
-			Throws(ErrUncomparable, "order"),
+			Throws(eval.ErrUncomparable, "order"),
 		That("put 1 (float64 1) | order").
-			Throws(ErrUncomparable, "order"),
+			Throws(eval.ErrUncomparable, "order"),
 		That("put 1 (float64 1) b | order").
-			Throws(ErrUncomparable, "order"),
+			Throws(eval.ErrUncomparable, "order"),
 		That("put [a] a | order").
-			Throws(ErrUncomparable, "order"),
+			Throws(eval.ErrUncomparable, "order"),
 		That("put [a] [(float64 1)] | order").
-			Throws(ErrUncomparable, "order"),
+			Throws(eval.ErrUncomparable, "order"),
 
 		// &reverse
 		That("put foo bar ipsum | order &reverse").Puts("ipsum", "foo", "bar"),
@@ -338,7 +338,7 @@ func TestOrder(t *testing.T) {
 		// &less-than throwing an exception
 		That("put 1 10 2 5 | order &less-than={|a b| fail bad }").
 			Throws(
-				FailError{"bad"},
+				eval.FailError{"bad"},
 				"fail bad ", "order &less-than={|a b| fail bad }"),
 
 		// &less-than and &reverse

--- a/pkg/eval/builtin_fn_flow_test.go
+++ b/pkg/eval/builtin_fn_flow_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	"src.elv.sh/pkg/eval/errs"
 	. "src.elv.sh/pkg/eval/evaltest"
@@ -14,7 +14,7 @@ func TestRunParallel(t *testing.T) {
 	Test(t,
 		That(`run-parallel { put lorem } { echo ipsum }`).
 			Puts("lorem").Prints("ipsum\n"),
-		That(`run-parallel { } { fail foo }`).Throws(FailError{"foo"}),
+		That(`run-parallel { } { fail foo }`).Throws(eval.FailError{"foo"}),
 	)
 }
 
@@ -29,7 +29,7 @@ func TestEach(t *testing.T) {
 		That(`range 10 | each {|x| if (== $x 4) { continue }; put $x }`).
 			Puts(0, 1, 2, 3, 5, 6, 7, 8, 9),
 		That(`range 10 | each {|x| if (== $x 4) { fail haha }; put $x }`).
-			Puts(0, 1, 2, 3).Throws(FailError{"haha"}),
+			Puts(0, 1, 2, 3).Throws(eval.FailError{"haha"}),
 		// TODO(xiaq): Test that "each" does not close the stdin.
 	)
 }
@@ -66,7 +66,7 @@ func TestPeach(t *testing.T) {
 		`).Puts(true),
 		// Verify that exceptions are propagated.
 		That(`peach {|x| fail $x } [a]`).
-			Throws(FailError{"a"}, "fail $x ", "peach {|x| fail $x } [a]"),
+			Throws(eval.FailError{"a"}, "fail $x ", "peach {|x| fail $x } [a]"),
 		// Verify that `break` works by terminating the `peach` before the entire sequence is
 		// consumed.
 		That(`
@@ -80,11 +80,11 @@ func TestPeach(t *testing.T) {
 
 func TestFail(t *testing.T) {
 	Test(t,
-		That("fail haha").Throws(FailError{"haha"}, "fail haha"),
+		That("fail haha").Throws(eval.FailError{"haha"}, "fail haha"),
 		That("fn f { fail haha }", "fail ?(f)").Throws(
-			FailError{"haha"}, "fail haha ", "f"),
+			eval.FailError{"haha"}, "fail haha ", "f"),
 		That("fail []").Throws(
-			FailError{vals.EmptyList}, "fail []"),
+			eval.FailError{vals.EmptyList}, "fail []"),
 		That("put ?(fail 1)[reason][type]").Puts("fail"),
 		That("put ?(fail 1)[reason][content]").Puts("1"),
 	)
@@ -92,7 +92,7 @@ func TestFail(t *testing.T) {
 
 func TestReturn(t *testing.T) {
 	Test(t,
-		That("return").Throws(Return),
+		That("return").Throws(eval.Return),
 		// Use of return inside fn is tested in TestFn
 	)
 }
@@ -103,7 +103,7 @@ func TestDefer(t *testing.T) {
 		That("defer { }").
 			Throws(ErrorWithMessage("defer must be called from within a closure")),
 		That("{ defer { fail foo } }").
-			Throws(FailError{"foo"}, "fail foo ", "{ defer { fail foo } }"),
+			Throws(eval.FailError{"foo"}, "fail foo ", "{ defer { fail foo } }"),
 		That("{ defer {|x| } }").Throws(
 			errs.ArityMismatch{What: "arguments",
 				ValidLow: 1, ValidHigh: 1, Actual: 0},

--- a/pkg/eval/builtin_fn_misc_unix_test.go
+++ b/pkg/eval/builtin_fn_misc_unix_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 	"time"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/testutil"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 )
 
-func interruptedTimeAfterMock(fm *Frame, d time.Duration) <-chan time.Time {
+func interruptedTimeAfterMock(fm *eval.Frame, d time.Duration) <-chan time.Time {
 	if d == time.Second {
 		// Special-case intended to verity that a sleep can be interrupted.
 		go func() {
@@ -29,10 +29,10 @@ func interruptedTimeAfterMock(fm *Frame, d time.Duration) <-chan time.Time {
 }
 
 func TestInterruptedSleep(t *testing.T) {
-	TimeAfter = interruptedTimeAfterMock
+	eval.TimeAfter = interruptedTimeAfterMock
 	Test(t,
 		// Special-case that should result in the sleep being interrupted. See
 		// timeAfterMock above.
-		That(`sleep 1s`).Throws(ErrInterrupted, "sleep 1s"),
+		That(`sleep 1s`).Throws(eval.ErrInterrupted, "sleep 1s"),
 	)
 }

--- a/pkg/eval/builtin_fn_num_test.go
+++ b/pkg/eval/builtin_fn_num_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vals"
 
@@ -213,12 +213,12 @@ func TestArithmeticCommands(t *testing.T) {
 		// 0 / non-zero
 		That("/ 0 1/2 0.1").Puts(0),
 		// anything / 0
-		That("/ 0 0").Throws(ErrDivideByZero, "/ 0 0"),
-		That("/ 1 0").Throws(ErrDivideByZero, "/ 1 0"),
-		That("/ 1.0 0").Throws(ErrDivideByZero, "/ 1.0 0"),
+		That("/ 0 0").Throws(eval.ErrDivideByZero, "/ 0 0"),
+		That("/ 1 0").Throws(eval.ErrDivideByZero, "/ 1 0"),
+		That("/ 1.0 0").Throws(eval.ErrDivideByZero, "/ 1.0 0"),
 
 		That("% 23 7").Puts(2),
-		That("% 1 0").Throws(ErrDivideByZero, "% 1 0"),
+		That("% 1 0").Throws(eval.ErrDivideByZero, "% 1 0"),
 	)
 }
 

--- a/pkg/eval/builtin_fn_str_test.go
+++ b/pkg/eval/builtin_fn_str_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	. "src.elv.sh/pkg/eval/evaltest"
 )
 
@@ -37,8 +37,8 @@ func TestBase(t *testing.T) {
 	Test(t,
 		That(`base 2 1 3 4 16 255`).Puts("1", "11", "100", "10000", "11111111"),
 		That(`base 16 42 233`).Puts("2a", "e9"),
-		That(`base 1 1`).Throws(ErrBadBase),
-		That(`base 37 10`).Throws(ErrBadBase),
+		That(`base 1 1`).Throws(eval.ErrBadBase),
+		That(`base 37 10`).Throws(eval.ErrBadBase),
 		thatOutputErrorIsBubbled("base 2 1"),
 	)
 }
@@ -57,7 +57,7 @@ func TestEawk(t *testing.T) {
 			Puts("cz", "33"),
 		// Bad input type
 		That(`num 42 | eawk {|@a| fail "this should not run" }`).
-			Throws(ErrInputOfEawkMustBeString),
+			Throws(eval.ErrInputOfEawkMustBeString),
 		// Propagation of exception
 		That(`
 			to-lines [1 2 3 4] | eawk {|@a|
@@ -66,7 +66,7 @@ func TestEawk(t *testing.T) {
 				}
 				put $a[1]
 			}
-		`).Puts("1", "2").Throws(FailError{"stop eawk"}),
+		`).Puts("1", "2").Throws(eval.FailError{"stop eawk"}),
 		// break
 		That(`
 			to-lines [" a" "b\tc " "d" "e"] | eawk {|@a|

--- a/pkg/eval/builtin_ns_test.go
+++ b/pkg/eval/builtin_ns_test.go
@@ -3,13 +3,13 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
 )
 
 func TestExplicitBuiltinModule(t *testing.T) {
-	TestWithSetup(t, func(ev *Evaler) { ev.Args = vals.MakeList("a", "b") },
+	TestWithSetup(t, func(ev *eval.Evaler) { ev.Args = vals.MakeList("a", "b") },
 		That("all $args").Puts("a", "b"),
 		// Regression test for #1414
 		That("use builtin; all $builtin:args").Puts("a", "b"),

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -13,7 +13,7 @@ import (
 	"src.elv.sh/pkg/prog/progtest"
 
 	. "src.elv.sh/pkg/eval/evaltest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestPragma(t *testing.T) {
@@ -183,7 +183,7 @@ func (v *badVar) Set(any) error {
 }
 
 func TestDel(t *testing.T) {
-	Setenv(t, "TEST_ENV", "test value")
+	testutil.Setenv(t, "TEST_ENV", "test value")
 
 	Test(t,
 		// Deleting variable
@@ -426,9 +426,9 @@ func TestFn(t *testing.T) {
 
 // Regression test for #1225
 func TestUse_SetsVariableCorrectlyIfModuleCallsExtendGlobal(t *testing.T) {
-	libdir := InTempDir(t)
+	libdir := testutil.InTempDir(t)
 
-	ApplyDir(Dir{"a.elv": "add-var"})
+	testutil.ApplyDir(testutil.Dir{"a.elv": "add-var"})
 	ev := NewEvaler()
 	ev.LibDirs = []string{libdir}
 	addVar := func() {
@@ -451,8 +451,8 @@ func TestUse_SetsVariableCorrectlyIfModuleCallsExtendGlobal(t *testing.T) {
 }
 
 func TestUse_SupportsCircularDependency(t *testing.T) {
-	libdir := InTempDir(t)
-	ApplyDir(Dir{
+	libdir := testutil.InTempDir(t)
+	testutil.ApplyDir(testutil.Dir{
 		"a.elv": "var pre = apre; use b; put $b:pre $b:post; var post = apost",
 		"b.elv": "var pre = bpre; use a; put $a:pre $a:post; var post = bpost",
 	})
@@ -468,21 +468,21 @@ func TestUse_SupportsCircularDependency(t *testing.T) {
 }
 
 func TestUse(t *testing.T) {
-	libdir1 := InTempDir(t)
-	ApplyDir(Dir{
+	libdir1 := testutil.InTempDir(t)
+	testutil.ApplyDir(testutil.Dir{
 		"shadow.elv": "put lib1",
 	})
 
-	libdir2 := InTempDir(t)
-	ApplyDir(Dir{
+	libdir2 := testutil.InTempDir(t)
+	testutil.ApplyDir(testutil.Dir{
 		"has-init.elv": "put has-init",
 		"put-x.elv":    "put $x",
 		"lorem.elv":    "var name = lorem; fn put-name { put $name }",
 		"d.elv":        "var name = d",
 		"shadow.elv":   "put lib2",
-		"a": Dir{
-			"b": Dir{
-				"c": Dir{
+		"a": testutil.Dir{
+			"b": testutil.Dir{
+				"c": testutil.Dir{
 					"d.elv": "var name = a/b/c/d",
 					"x.elv": "use ./d; var d = $d:name; use ../../../lorem; var lorem = $lorem:name",
 				},
@@ -545,8 +545,8 @@ func TestUse(t *testing.T) {
 // Regression test for #1072
 func TestUse_WarnsAboutDeprecatedFeatures(t *testing.T) {
 	progtest.SetDeprecationLevel(t, 18)
-	libdir := InTempDir(t)
-	MustWriteFile("dep.elv", "a=b nop $a")
+	libdir := testutil.InTempDir(t)
+	testutil.MustWriteFile("dep.elv", "a=b nop $a")
 
 	TestWithSetup(t, func(ev *Evaler) { ev.LibDirs = []string{libdir} },
 		// Importing module triggers check for deprecated features

--- a/pkg/eval/chdir_test.go
+++ b/pkg/eval/chdir_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/env"
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/parse"
@@ -15,7 +15,7 @@ import (
 func TestChdir(t *testing.T) {
 	dst := testutil.TempDir(t)
 
-	ev := NewEvaler()
+	ev := eval.NewEvaler()
 
 	argDirInBefore, argDirInAfter := "", ""
 	ev.AddBeforeChdir(func(dir string) { argDirInBefore = dir })
@@ -63,7 +63,7 @@ func TestChdirElvishHooks(t *testing.T) {
 func TestChdirError(t *testing.T) {
 	testutil.InTempDir(t)
 
-	ev := NewEvaler()
+	ev := eval.NewEvaler()
 	err := ev.Chdir("i/dont/exist")
 	if err == nil {
 		t.Errorf("Chdir => no error when dir does not exist")

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
@@ -79,8 +79,8 @@ func TestStringLiteral(t *testing.T) {
 }
 
 func TestTilde(t *testing.T) {
-	home := InTempHome(t)
-	ApplyDir(Dir{"file1": "", "file2": ""})
+	home := testutil.InTempHome(t)
+	testutil.ApplyDir(testutil.Dir{"file1": "", "file2": ""})
 
 	Test(t,
 		// Tilde

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/testutil"
 
@@ -40,8 +40,8 @@ func TestIndexing(t *testing.T) {
 		That("put [&key=value][bad]").Throws(
 			vals.NoSuchKey("bad"), "[&key=value][bad]"),
 
-		That("put (fail x)[a]").Throws(FailError{"x"}, "fail x"),
-		That("put [foo][(fail x)]").Throws(FailError{"x"}, "fail x"),
+		That("put (fail x)[a]").Throws(eval.FailError{"x"}, "fail x"),
+		That("put [foo][(fail x)]").Throws(eval.FailError{"x"}, "fail x"),
 	)
 }
 
@@ -154,7 +154,7 @@ func TestVariableUse(t *testing.T) {
 		// Only names ending in ~ are resolved, and resolution always succeeds
 		// regardless of whether the command actually exists. Colons inside the
 		// name are supported.
-		That("put $e:a:b~").Puts(NewExternalCmd("a:b")),
+		That("put $e:a:b~").Puts(eval.NewExternalCmd("a:b")),
 
 		// A "normal" namespace access indexes the namespace as a variable.
 		That("var ns: = (ns [&a= val]); put $ns:a").Puts("val"),

--- a/pkg/eval/compiler_test.go
+++ b/pkg/eval/compiler_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/parse"
 	"src.elv.sh/pkg/prog/progtest"
 )
@@ -22,7 +22,7 @@ func testCompileTimeDeprecation(t *testing.T, code, wantWarning string, level in
 	t.Helper()
 	progtest.SetDeprecationLevel(t, level)
 
-	ev := NewEvaler()
+	ev := eval.NewEvaler()
 	errOutput := new(bytes.Buffer)
 
 	parseErr, compileErr := ev.Check(parse.Source{Code: code}, errOutput)

--- a/pkg/eval/exception_test.go
+++ b/pkg/eval/exception_test.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 
 	"src.elv.sh/pkg/diag"
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
@@ -18,14 +18,14 @@ import (
 
 func TestReason(t *testing.T) {
 	err := errors.New("ordinary error")
-	tt.Test(t, tt.Fn("Reason", Reason), tt.Table{
+	tt.Test(t, tt.Fn("Reason", eval.Reason), tt.Table{
 		tt.Args(err).Rets(err),
 		tt.Args(makeException(err)).Rets(err),
 	})
 }
 
 func TestException(t *testing.T) {
-	err := FailError{"error"}
+	err := eval.FailError{"error"}
 	exc := makeException(err)
 	vals.TestValue(t, exc).
 		Kind("exception").
@@ -38,21 +38,21 @@ func TestException(t *testing.T) {
 		IndexError("stack", vals.NoSuchKey("stack")).
 		Repr("[&reason=[&content=error &type=fail]]")
 
-	vals.TestValue(t, OK).
+	vals.TestValue(t, eval.OK).
 		Kind("exception").
 		Bool(true).
 		Repr("$ok")
 }
 
-func makeException(cause error, entries ...*diag.Context) Exception {
-	return NewException(cause, makeStackTrace(entries...))
+func makeException(cause error, entries ...*diag.Context) eval.Exception {
+	return eval.NewException(cause, makeStackTrace(entries...))
 }
 
 // Creates a new StackTrace, using the first entry as the head.
-func makeStackTrace(entries ...*diag.Context) *StackTrace {
-	var s *StackTrace
+func makeStackTrace(entries ...*diag.Context) *eval.StackTrace {
+	var s *eval.StackTrace
 	for i := len(entries) - 1; i >= 0; i-- {
-		s = &StackTrace{Head: entries[i], Next: s}
+		s = &eval.StackTrace{Head: entries[i], Next: s}
 	}
 	return s
 }
@@ -88,13 +88,13 @@ func TestErrorMethods(t *testing.T) {
 	tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
 		tt.Args(makeException(errors.New("err"))).Rets("err"),
 
-		tt.Args(MakePipelineError([]Exception{
+		tt.Args(eval.MakePipelineError([]eval.Exception{
 			makeException(errors.New("err1")),
 			makeException(errors.New("err2"))})).Rets("(err1 | err2)"),
 
-		tt.Args(Return).Rets("return"),
-		tt.Args(Break).Rets("break"),
-		tt.Args(Continue).Rets("continue"),
-		tt.Args(Flow(1000)).Rets("!(BAD FLOW: 1000)"),
+		tt.Args(eval.Return).Rets("return"),
+		tt.Args(eval.Break).Rets("break"),
+		tt.Args(eval.Continue).Rets("continue"),
+		tt.Args(eval.Flow(1000)).Rets("!(BAD FLOW: 1000)"),
 	})
 }

--- a/pkg/eval/exception_unix_test.go
+++ b/pkg/eval/exception_unix_test.go
@@ -8,31 +8,31 @@ import (
 	"syscall"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	"src.elv.sh/pkg/tt"
 )
 
 func TestExternalCmdExit_Error(t *testing.T) {
 	tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
-		tt.Args(ExternalCmdExit{0x0, "ls", 1}).Rets("ls exited with 0"),
-		tt.Args(ExternalCmdExit{0x100, "ls", 1}).Rets("ls exited with 1"),
+		tt.Args(eval.ExternalCmdExit{0x0, "ls", 1}).Rets("ls exited with 0"),
+		tt.Args(eval.ExternalCmdExit{0x100, "ls", 1}).Rets("ls exited with 1"),
 		// Note: all Unix'es have SIGINT = 2, but syscall package has different
 		// string in gccgo("Interrupt") and gc("interrupt").
-		tt.Args(ExternalCmdExit{0x2, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String()),
+		tt.Args(eval.ExternalCmdExit{0x2, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String()),
 		// 0x80 + signal for core dumped
-		tt.Args(ExternalCmdExit{0x82, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String() + " (core dumped)"),
+		tt.Args(eval.ExternalCmdExit{0x82, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String() + " (core dumped)"),
 		// 0x7f + signal<<8 for stopped
-		tt.Args(ExternalCmdExit{0x27f, "ls", 1}).Rets("ls stopped by signal " + syscall.SIGINT.String() + " (pid=1)"),
+		tt.Args(eval.ExternalCmdExit{0x27f, "ls", 1}).Rets("ls stopped by signal " + syscall.SIGINT.String() + " (pid=1)"),
 	})
 	if runtime.GOOS == "linux" {
 		tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
 			// 0x057f + cause<<16 for trapped. SIGTRAP is 5 on all Unix'es but have
 			// different string representations on different OSes.
-			tt.Args(ExternalCmdExit{0x1057f, "ls", 1}).Rets(fmt.Sprintf(
+			tt.Args(eval.ExternalCmdExit{0x1057f, "ls", 1}).Rets(fmt.Sprintf(
 				"ls stopped by signal %s (pid=1) (trapped 1)", syscall.SIGTRAP)),
 			// 0xff is the only exit code that is not exited, signaled or stopped.
-			tt.Args(ExternalCmdExit{0xff, "ls", 1}).Rets("ls has unknown WaitStatus 255"),
+			tt.Args(eval.ExternalCmdExit{0xff, "ls", 1}).Rets("ls has unknown WaitStatus 255"),
 		})
 	}
 }

--- a/pkg/eval/external_cmd_test.go
+++ b/pkg/eval/external_cmd_test.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/testutil"
@@ -21,9 +21,9 @@ func TestBuiltinFnExternal(t *testing.T) {
 		That("var e = (external false); var m = [&$e=true]; put (repr $m)").Puts("[&<external false>=true]"),
 		// Test calling of external commands.
 		That("var e = (external true); $e").DoesNothing(),
-		That("var e = (external true); $e &option").Throws(ErrExternalCmdOpts, "$e &option"),
+		That("var e = (external true); $e &option").Throws(eval.ErrExternalCmdOpts, "$e &option"),
 		That("var e = (external false); $e").Throws(CmdExit(
-			ExternalCmdExit{CmdName: "false", WaitStatus: exitWaitStatus(1)})),
+			eval.ExternalCmdExit{CmdName: "false", WaitStatus: exitWaitStatus(1)})),
 
 		// TODO: Modify the ExternalCmd.Call method to wrap the Go error in a
 		// predictable Elvish error so we don't have to resort to using

--- a/pkg/eval/external_cmd_unix_internal_test.go
+++ b/pkg/eval/external_cmd_unix_internal_test.go
@@ -10,20 +10,20 @@ import (
 
 	"src.elv.sh/pkg/env"
 	"src.elv.sh/pkg/parse"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestExec_Argv0Argv(t *testing.T) {
-	dir := InTempDir(t)
-	ApplyDir(Dir{
-		"bin": Dir{
-			"elvish": File{Perm: 0755},
-			"cat":    File{Perm: 0755},
+	dir := testutil.InTempDir(t)
+	testutil.ApplyDir(testutil.Dir{
+		"bin": testutil.Dir{
+			"elvish": testutil.File{Perm: 0755},
+			"cat":    testutil.File{Perm: 0755},
 		},
 	})
 
-	Setenv(t, "PATH", dir+"/bin")
-	Setenv(t, env.SHLVL, "1")
+	testutil.Setenv(t, "PATH", dir+"/bin")
+	testutil.Setenv(t, env.SHLVL, "1")
 
 	var tests = []struct {
 		name      string
@@ -104,7 +104,7 @@ func TestDecSHLVL(t *testing.T) {
 
 func testDecSHLVL(t *testing.T, oldValue, newValue string) {
 	t.Helper()
-	Setenv(t, env.SHLVL, oldValue)
+	testutil.Setenv(t, env.SHLVL, oldValue)
 
 	decSHLVL()
 	if gotValue := os.Getenv(env.SHLVL); gotValue != newValue {

--- a/pkg/eval/glob_test.go
+++ b/pkg/eval/glob_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/testutil"
@@ -38,7 +38,7 @@ func TestGlob_NoMatch(t *testing.T) {
 	testutil.InTempDir(t)
 
 	Test(t,
-		That("put a/b/nonexistent*").Throws(ErrWildcardNoMatch),
+		That("put a/b/nonexistent*").Throws(eval.ErrWildcardNoMatch),
 		That("put a/b/nonexistent*[nomatch-ok]").DoesNothing(),
 	)
 }
@@ -94,9 +94,9 @@ func TestGlob_Type(t *testing.T) {
 		That("put **[type:regular]f*").Puts("d1/f1", "d2/fm", "foo"),
 		That("put **f*[type:regular]").Puts("d1/f1", "d2/fm", "foo"),
 
-		That("put *[type:dir][type:regular]").Throws(ErrMultipleTypeModifiers),
-		That("put **[type:dir]f*[type:regular]").Throws(ErrMultipleTypeModifiers),
-		That("put **[type:unknown]").Throws(ErrUnknownTypeModifier),
+		That("put *[type:dir][type:regular]").Throws(eval.ErrMultipleTypeModifiers),
+		That("put **[type:dir]f*[type:regular]").Throws(eval.ErrMultipleTypeModifiers),
+		That("put **[type:unknown]").Throws(eval.ErrUnknownTypeModifier),
 	)
 }
 
@@ -104,7 +104,7 @@ func TestGlob_BadOperation(t *testing.T) {
 	testutil.InTempDir(t)
 
 	Test(t,
-		That("put *[[]]").Throws(ErrModifierMustBeString),
+		That("put *[[]]").Throws(eval.ErrModifierMustBeString),
 		That("put *[bad-mod]").Throws(ErrorWithMessage("unknown modifier bad-mod")),
 
 		That("put *{ }").

--- a/pkg/eval/go_fn_test.go
+++ b/pkg/eval/go_fn_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
@@ -31,13 +31,13 @@ func TestGoFn_RawOptions(t *testing.T) {
 
 		// RawOptions
 		That("f &foo=bar").DoesNothing().
-			WithSetup(f(func(opts RawOptions) {
+			WithSetup(f(func(opts eval.RawOptions) {
 				if opts["foo"] != "bar" {
 					t.Errorf("RawOptions parameter doesn't get options")
 				}
 			})),
 		// Options when the function does not accept options.
-		That("f &foo=bar").Throws(ErrNoOptAccepted).
+		That("f &foo=bar").Throws(eval.ErrNoOptAccepted).
 			WithSetup(f(func() {
 				t.Errorf("Function called when there are extra options")
 			})),
@@ -52,7 +52,7 @@ func TestGoFn_RawOptions(t *testing.T) {
 				}
 			})),
 		// Invalid option; regression test for #958.
-		That("f &bad=bar").Throws(UnknownOption{"bad"}).
+		That("f &bad=bar").Throws(eval.UnknownOption{"bad"}).
 			WithSetup(f(func(opts someOptions) {
 				t.Errorf("function called when there are invalid options")
 			})),
@@ -116,11 +116,11 @@ func TestGoFn_RawOptions(t *testing.T) {
 				t.Errorf("Function called when there are too few arguments")
 			})),
 		// Wrong argument type
-		That("f (num 1)").Throws(ErrorWithType(WrongArgType{})).
+		That("f (num 1)").Throws(ErrorWithType(eval.WrongArgType{})).
 			WithSetup(f(func(x string) {
 				t.Errorf("Function called when arguments have wrong type")
 			})),
-		That("f str").Throws(ErrorWithType(WrongArgType{})).
+		That("f str").Throws(ErrorWithType(eval.WrongArgType{})).
 			WithSetup(f(func(x int) {
 				t.Errorf("Function called when arguments have wrong type")
 			})),
@@ -148,14 +148,14 @@ func TestGoFn_RawOptions(t *testing.T) {
 	)
 }
 
-func f(body any) func(*Evaler) {
-	return func(ev *Evaler) {
-		ev.ExtendGlobal(BuildNs().AddGoFn("f", body))
+func f(body any) func(*eval.Evaler) {
+	return func(ev *eval.Evaler) {
+		ev.ExtendGlobal(eval.BuildNs().AddGoFn("f", body))
 	}
 }
 
-func testInputs(t *testing.T, wantValues ...any) func(Inputs) {
-	return func(i Inputs) {
+func testInputs(t *testing.T, wantValues ...any) func(eval.Inputs) {
+	return func(i eval.Inputs) {
 		t.Helper()
 		var values []any
 		i(func(x any) {

--- a/pkg/eval/options_test.go
+++ b/pkg/eval/options_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type opts struct {
@@ -24,10 +24,10 @@ func TestScanOptions(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("scanOptions", wrapper), Table{
-		Args(RawOptions{"foo": "lorem ipsum"}, opts{}).
+	tt.Test(t, tt.Fn("scanOptions", wrapper), tt.Table{
+		tt.Args(RawOptions{"foo": "lorem ipsum"}, opts{}).
 			Rets(opts{Foo: "lorem ipsum"}, nil),
-		Args(RawOptions{"bar": 20}, opts{bar: 10}).
+		tt.Args(RawOptions{"bar": 20}, opts{bar: 10}).
 			Rets(opts{bar: 10}, UnknownOption{"bar"}),
 	})
 }

--- a/pkg/eval/purely_eval_test.go
+++ b/pkg/eval/purely_eval_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/testutil"
 
 	"src.elv.sh/pkg/eval/vals"
@@ -39,11 +39,11 @@ func TestPurelyEvalCompound(t *testing.T) {
 		{code: "$@x", wantBad: true},
 	}
 
-	ev := NewEvaler()
-	ev.ExtendGlobal(BuildNs().
+	ev := eval.NewEvaler()
+	ev.ExtendGlobal(eval.BuildNs().
 		AddVar("x", vars.NewReadOnly("bar")).
 		AddVar("y", vars.NewReadOnly(vals.MakeList())).
-		AddNs("ns", BuildNs().AddVar("x", vars.NewReadOnly("foo"))))
+		AddNs("ns", eval.BuildNs().AddVar("x", vars.NewReadOnly("foo"))))
 
 	for _, test := range tests {
 		t.Run(test.code, func(t *testing.T) {

--- a/pkg/eval/pwd_test.go
+++ b/pkg/eval/pwd_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/testutil"
 
 	. "src.elv.sh/pkg/eval/evaltest"
@@ -52,9 +52,9 @@ func TestBuiltinPwd(t *testing.T) {
 
 // Verify the behavior when the CWD cannot be determined.
 func TestBuiltinPwd_GetwdError(t *testing.T) {
-	origGetwd := Getwd
-	Getwd = mockGetwdWithError
-	defer func() { Getwd = origGetwd }()
+	origGetwd := eval.Getwd
+	eval.Getwd = mockGetwdWithError
+	defer func() { eval.Getwd = origGetwd }()
 
 	Test(t,
 		That(`put $pwd`).Puts("/unknown/pwd"),

--- a/pkg/eval/vals/aliased_types_test.go
+++ b/pkg/eval/vals/aliased_types_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestMakeMap_PanicsWithOddNumberOfArguments(t *testing.T) {
-	Test(t, Fn("Recover", testutil.Recover), Table{
+	tt.Test(t, tt.Fn("Recover", testutil.Recover), tt.Table{
 		//lint:ignore SA5012 testing panic
-		Args(func() { MakeMap("foo") }).Rets("odd number of arguments to MakeMap"),
+		tt.Args(func() { MakeMap("foo") }).Rets("odd number of arguments to MakeMap"),
 	})
 }

--- a/pkg/eval/vals/assoc_test.go
+++ b/pkg/eval/vals/assoc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customAssocer struct{}
@@ -17,30 +17,30 @@ func (a customAssocer) Assoc(k, v any) (any, error) {
 }
 
 func TestAssoc(t *testing.T) {
-	Test(t, Fn("Assoc", Assoc), Table{
-		Args("0123", "0", "foo").Rets("foo123", nil),
-		Args("0123", "1..3", "bar").Rets("0bar3", nil),
-		Args("0123", "1..3", 12).Rets(nil, errReplacementMustBeString),
-		Args("0123", "x", "y").Rets(nil, errIndexMustBeInteger),
+	tt.Test(t, tt.Fn("Assoc", Assoc), tt.Table{
+		tt.Args("0123", "0", "foo").Rets("foo123", nil),
+		tt.Args("0123", "1..3", "bar").Rets("0bar3", nil),
+		tt.Args("0123", "1..3", 12).Rets(nil, errReplacementMustBeString),
+		tt.Args("0123", "x", "y").Rets(nil, errIndexMustBeInteger),
 
-		Args(MakeList("0", "1", "2", "3"), "0", "foo").Rets(
+		tt.Args(MakeList("0", "1", "2", "3"), "0", "foo").Rets(
 			eq(MakeList("foo", "1", "2", "3")), nil),
-		Args(MakeList("0", "1", "2", "3"), 0, "foo").Rets(
+		tt.Args(MakeList("0", "1", "2", "3"), 0, "foo").Rets(
 			eq(MakeList("foo", "1", "2", "3")), nil),
-		Args(MakeList("0"), MakeList("0"), "1").Rets(nil, errIndexMustBeInteger),
-		Args(MakeList("0"), "1", "x").Rets(nil, errs.OutOfRange{
+		tt.Args(MakeList("0"), MakeList("0"), "1").Rets(nil, errIndexMustBeInteger),
+		tt.Args(MakeList("0"), "1", "x").Rets(nil, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "0", Actual: "1"}),
 		// TODO: Support list assoc with slice
-		Args(MakeList("0", "1", "2", "3"), "1..3", MakeList("foo")).Rets(
+		tt.Args(MakeList("0", "1", "2", "3"), "1..3", MakeList("foo")).Rets(
 			nil, errAssocWithSlice),
 
-		Args(MakeMap("k", "v", "k2", "v2"), "k", "newv").Rets(
+		tt.Args(MakeMap("k", "v", "k2", "v2"), "k", "newv").Rets(
 			eq(MakeMap("k", "newv", "k2", "v2")), nil),
-		Args(MakeMap("k", "v"), "k2", "v2").Rets(
+		tt.Args(MakeMap("k", "v"), "k2", "v2").Rets(
 			eq(MakeMap("k", "v", "k2", "v2")), nil),
 
-		Args(customAssocer{}, "x", "y").Rets("custom result", errCustomAssoc),
+		tt.Args(customAssocer{}, "x", "y").Rets("custom result", errCustomAssoc),
 
-		Args(struct{}{}, "x", "y").Rets(nil, errAssocUnsupported),
+		tt.Args(struct{}{}, "x", "y").Rets(nil, errAssocUnsupported),
 	})
 }

--- a/pkg/eval/vals/bool_test.go
+++ b/pkg/eval/vals/bool_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customBooler struct{ b bool }
@@ -13,15 +13,15 @@ func (b customBooler) Bool() bool { return b.b }
 type customNonBooler struct{}
 
 func TestBool(t *testing.T) {
-	Test(t, Fn("Bool", Bool), Table{
-		Args(nil).Rets(false),
+	tt.Test(t, tt.Fn("Bool", Bool), tt.Table{
+		tt.Args(nil).Rets(false),
 
-		Args(true).Rets(true),
-		Args(false).Rets(false),
+		tt.Args(true).Rets(true),
+		tt.Args(false).Rets(false),
 
-		Args(customBooler{true}).Rets(true),
-		Args(customBooler{false}).Rets(false),
+		tt.Args(customBooler{true}).Rets(true),
+		tt.Args(customBooler{false}).Rets(false),
 
-		Args(customNonBooler{}).Rets(true),
+		tt.Args(customNonBooler{}).Rets(true),
 	})
 }

--- a/pkg/eval/vals/concat_test.go
+++ b/pkg/eval/vals/concat_test.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // An implementation for Concatter that accepts strings, returns a special
@@ -34,28 +34,28 @@ func (rconcatter) RConcat(lhs any) (any, error) {
 }
 
 func TestConcat(t *testing.T) {
-	Test(t, Fn("Concat", Concat), Table{
-		Args("foo", "bar").Rets("foobar", nil),
+	tt.Test(t, tt.Fn("Concat", Concat), tt.Table{
+		tt.Args("foo", "bar").Rets("foobar", nil),
 		// string+number
-		Args("foo", 2).Rets("foo2", nil),
-		Args("foo", bigInt(z)).Rets("foo"+z, nil),
-		Args("foo", big.NewRat(1, 2)).Rets("foo1/2", nil),
-		Args("foo", 2.0).Rets("foo2.0", nil),
+		tt.Args("foo", 2).Rets("foo2", nil),
+		tt.Args("foo", bigInt(z)).Rets("foo"+z, nil),
+		tt.Args("foo", big.NewRat(1, 2)).Rets("foo1/2", nil),
+		tt.Args("foo", 2.0).Rets("foo2.0", nil),
 		// number+string
-		Args(2, "foo").Rets("2foo", nil),
-		Args(bigInt(z), "foo").Rets(z+"foo", nil),
-		Args(big.NewRat(1, 2), "foo").Rets("1/2foo", nil),
-		Args(2.0, "foo").Rets("2.0foo", nil),
+		tt.Args(2, "foo").Rets("2foo", nil),
+		tt.Args(bigInt(z), "foo").Rets(z+"foo", nil),
+		tt.Args(big.NewRat(1, 2), "foo").Rets("1/2foo", nil),
+		tt.Args(2.0, "foo").Rets("2.0foo", nil),
 
 		// LHS implements Concatter and succeeds
-		Args(concatter{}, "bar").Rets("concatter bar", nil),
+		tt.Args(concatter{}, "bar").Rets("concatter bar", nil),
 		// LHS implements Concatter but returns ErrConcatNotImplemented; RHS
 		// does not implement RConcatter
-		Args(concatter{}, 12).Rets(nil, cannotConcat{"!!vals.concatter", "number"}),
+		tt.Args(concatter{}, 12).Rets(nil, cannotConcat{"!!vals.concatter", "number"}),
 		// LHS implements Concatter but returns another error
-		Args(concatter{}, 12.0).Rets(nil, errBadFloat64),
+		tt.Args(concatter{}, 12.0).Rets(nil, errBadFloat64),
 
 		// LHS does not implement Concatter but RHS implements RConcatter
-		Args(12, rconcatter{}).Rets("rconcatter", nil),
+		tt.Args(12, rconcatter{}).Rets("rconcatter", nil),
 	})
 }

--- a/pkg/eval/vals/conversion_test.go
+++ b/pkg/eval/vals/conversion_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type someType struct {
@@ -23,35 +23,35 @@ func TestScanToGo_ConcreteTypeDst(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
 		// int
-		Args("12", 0).Rets(12),
-		Args("0x12", 0).Rets(0x12),
-		Args(12.0, 0).Rets(0, errMustBeInteger),
-		Args(0.5, 0).Rets(0, errMustBeInteger),
-		Args(someType{}, 0).Rets(Any, errMustBeInteger),
-		Args("x", 0).Rets(Any, cannotParseAs{"integer", "x"}),
+		tt.Args("12", 0).Rets(12),
+		tt.Args("0x12", 0).Rets(0x12),
+		tt.Args(12.0, 0).Rets(0, errMustBeInteger),
+		tt.Args(0.5, 0).Rets(0, errMustBeInteger),
+		tt.Args(someType{}, 0).Rets(tt.Any, errMustBeInteger),
+		tt.Args("x", 0).Rets(tt.Any, cannotParseAs{"integer", "x"}),
 
 		// float64
-		Args(23, 0.0).Rets(23.0),
-		Args(big.NewRat(1, 2), 0.0).Rets(0.5),
-		Args(1.2, 0.0).Rets(1.2),
-		Args("23", 0.0).Rets(23.0),
-		Args("0x23", 0.0).Rets(float64(0x23)),
-		Args(someType{}, 0.0).Rets(Any, errMustBeNumber),
-		Args("x", 0.0).Rets(Any, cannotParseAs{"number", "x"}),
+		tt.Args(23, 0.0).Rets(23.0),
+		tt.Args(big.NewRat(1, 2), 0.0).Rets(0.5),
+		tt.Args(1.2, 0.0).Rets(1.2),
+		tt.Args("23", 0.0).Rets(23.0),
+		tt.Args("0x23", 0.0).Rets(float64(0x23)),
+		tt.Args(someType{}, 0.0).Rets(tt.Any, errMustBeNumber),
+		tt.Args("x", 0.0).Rets(tt.Any, cannotParseAs{"number", "x"}),
 
 		// rune
-		Args("x", ' ').Rets('x'),
-		Args(someType{}, ' ').Rets(Any, errMustBeString),
-		Args("\xc3\x28", ' ').Rets(Any, errMustBeValidUTF8), // Invalid UTF8
-		Args("ab", ' ').Rets(Any, errMustHaveSingleRune),
+		tt.Args("x", ' ').Rets('x'),
+		tt.Args(someType{}, ' ').Rets(tt.Any, errMustBeString),
+		tt.Args("\xc3\x28", ' ').Rets(tt.Any, errMustBeValidUTF8), // Invalid UTF8
+		tt.Args("ab", ' ').Rets(tt.Any, errMustHaveSingleRune),
 
 		// Other types don't undergo any conversion, as long as the types match
-		Args("foo", "").Rets("foo"),
-		Args(someType{"foo"}, someType{}).Rets(someType{"foo"}),
-		Args(nil, nil).Rets(nil),
-		Args("x", someType{}).Rets(Any, WrongType{"!!vals.someType", "string"}),
+		tt.Args("foo", "").Rets("foo"),
+		tt.Args(someType{"foo"}, someType{}).Rets(someType{"foo"}),
+		tt.Args(nil, nil).Rets(nil),
+		tt.Args("x", someType{}).Rets(tt.Any, WrongType{"!!vals.someType", "string"}),
 	})
 }
 
@@ -62,20 +62,20 @@ func TestScanToGo_NumDst(t *testing.T) {
 		return n, err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
 		// Strings are automatically converted
-		Args("12").Rets(12),
-		Args(z).Rets(bigInt(z)),
-		Args("1/2").Rets(big.NewRat(1, 2)),
-		Args("12.0").Rets(12.0),
+		tt.Args("12").Rets(12),
+		tt.Args(z).Rets(bigInt(z)),
+		tt.Args("1/2").Rets(big.NewRat(1, 2)),
+		tt.Args("12.0").Rets(12.0),
 		// Already numbers
-		Args(12).Rets(12),
-		Args(bigInt(z)).Rets(bigInt(z)),
-		Args(big.NewRat(1, 2)).Rets(big.NewRat(1, 2)),
-		Args(12.0).Rets(12.0),
+		tt.Args(12).Rets(12),
+		tt.Args(bigInt(z)).Rets(bigInt(z)),
+		tt.Args(big.NewRat(1, 2)).Rets(big.NewRat(1, 2)),
+		tt.Args(12.0).Rets(12.0),
 
-		Args("bad").Rets(Any, cannotParseAs{"number", "bad"}),
-		Args(EmptyList).Rets(Any, errMustBeNumber),
+		tt.Args("bad").Rets(tt.Any, cannotParseAs{"number", "bad"}),
+		tt.Args(EmptyList).Rets(tt.Any, errMustBeNumber),
 	})
 }
 
@@ -86,10 +86,10 @@ func TestScanToGo_InterfaceDst(t *testing.T) {
 		return l, err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
-		Args(EmptyList).Rets(EmptyList),
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
+		tt.Args(EmptyList).Rets(EmptyList),
 
-		Args("foo").Rets(Any, WrongType{"!!vector.Vector", "string"}),
+		tt.Args("foo").Rets(tt.Any, WrongType{"!!vector.Vector", "string"}),
 	})
 }
 
@@ -109,11 +109,11 @@ func TestScanListToGo(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanListToGo", scanListToGo), Table{
-		Args(MakeList("1", "2"), []int{}).Rets([]int{1, 2}),
-		Args(MakeList("1", "2"), []string{}).Rets([]string{"1", "2"}),
+	tt.Test(t, tt.Fn("ScanListToGo", scanListToGo), tt.Table{
+		tt.Args(MakeList("1", "2"), []int{}).Rets([]int{1, 2}),
+		tt.Args(MakeList("1", "2"), []string{}).Rets([]string{"1", "2"}),
 
-		Args(MakeList("1", "a"), []int{}).Rets([]int{}, cannotParseAs{"integer", "a"}),
+		tt.Args(MakeList("1", "a"), []int{}).Rets([]int{}, cannotParseAs{"integer", "a"}),
 	})
 }
 
@@ -142,18 +142,18 @@ func TestScanListElementsToGo(t *testing.T) {
 		return vals, err
 	}
 
-	Test(t, Fn("ScanListElementsToGo", scanListElementsToGo), Table{
-		Args(MakeList("1", "2"), 0, 0).Rets([]any{1, 2}),
-		Args(MakeList("1", "2"), "", "").Rets([]any{"1", "2"}),
-		Args(MakeList("1", "2"), 0, Optional(0)).Rets([]any{1, 2}),
-		Args(MakeList("1"), 0, Optional(0)).Rets([]any{1, 0}),
+	tt.Test(t, tt.Fn("ScanListElementsToGo", scanListElementsToGo), tt.Table{
+		tt.Args(MakeList("1", "2"), 0, 0).Rets([]any{1, 2}),
+		tt.Args(MakeList("1", "2"), "", "").Rets([]any{"1", "2"}),
+		tt.Args(MakeList("1", "2"), 0, Optional(0)).Rets([]any{1, 2}),
+		tt.Args(MakeList("1"), 0, Optional(0)).Rets([]any{1, 0}),
 
-		Args(MakeList("a"), 0).Rets([]any{0},
+		tt.Args(MakeList("a"), 0).Rets([]any{0},
 			cannotParseAs{"integer", "a"}),
-		Args(MakeList("1"), 0, 0).Rets([]any{0, 0},
+		tt.Args(MakeList("1"), 0, 0).Rets([]any{0, 0},
 			errs.ArityMismatch{What: "list elements",
 				ValidLow: 2, ValidHigh: 2, Actual: 1}),
-		Args(MakeList("1"), 0, 0, Optional(0)).Rets([]any{0, 0, 0},
+		tt.Args(MakeList("1"), 0, 0, Optional(0)).Rets([]any{0, 0, 0},
 			errs.ArityMismatch{What: "list elements",
 				ValidLow: 2, ValidHigh: 3, Actual: 1}),
 	})
@@ -176,35 +176,35 @@ func TestScanMapToGo(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanListToGo", scanMapToGo), Table{
-		Args(MakeMap("foo", "1"), aStruct{}).Rets(aStruct{Foo: 1}),
+	tt.Test(t, tt.Fn("ScanListToGo", scanMapToGo), tt.Table{
+		tt.Args(MakeMap("foo", "1"), aStruct{}).Rets(aStruct{Foo: 1}),
 		// More fields is OK
-		Args(MakeMap("foo", "1", "bar", "x"), aStruct{}).Rets(aStruct{Foo: 1}),
+		tt.Args(MakeMap("foo", "1", "bar", "x"), aStruct{}).Rets(aStruct{Foo: 1}),
 		// Fewer fields is OK
-		Args(MakeMap(), aStruct{}).Rets(aStruct{}),
+		tt.Args(MakeMap(), aStruct{}).Rets(aStruct{}),
 		// Unexported fields are ignored
-		Args(MakeMap("bar", 20), aStruct{bar: 10}).Rets(aStruct{bar: 10}),
+		tt.Args(MakeMap("bar", 20), aStruct{bar: 10}).Rets(aStruct{bar: 10}),
 
 		// Conversion error
-		Args(MakeMap("foo", "a"), aStruct{}).
+		tt.Args(MakeMap("foo", "a"), aStruct{}).
 			Rets(aStruct{}, cannotParseAs{"integer", "a"}),
 	})
 }
 
 func TestFromGo(t *testing.T) {
-	Test(t, Fn("FromGo", FromGo), Table{
+	tt.Test(t, tt.Fn("FromGo", FromGo), tt.Table{
 		// BigInt -> int, when in range
-		Args(bigInt(z)).Rets(bigInt(z)),
-		Args(big.NewInt(100)).Rets(100),
+		tt.Args(bigInt(z)).Rets(bigInt(z)),
+		tt.Args(big.NewInt(100)).Rets(100),
 		// BigRat -> BigInt or int, when denominator is 1
-		Args(bigRat(z1 + "/" + z)).Rets(bigRat(z1 + "/" + z)),
-		Args(bigRat(z + "/1")).Rets(bigInt(z)),
-		Args(bigRat("2/1")).Rets(2),
+		tt.Args(bigRat(z1 + "/" + z)).Rets(bigRat(z1 + "/" + z)),
+		tt.Args(bigRat(z + "/1")).Rets(bigInt(z)),
+		tt.Args(bigRat("2/1")).Rets(2),
 		// rune -> string
-		Args('x').Rets("x"),
+		tt.Args('x').Rets("x"),
 
 		// Other types don't undergo any conversion
-		Args(nil).Rets(nil),
-		Args(someType{"foo"}).Rets(someType{"foo"}),
+		tt.Args(nil).Rets(nil),
+		tt.Args(someType{"foo"}).Rets(someType{"foo"}),
 	})
 }

--- a/pkg/eval/vals/dissoc_test.go
+++ b/pkg/eval/vals/dissoc_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type dissocer struct{}
@@ -11,9 +11,9 @@ type dissocer struct{}
 func (dissocer) Dissoc(any) any { return "custom ret" }
 
 func TestDissoc(t *testing.T) {
-	Test(t, Fn("Dissoc", Dissoc), Table{
-		Args(MakeMap("k1", "v1", "k2", "v2"), "k1").Rets(eq(MakeMap("k2", "v2"))),
-		Args(dissocer{}, "x").Rets("custom ret"),
-		Args("", "x").Rets(nil),
+	tt.Test(t, tt.Fn("Dissoc", Dissoc), tt.Table{
+		tt.Args(MakeMap("k1", "v1", "k2", "v2"), "k1").Rets(eq(MakeMap("k2", "v2"))),
+		tt.Args(dissocer{}, "x").Rets("custom ret"),
+		tt.Args("", "x").Rets(nil),
 	})
 }

--- a/pkg/eval/vals/equal_test.go
+++ b/pkg/eval/vals/equal_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customEqualer struct{ ret bool }
@@ -15,47 +15,47 @@ func (c customEqualer) Equal(any) bool { return c.ret }
 type customStruct struct{ a, b string }
 
 func TestEqual(t *testing.T) {
-	Test(t, Fn("Equal", Equal), Table{
-		Args(nil, nil).Rets(true),
-		Args(nil, "").Rets(false),
+	tt.Test(t, tt.Fn("Equal", Equal), tt.Table{
+		tt.Args(nil, nil).Rets(true),
+		tt.Args(nil, "").Rets(false),
 
-		Args(true, true).Rets(true),
-		Args(true, false).Rets(false),
+		tt.Args(true, true).Rets(true),
+		tt.Args(true, false).Rets(false),
 
-		Args(1.0, 1.0).Rets(true),
-		Args(1.0, 1.1).Rets(false),
-		Args("1.0", 1.0).Rets(false),
-		Args(1, 1.0).Rets(false),
-		Args(1, 1).Rets(true),
-		Args(bigInt(z), bigInt(z)).Rets(true),
-		Args(bigInt(z), 1).Rets(false),
-		Args(bigInt(z), bigInt(z1)).Rets(false),
-		Args(big.NewRat(1, 2), big.NewRat(1, 2)).Rets(true),
-		Args(big.NewRat(1, 2), 0.5).Rets(false),
+		tt.Args(1.0, 1.0).Rets(true),
+		tt.Args(1.0, 1.1).Rets(false),
+		tt.Args("1.0", 1.0).Rets(false),
+		tt.Args(1, 1.0).Rets(false),
+		tt.Args(1, 1).Rets(true),
+		tt.Args(bigInt(z), bigInt(z)).Rets(true),
+		tt.Args(bigInt(z), 1).Rets(false),
+		tt.Args(bigInt(z), bigInt(z1)).Rets(false),
+		tt.Args(big.NewRat(1, 2), big.NewRat(1, 2)).Rets(true),
+		tt.Args(big.NewRat(1, 2), 0.5).Rets(false),
 
-		Args("lorem", "lorem").Rets(true),
-		Args("lorem", "ipsum").Rets(false),
+		tt.Args("lorem", "lorem").Rets(true),
+		tt.Args("lorem", "ipsum").Rets(false),
 
-		Args(os.Stdin, os.Stdin).Rets(true),
-		Args(os.Stdin, os.Stderr).Rets(false),
-		Args(os.Stdin, "").Rets(false),
-		Args(os.Stdin, 0).Rets(false),
+		tt.Args(os.Stdin, os.Stdin).Rets(true),
+		tt.Args(os.Stdin, os.Stderr).Rets(false),
+		tt.Args(os.Stdin, "").Rets(false),
+		tt.Args(os.Stdin, 0).Rets(false),
 
-		Args(MakeList("a", "b"), MakeList("a", "b")).Rets(true),
-		Args(MakeList("a", "b"), MakeList("a")).Rets(false),
-		Args(MakeList("a", "b"), MakeList("a", "c")).Rets(false),
-		Args(MakeList("a", "b"), "").Rets(false),
-		Args(MakeList("a", "b"), 1.0).Rets(false),
+		tt.Args(MakeList("a", "b"), MakeList("a", "b")).Rets(true),
+		tt.Args(MakeList("a", "b"), MakeList("a")).Rets(false),
+		tt.Args(MakeList("a", "b"), MakeList("a", "c")).Rets(false),
+		tt.Args(MakeList("a", "b"), "").Rets(false),
+		tt.Args(MakeList("a", "b"), 1.0).Rets(false),
 
-		Args(MakeMap("k", "v"), MakeMap("k", "v")).Rets(true),
-		Args(MakeMap("k", "v"), MakeMap("k2", "v")).Rets(false),
-		Args(MakeMap("k", "v", "k2", "v2"), MakeMap("k", "v")).Rets(false),
-		Args(MakeMap("k", "v"), "").Rets(false),
-		Args(MakeMap("k", "v"), 1.0).Rets(false),
+		tt.Args(MakeMap("k", "v"), MakeMap("k", "v")).Rets(true),
+		tt.Args(MakeMap("k", "v"), MakeMap("k2", "v")).Rets(false),
+		tt.Args(MakeMap("k", "v", "k2", "v2"), MakeMap("k", "v")).Rets(false),
+		tt.Args(MakeMap("k", "v"), "").Rets(false),
+		tt.Args(MakeMap("k", "v"), 1.0).Rets(false),
 
-		Args(customEqualer{true}, 2).Rets(true),
-		Args(customEqualer{false}, 2).Rets(false),
+		tt.Args(customEqualer{true}, 2).Rets(true),
+		tt.Args(customEqualer{false}, 2).Rets(false),
 
-		Args(&customStruct{"a", "b"}, &customStruct{"a", "b"}).Rets(true),
+		tt.Args(&customStruct{"a", "b"}, &customStruct{"a", "b"}).Rets(true),
 	})
 }

--- a/pkg/eval/vals/errors_test.go
+++ b/pkg/eval/vals/errors_test.go
@@ -3,12 +3,12 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestErrors(t *testing.T) {
-	Test(t, Fn("error.Error", error.Error), Table{
-		Args(cannotIterate{"num"}).Rets("cannot iterate num"),
-		Args(cannotIterateKeysOf{"num"}).Rets("cannot iterate keys of num"),
+	tt.Test(t, tt.Fn("error.Error", error.Error), tt.Table{
+		tt.Args(cannotIterate{"num"}).Rets("cannot iterate num"),
+		tt.Args(cannotIterateKeysOf{"num"}).Rets("cannot iterate keys of num"),
 	})
 }

--- a/pkg/eval/vals/has_key_test.go
+++ b/pkg/eval/vals/has_key_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type hasKeyer struct{ key any }
@@ -11,22 +11,22 @@ type hasKeyer struct{ key any }
 func (h hasKeyer) HasKey(k any) bool { return k == h.key }
 
 func TestHasKey(t *testing.T) {
-	Test(t, Fn("HasKey", HasKey), Table{
+	tt.Test(t, tt.Fn("HasKey", HasKey), tt.Table{
 		// Map
-		Args(MakeMap("k", "v"), "k").Rets(true),
-		Args(MakeMap("k", "v"), "bad").Rets(false),
+		tt.Args(MakeMap("k", "v"), "k").Rets(true),
+		tt.Args(MakeMap("k", "v"), "bad").Rets(false),
 		// HasKeyer
-		Args(hasKeyer{"valid"}, "valid").Rets(true),
-		Args(hasKeyer{"valid"}, "invalid").Rets(false),
+		tt.Args(hasKeyer{"valid"}, "valid").Rets(true),
+		tt.Args(hasKeyer{"valid"}, "invalid").Rets(false),
 		// Fallback to IterateKeys
-		Args(keysIterator{vs("lorem")}, "lorem").Rets(true),
-		Args(keysIterator{vs("lorem")}, "ipsum").Rets(false),
+		tt.Args(keysIterator{vs("lorem")}, "lorem").Rets(true),
+		tt.Args(keysIterator{vs("lorem")}, "ipsum").Rets(false),
 		// Fallback to Len
-		Args(MakeList("lorem", "ipsum"), "0").Rets(true),
-		Args(MakeList("lorem", "ipsum"), "0..").Rets(true),
-		Args(MakeList("lorem", "ipsum"), "2").Rets(false),
+		tt.Args(MakeList("lorem", "ipsum"), "0").Rets(true),
+		tt.Args(MakeList("lorem", "ipsum"), "0..").Rets(true),
+		tt.Args(MakeList("lorem", "ipsum"), "2").Rets(false),
 
 		// Non-container
-		Args(1, "0").Rets(false),
+		tt.Args(1, "0").Rets(false),
 	})
 }

--- a/pkg/eval/vals/hash_test.go
+++ b/pkg/eval/vals/hash_test.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 
 	"src.elv.sh/pkg/persistent/hash"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type hasher struct{}
@@ -23,19 +23,19 @@ func TestHash(t *testing.T) {
 	z.Add(z, big.NewInt(9))
 	// z = 5 << wordSize + 9
 
-	Test(t, Fn("Hash", Hash), Table{
-		Args(false).Rets(uint32(0)),
-		Args(true).Rets(uint32(1)),
-		Args(1).Rets(uint32(1)),
-		Args(z).Rets(hash.DJB(1, 9, 5)),
-		Args(big.NewRat(3, 2)).Rets(hash.DJB(Hash(big.NewInt(3)), Hash(big.NewInt(2)))),
-		Args(1.0).Rets(hash.UInt64(math.Float64bits(1.0))),
-		Args("foo").Rets(hash.String("foo")),
-		Args(os.Stdin).Rets(hash.UIntPtr(os.Stdin.Fd())),
-		Args(MakeList("foo", "bar")).Rets(hash.DJB(Hash("foo"), Hash("bar"))),
-		Args(MakeMap("foo", "bar")).
+	tt.Test(t, tt.Fn("Hash", Hash), tt.Table{
+		tt.Args(false).Rets(uint32(0)),
+		tt.Args(true).Rets(uint32(1)),
+		tt.Args(1).Rets(uint32(1)),
+		tt.Args(z).Rets(hash.DJB(1, 9, 5)),
+		tt.Args(big.NewRat(3, 2)).Rets(hash.DJB(Hash(big.NewInt(3)), Hash(big.NewInt(2)))),
+		tt.Args(1.0).Rets(hash.UInt64(math.Float64bits(1.0))),
+		tt.Args("foo").Rets(hash.String("foo")),
+		tt.Args(os.Stdin).Rets(hash.UIntPtr(os.Stdin.Fd())),
+		tt.Args(MakeList("foo", "bar")).Rets(hash.DJB(Hash("foo"), Hash("bar"))),
+		tt.Args(MakeMap("foo", "bar")).
 			Rets(hash.DJB(Hash("foo"), Hash("bar"))),
-		Args(hasher{}).Rets(uint32(42)),
-		Args(nonHasher{}).Rets(uint32(0)),
+		tt.Args(hasher{}).Rets(uint32(42)),
+		tt.Args(nonHasher{}).Rets(uint32(0)),
 	})
 }

--- a/pkg/eval/vals/index_test.go
+++ b/pkg/eval/vals/index_test.go
@@ -6,7 +6,7 @@ import (
 
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 var (
@@ -16,110 +16,110 @@ var (
 )
 
 func TestIndex(t *testing.T) {
-	Test(t, Fn("Index", Index), Table{
+	tt.Test(t, tt.Fn("Index", Index), tt.Table{
 		// String indices
-		Args("abc", "0").Rets("a", nil),
-		Args("abc", 0).Rets("a", nil),
-		Args("你好", "0").Rets("你", nil),
-		Args("你好", "3").Rets("好", nil),
-		Args("你好", "2").Rets(Any, errIndexNotAtRuneBoundary),
+		tt.Args("abc", "0").Rets("a", nil),
+		tt.Args("abc", 0).Rets("a", nil),
+		tt.Args("你好", "0").Rets("你", nil),
+		tt.Args("你好", "3").Rets("好", nil),
+		tt.Args("你好", "2").Rets(tt.Any, errIndexNotAtRuneBoundary),
 		// String slices with half-open range.
-		Args("abc", "1..2").Rets("b", nil),
-		Args("abc", "1..").Rets("bc", nil),
-		Args("abc", "..").Rets("abc", nil),
-		Args("abc", "..0").Rets("", nil), // i == j == 0 is allowed
-		Args("abc", "3..").Rets("", nil), // i == j == n is allowed
+		tt.Args("abc", "1..2").Rets("b", nil),
+		tt.Args("abc", "1..").Rets("bc", nil),
+		tt.Args("abc", "..").Rets("abc", nil),
+		tt.Args("abc", "..0").Rets("", nil), // i == j == 0 is allowed
+		tt.Args("abc", "3..").Rets("", nil), // i == j == n is allowed
 		// String slices with closed range.
-		Args("abc", "0..=1").Rets("ab", nil),
-		Args("abc", "1..=").Rets("bc", nil),
-		Args("abc", "..=1").Rets("ab", nil),
-		Args("abc", "..=").Rets("abc", nil),
+		tt.Args("abc", "0..=1").Rets("ab", nil),
+		tt.Args("abc", "1..=").Rets("bc", nil),
+		tt.Args("abc", "..=1").Rets("ab", nil),
+		tt.Args("abc", "..=").Rets("abc", nil),
 		// String slices not at rune boundary.
-		Args("你好", "2..").Rets(Any, errIndexNotAtRuneBoundary),
-		Args("你好", "..2").Rets(Any, errIndexNotAtRuneBoundary),
+		tt.Args("你好", "2..").Rets(tt.Any, errIndexNotAtRuneBoundary),
+		tt.Args("你好", "..2").Rets(tt.Any, errIndexNotAtRuneBoundary),
 
 		// List indices
 		// ============
 
 		// Simple indices: 0 <= i < n.
-		Args(li4, "0").Rets("foo", nil),
-		Args(li4, "3").Rets("ipsum", nil),
-		Args(li0, "0").Rets(Any, errs.OutOfRange{
+		tt.Args(li4, "0").Rets("foo", nil),
+		tt.Args(li4, "3").Rets("ipsum", nil),
+		tt.Args(li0, "0").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "-1", Actual: "0"}),
-		Args(li4, "4").Rets(Any, errs.OutOfRange{
+		tt.Args(li4, "4").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "3", Actual: "4"}),
-		Args(li4, "5").Rets(Any, errs.OutOfRange{
+		tt.Args(li4, "5").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "3", Actual: "5"}),
-		Args(li4, z).Rets(Any,
+		tt.Args(li4, z).Rets(tt.Any,
 			errs.OutOfRange{What: "index", ValidLow: "0", ValidHigh: "3", Actual: z}),
 		// Negative indices: -n <= i < 0.
-		Args(li4, "-1").Rets("ipsum", nil),
-		Args(li4, "-4").Rets("foo", nil),
-		Args(li4, "-5").Rets(Any, errs.OutOfRange{
+		tt.Args(li4, "-1").Rets("ipsum", nil),
+		tt.Args(li4, "-4").Rets("foo", nil),
+		tt.Args(li4, "-5").Rets(tt.Any, errs.OutOfRange{
 			What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-5"}),
-		Args(li4, "-"+z).Rets(Any,
+		tt.Args(li4, "-"+z).Rets(tt.Any,
 			errs.OutOfRange{What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-" + z}),
 		// Float indices are not allowed even if the value is an integer.
-		Args(li4, 0.0).Rets(Any, errIndexMustBeInteger),
+		tt.Args(li4, 0.0).Rets(tt.Any, errIndexMustBeInteger),
 
 		// Integer indices are allowed.
-		Args(li4, 0).Rets("foo", nil),
-		Args(li4, 3).Rets("ipsum", nil),
-		Args(li4, 5).Rets(nil, errs.OutOfRange{
+		tt.Args(li4, 0).Rets("foo", nil),
+		tt.Args(li4, 3).Rets("ipsum", nil),
+		tt.Args(li4, 5).Rets(nil, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "3", Actual: "5"}),
-		Args(li4, -1).Rets("ipsum", nil),
-		Args(li4, -5).Rets(nil, errs.OutOfRange{
+		tt.Args(li4, -1).Rets("ipsum", nil),
+		tt.Args(li4, -5).Rets(nil, errs.OutOfRange{
 			What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-5"}),
 
 		// Half-open slices.
-		Args(li4, "1..3").Rets(eq(MakeList("bar", "lorem")), nil),
-		Args(li4, "3..4").Rets(eq(MakeList("ipsum")), nil),
-		Args(li4, "0..0").Rets(eq(EmptyList), nil), // i == j == 0 is allowed
-		Args(li4, "4..4").Rets(eq(EmptyList), nil), // i == j == n is allowed
+		tt.Args(li4, "1..3").Rets(eq(MakeList("bar", "lorem")), nil),
+		tt.Args(li4, "3..4").Rets(eq(MakeList("ipsum")), nil),
+		tt.Args(li4, "0..0").Rets(eq(EmptyList), nil), // i == j == 0 is allowed
+		tt.Args(li4, "4..4").Rets(eq(EmptyList), nil), // i == j == n is allowed
 		// i defaults to 0
-		Args(li4, "..2").Rets(eq(MakeList("foo", "bar")), nil),
-		Args(li4, "..-1").Rets(eq(MakeList("foo", "bar", "lorem")), nil),
+		tt.Args(li4, "..2").Rets(eq(MakeList("foo", "bar")), nil),
+		tt.Args(li4, "..-1").Rets(eq(MakeList("foo", "bar", "lorem")), nil),
 		// j defaults to n
-		Args(li4, "3..").Rets(eq(MakeList("ipsum")), nil),
-		Args(li4, "-2..").Rets(eq(MakeList("lorem", "ipsum")), nil),
+		tt.Args(li4, "3..").Rets(eq(MakeList("ipsum")), nil),
+		tt.Args(li4, "-2..").Rets(eq(MakeList("lorem", "ipsum")), nil),
 		// Both indices can be omitted.
-		Args(li0, "..").Rets(eq(li0), nil),
-		Args(li4, "..").Rets(eq(li4), nil),
+		tt.Args(li0, "..").Rets(eq(li0), nil),
+		tt.Args(li4, "..").Rets(eq(li4), nil),
 
 		// Closed slices.
-		Args(li4, "1..=2").Rets(eq(MakeList("bar", "lorem")), nil),
-		Args(li4, "..=1").Rets(eq(MakeList("foo", "bar")), nil),
-		Args(li4, "..=-2").Rets(eq(MakeList("foo", "bar", "lorem")), nil),
-		Args(li4, "3..=").Rets(eq(MakeList("ipsum")), nil),
-		Args(li4, "..=").Rets(eq(li4), nil),
+		tt.Args(li4, "1..=2").Rets(eq(MakeList("bar", "lorem")), nil),
+		tt.Args(li4, "..=1").Rets(eq(MakeList("foo", "bar")), nil),
+		tt.Args(li4, "..=-2").Rets(eq(MakeList("foo", "bar", "lorem")), nil),
+		tt.Args(li4, "3..=").Rets(eq(MakeList("ipsum")), nil),
+		tt.Args(li4, "..=").Rets(eq(li4), nil),
 
 		// Slice index out of range.
-		Args(li4, "-5..1").Rets(nil, errs.OutOfRange{
+		tt.Args(li4, "-5..1").Rets(nil, errs.OutOfRange{
 			What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-5"}),
-		Args(li4, "0..5").Rets(nil, errs.OutOfRange{
+		tt.Args(li4, "0..5").Rets(nil, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "4", Actual: "5"}),
-		Args(li4, z+"..").Rets(nil,
+		tt.Args(li4, z+"..").Rets(nil,
 			errs.OutOfRange{What: "index", ValidLow: "0", ValidHigh: "4", Actual: z}),
 		// Slice index upper < lower
-		Args(li4, "3..2").Rets(nil, errs.OutOfRange{
+		tt.Args(li4, "3..2").Rets(nil, errs.OutOfRange{
 			What: "slice upper index", ValidLow: "3", ValidHigh: "4", Actual: "2"}),
-		Args(li4, "-1..-2").Rets(nil,
+		tt.Args(li4, "-1..-2").Rets(nil,
 			errs.OutOfRange{What: "negative slice upper index",
 				ValidLow: "-1", ValidHigh: "-1", Actual: "-2"}),
 
 		// Malformed list indices.
-		Args(li4, "a").Rets(Any, errIndexMustBeInteger),
+		tt.Args(li4, "a").Rets(tt.Any, errIndexMustBeInteger),
 		// TODO(xiaq): Make the error more accurate.
-		Args(li4, "1:3:2").Rets(Any, errIndexMustBeInteger),
+		tt.Args(li4, "1:3:2").Rets(tt.Any, errIndexMustBeInteger),
 
 		// Map indices
 		// ============
 
-		Args(m, "foo").Rets("bar", nil),
-		Args(m, "bad").Rets(Any, NoSuchKey("bad")),
+		tt.Args(m, "foo").Rets("bar", nil),
+		tt.Args(m, "bad").Rets(tt.Any, NoSuchKey("bad")),
 
 		// Not indexable
-		Args(1, "foo").Rets(nil, errNotIndexable),
+		tt.Args(1, "foo").Rets(nil, errNotIndexable),
 	})
 }
 
@@ -130,9 +130,9 @@ func TestIndex_File(t *testing.T) {
 		t.Skip("create file:", err)
 	}
 
-	Test(t, Fn("Index", Index), Table{
-		Args(f, "fd").Rets(int(f.Fd()), nil),
-		Args(f, "name").Rets(f.Name(), nil),
-		Args(f, "x").Rets(nil, NoSuchKey("x")),
+	tt.Test(t, tt.Fn("Index", Index), tt.Table{
+		tt.Args(f, "fd").Rets(int(f.Fd()), nil),
+		tt.Args(f, "name").Rets(f.Name(), nil),
+		tt.Args(f, "x").Rets(nil, NoSuchKey("x")),
 	})
 }

--- a/pkg/eval/vals/iterate_keys_test.go
+++ b/pkg/eval/vals/iterate_keys_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func vs(xs ...any) []any { return xs }
@@ -17,11 +17,11 @@ func (k keysIterator) IterateKeys(f func(any) bool) {
 type nonKeysIterator struct{}
 
 func TestIterateKeys(t *testing.T) {
-	Test(t, Fn("collectKeys", collectKeys), Table{
-		Args(MakeMap("k1", "v1", "k2", "v2")).Rets(vs("k1", "k2"), nil),
-		Args(keysIterator{vs("lorem", "ipsum")}).Rets(vs("lorem", "ipsum")),
-		Args(nonKeysIterator{}).Rets(
-			Any, cannotIterateKeysOf{"!!vals.nonKeysIterator"}),
+	tt.Test(t, tt.Fn("collectKeys", collectKeys), tt.Table{
+		tt.Args(MakeMap("k1", "v1", "k2", "v2")).Rets(vs("k1", "k2"), nil),
+		tt.Args(keysIterator{vs("lorem", "ipsum")}).Rets(vs("lorem", "ipsum")),
+		tt.Args(nonKeysIterator{}).Rets(
+			tt.Any, cannotIterateKeysOf{"!!vals.nonKeysIterator"}),
 	})
 }
 

--- a/pkg/eval/vals/iterate_test.go
+++ b/pkg/eval/vals/iterate_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // An implementation of Iterator.
@@ -17,20 +17,20 @@ func (i iterator) Iterate(f func(any) bool) {
 type nonIterator struct{}
 
 func TestCanIterate(t *testing.T) {
-	Test(t, Fn("CanIterate", CanIterate), Table{
-		Args("foo").Rets(true),
-		Args(MakeList("foo", "bar")).Rets(true),
-		Args(iterator{vs("a", "b")}).Rets(true),
-		Args(nonIterator{}).Rets(false),
+	tt.Test(t, tt.Fn("CanIterate", CanIterate), tt.Table{
+		tt.Args("foo").Rets(true),
+		tt.Args(MakeList("foo", "bar")).Rets(true),
+		tt.Args(iterator{vs("a", "b")}).Rets(true),
+		tt.Args(nonIterator{}).Rets(false),
 	})
 }
 
 func TestCollect(t *testing.T) {
-	Test(t, Fn("Collect", Collect), Table{
-		Args("foo").Rets(vs("f", "o", "o"), nil),
-		Args(MakeList("foo", "bar")).Rets(vs("foo", "bar"), nil),
-		Args(iterator{vs("a", "b")}).Rets(vs("a", "b"), nil),
-		Args(nonIterator{}).Rets(vs(), cannotIterate{"!!vals.nonIterator"}),
+	tt.Test(t, tt.Fn("Collect", Collect), tt.Table{
+		tt.Args("foo").Rets(vs("f", "o", "o"), nil),
+		tt.Args(MakeList("foo", "bar")).Rets(vs("foo", "bar"), nil),
+		tt.Args(iterator{vs("a", "b")}).Rets(vs("a", "b"), nil),
+		tt.Args(nonIterator{}).Rets(vs(), cannotIterate{"!!vals.nonIterator"}),
 	})
 }
 

--- a/pkg/eval/vals/kind_test.go
+++ b/pkg/eval/vals/kind_test.go
@@ -5,26 +5,24 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type xtype int
 
 func TestKind(t *testing.T) {
-	Test(t, Fn("Kind", Kind), Table{
-		Args(nil).Rets("nil"),
-		Args(true).Rets("bool"),
-		Args("").Rets("string"),
-		Args(1).Rets("number"),
-		Args(bigInt(z)).Rets("number"),
-		Args(big.NewRat(1, 2)).Rets("number"),
-		Args(1.0).Rets("number"),
-		Args(os.Stdin).Rets("file"),
-		Args(EmptyList).Rets("list"),
-		Args(EmptyMap).Rets("map"),
-
-		Args(xtype(0)).Rets("!!vals.xtype"),
-
-		Args(os.Stdin).Rets("file"),
+	tt.Test(t, tt.Fn("Kind", Kind), tt.Table{
+		tt.Args(nil).Rets("nil"),
+		tt.Args(true).Rets("bool"),
+		tt.Args("").Rets("string"),
+		tt.Args(1).Rets("number"),
+		tt.Args(bigInt(z)).Rets("number"),
+		tt.Args(big.NewRat(1, 2)).Rets("number"),
+		tt.Args(1.0).Rets("number"),
+		tt.Args(os.Stdin).Rets("file"),
+		tt.Args(EmptyList).Rets("list"),
+		tt.Args(EmptyMap).Rets("map"),
+		tt.Args(xtype(0)).Rets("!!vals.xtype"),
+		tt.Args(os.Stdin).Rets("file"),
 	})
 }

--- a/pkg/eval/vals/len_test.go
+++ b/pkg/eval/vals/len_test.go
@@ -3,12 +3,12 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestLen(t *testing.T) {
-	Test(t, Fn("Len", Len), Table{
-		Args("foobar").Rets(6),
-		Args(10).Rets(-1),
+	tt.Test(t, tt.Fn("Len", Len), tt.Table{
+		tt.Args("foobar").Rets(6),
+		tt.Args(10).Rets(-1),
 	})
 }

--- a/pkg/eval/vals/num_test.go
+++ b/pkg/eval/vals/num_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // Test utilities.
@@ -25,71 +25,70 @@ const (
 )
 
 func TestParseNum(t *testing.T) {
-	Test(t, Fn("ParseNum", ParseNum), Table{
-		Args("1").Rets(1),
+	tt.Test(t, tt.Fn("ParseNum", ParseNum), tt.Table{
+		tt.Args("1").Rets(1),
 
-		Args(z).Rets(bigInt(z)),
+		tt.Args(z).Rets(bigInt(z)),
 
-		Args("1/2").Rets(big.NewRat(1, 2)),
-		Args("2/1").Rets(2),
-		Args(z + "/1").Rets(bigInt(z)),
+		tt.Args("1/2").Rets(big.NewRat(1, 2)),
+		tt.Args("2/1").Rets(2),
+		tt.Args(z + "/1").Rets(bigInt(z)),
 
-		Args("1.0").Rets(1.0),
-		Args("1e-5").Rets(1e-5),
+		tt.Args("1.0").Rets(1.0),
+		tt.Args("1e-5").Rets(1e-5),
 
-		Args("x").Rets(nil),
-		Args("x/y").Rets(nil),
+		tt.Args("x").Rets(nil),
+		tt.Args("x/y").Rets(nil),
 	})
 }
 
 func TestUnifyNums(t *testing.T) {
-	Test(t, Fn("UnifyNums", UnifyNums), Table{
-		Args([]Num{1, 2, 3, 4}, Int).
+	tt.Test(t, tt.Fn("UnifyNums", UnifyNums), tt.Table{
+		tt.Args([]Num{1, 2, 3, 4}, Int).
 			Rets([]int{1, 2, 3, 4}),
 
-		Args([]Num{1, 2, 3, bigInt(z)}, Int).
+		tt.Args([]Num{1, 2, 3, bigInt(z)}, Int).
 			Rets([]*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3), bigInt(z)}),
 
-		Args([]Num{1, 2, 3, big.NewRat(1, 2)}, Int).
+		tt.Args([]Num{1, 2, 3, big.NewRat(1, 2)}, Int).
 			Rets([]*big.Rat{
 				big.NewRat(1, 1), big.NewRat(2, 1),
 				big.NewRat(3, 1), big.NewRat(1, 2)}),
-		Args([]Num{1, 2, bigInt(z), big.NewRat(1, 2)}, Int).
+		tt.Args([]Num{1, 2, bigInt(z), big.NewRat(1, 2)}, Int).
 			Rets([]*big.Rat{
 				big.NewRat(1, 1), big.NewRat(2, 1), bigRat(z), big.NewRat(1, 2)}),
 
-		Args([]Num{1, 2, 3, 4.0}, Int).
+		tt.Args([]Num{1, 2, 3, 4.0}, Int).
 			Rets([]float64{1, 2, 3, 4}),
-		Args([]Num{1, 2, big.NewRat(1, 2), 4.0}, Int).
+		tt.Args([]Num{1, 2, big.NewRat(1, 2), 4.0}, Int).
 			Rets([]float64{1, 2, 0.5, 4}),
-		Args([]Num{1, 2, big.NewInt(3), 4.0}, Int).
+		tt.Args([]Num{1, 2, big.NewInt(3), 4.0}, Int).
 			Rets([]float64{1, 2, 3, 4}),
-		Args([]Num{1, 2, bigInt(z), 4.0}, Int).
+		tt.Args([]Num{1, 2, bigInt(z), 4.0}, Int).
 			Rets([]float64{1, 2, math.Inf(1), 4}),
 
-		Args([]Num{1, 2, 3, 4}, BigInt).
+		tt.Args([]Num{1, 2, 3, 4}, BigInt).
 			Rets([]*big.Int{
 				big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)}),
 	})
 }
 
 func TestUnifyNums2(t *testing.T) {
-	Test(t, Fn("UnifyNums2", UnifyNums2), Table{
-		Args(1, 2, Int).Rets(1, 2),
-		Args(1, bigInt(z), Int).Rets(big.NewInt(1), bigInt(z)),
-		Args(1, big.NewRat(1, 2), Int).Rets(big.NewRat(1, 1), big.NewRat(1, 2)),
-		Args(1, 2.0, Int).Rets(1.0, 2.0),
-
-		Args(1, 2, BigInt).Rets(big.NewInt(1), big.NewInt(2)),
+	tt.Test(t, tt.Fn("UnifyNums2", UnifyNums2), tt.Table{
+		tt.Args(1, 2, Int).Rets(1, 2),
+		tt.Args(1, bigInt(z), Int).Rets(big.NewInt(1), bigInt(z)),
+		tt.Args(1, big.NewRat(1, 2), Int).Rets(big.NewRat(1, 1), big.NewRat(1, 2)),
+		tt.Args(1, 2.0, Int).Rets(1.0, 2.0),
+		tt.Args(1, 2, BigInt).Rets(big.NewInt(1), big.NewInt(2)),
 	})
 }
 
 func TestInvalidNumType(t *testing.T) {
-	Test(t, Fn("Recover", testutil.Recover), Table{
-		Args(func() { UnifyNums([]Num{int32(0)}, 0) }).Rets("invalid num type int32"),
-		Args(func() { PromoteToBigInt(int32(0)) }).Rets("invalid num type int32"),
-		Args(func() { PromoteToBigRat(int32(0)) }).Rets("invalid num type int32"),
-		Args(func() { ConvertToFloat64(int32(0)) }).Rets("invalid num type int32"),
+	tt.Test(t, tt.Fn("Recover", testutil.Recover), tt.Table{
+		tt.Args(func() { UnifyNums([]Num{int32(0)}, 0) }).Rets("invalid num type int32"),
+		tt.Args(func() { PromoteToBigInt(int32(0)) }).Rets("invalid num type int32"),
+		tt.Args(func() { PromoteToBigRat(int32(0)) }).Rets("invalid num type int32"),
+		tt.Args(func() { ConvertToFloat64(int32(0)) }).Rets("invalid num type int32"),
 	})
 }
 

--- a/pkg/eval/vals/repr_test.go
+++ b/pkg/eval/vals/repr_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type reprer struct{}
@@ -16,30 +16,30 @@ func (reprer) Repr(int) string { return "<reprer>" }
 type nonReprer struct{}
 
 func TestReprPlain(t *testing.T) {
-	Test(t, Fn("ReprPlain", ReprPlain), Table{
-		Args(nil).Rets("$nil"),
+	tt.Test(t, tt.Fn("ReprPlain", ReprPlain), tt.Table{
+		tt.Args(nil).Rets("$nil"),
 
-		Args(false).Rets("$false"),
-		Args(true).Rets("$true"),
+		tt.Args(false).Rets("$false"),
+		tt.Args(true).Rets("$true"),
 
-		Args("foo").Rets("foo"),
+		tt.Args("foo").Rets("foo"),
 
-		Args(1).Rets("(num 1)"),
-		Args(bigInt(z)).Rets("(num " + z + ")"),
-		Args(big.NewRat(1, 2)).Rets("(num 1/2)"),
-		Args(1.0).Rets("(num 1.0)"),
-		Args(1e10).Rets("(num 10000000000.0)"),
+		tt.Args(1).Rets("(num 1)"),
+		tt.Args(bigInt(z)).Rets("(num " + z + ")"),
+		tt.Args(big.NewRat(1, 2)).Rets("(num 1/2)"),
+		tt.Args(1.0).Rets("(num 1.0)"),
+		tt.Args(1e10).Rets("(num 10000000000.0)"),
 
-		Args(os.Stdin).Rets(
+		tt.Args(os.Stdin).Rets(
 			fmt.Sprintf("<file{%s %d}>", os.Stdin.Name(), os.Stdin.Fd())),
 
-		Args(EmptyList).Rets("[]"),
-		Args(MakeList("foo", "bar")).Rets("[foo bar]"),
+		tt.Args(EmptyList).Rets("[]"),
+		tt.Args(MakeList("foo", "bar")).Rets("[foo bar]"),
 
-		Args(EmptyMap).Rets("[&]"),
-		Args(MakeMap("foo", "bar")).Rets("[&foo=bar]"),
+		tt.Args(EmptyMap).Rets("[&]"),
+		tt.Args(MakeMap("foo", "bar")).Rets("[&foo=bar]"),
 
-		Args(reprer{}).Rets("<reprer>"),
-		Args(nonReprer{}).Rets("<unknown {}>"),
+		tt.Args(reprer{}).Rets("<reprer>"),
+		tt.Args(nonReprer{}).Rets("<unknown {}>"),
 	})
 }

--- a/pkg/eval/vals/string_test.go
+++ b/pkg/eval/vals/string_test.go
@@ -4,32 +4,32 @@ import (
 	"bytes"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestToString(t *testing.T) {
-	Test(t, Fn("ToString", ToString), Table{
+	tt.Test(t, tt.Fn("ToString", ToString), tt.Table{
 		// string
-		Args("a").Rets("a"),
+		tt.Args("a").Rets("a"),
 
-		Args(1).Rets("1"),
+		tt.Args(1).Rets("1"),
 
 		// float64
-		Args(0.1).Rets("0.1"),
-		Args(42.0).Rets("42.0"),
+		tt.Args(0.1).Rets("0.1"),
+		tt.Args(42.0).Rets("42.0"),
 		// Whole numbers with more than 14 digits and trailing 0 are printed in
 		// scientific notation.
-		Args(1e13).Rets("10000000000000.0"),
-		Args(1e14).Rets("1e+14"),
-		Args(1e14 + 1).Rets("100000000000001.0"),
+		tt.Args(1e13).Rets("10000000000000.0"),
+		tt.Args(1e14).Rets("1e+14"),
+		tt.Args(1e14 + 1).Rets("100000000000001.0"),
 		// Numbers smaller than 0.0001 are printed in scientific notation.
-		Args(0.0001).Rets("0.0001"),
-		Args(0.00001).Rets("1e-05"),
-		Args(0.00009).Rets("9e-05"),
+		tt.Args(0.0001).Rets("0.0001"),
+		tt.Args(0.00001).Rets("1e-05"),
+		tt.Args(0.00009).Rets("9e-05"),
 
 		// Stringer
-		Args(bytes.NewBufferString("buffer")).Rets("buffer"),
+		tt.Args(bytes.NewBufferString("buffer")).Rets("buffer"),
 		// None of the above: delegate to Repr
-		Args(true).Rets("$true"),
+		tt.Args(true).Rets("$true"),
 	})
 }

--- a/pkg/eval/vals/testutils_test.go
+++ b/pkg/eval/vals/testutils_test.go
@@ -1,6 +1,8 @@
 package vals
 
-import "src.elv.sh/pkg/tt"
+import (
+	"src.elv.sh/pkg/tt"
+)
 
 // Returns a tt.Matcher that matches using the Equal function.
 func eq(r any) tt.Matcher { return equalMatcher{r} }

--- a/pkg/eval/var_parse_test.go
+++ b/pkg/eval/var_parse_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 
 	"src.elv.sh/pkg/tt"
 )
@@ -11,7 +11,7 @@ import (
 var Args = tt.Args
 
 func TestSplitSigil(t *testing.T) {
-	tt.Test(t, tt.Fn("SplitSigil", SplitSigil), tt.Table{
+	tt.Test(t, tt.Fn("SplitSigil", eval.SplitSigil), tt.Table{
 		Args("").Rets("", ""),
 		Args("x").Rets("", "x"),
 		Args("@x").Rets("@", "x"),
@@ -21,7 +21,7 @@ func TestSplitSigil(t *testing.T) {
 }
 
 func TestSplitQName(t *testing.T) {
-	tt.Test(t, tt.Fn("SplitQName", SplitQName), tt.Table{
+	tt.Test(t, tt.Fn("SplitQName", eval.SplitQName), tt.Table{
 		Args("").Rets("", ""),
 		Args("a").Rets("a", ""),
 		Args("a:").Rets("a:", ""),
@@ -33,7 +33,7 @@ func TestSplitQName(t *testing.T) {
 }
 
 func TestSplitQNameSegs(t *testing.T) {
-	tt.Test(t, tt.Fn("SplitQNameSegs", SplitQNameSegs), tt.Table{
+	tt.Test(t, tt.Fn("SplitQNameSegs", eval.SplitQNameSegs), tt.Table{
 		Args("").Rets([]string{}),
 		Args("a").Rets([]string{"a"}),
 		Args("a:").Rets([]string{"a:"}),
@@ -45,7 +45,7 @@ func TestSplitQNameSegs(t *testing.T) {
 }
 
 func TestSplitIncompleteQNameNs(t *testing.T) {
-	tt.Test(t, tt.Fn("SplitIncompleteQNameNs", SplitIncompleteQNameNs), tt.Table{
+	tt.Test(t, tt.Fn("SplitIncompleteQNameNs", eval.SplitIncompleteQNameNs), tt.Table{
 		Args("").Rets("", ""),
 		Args("a").Rets("", "a"),
 		Args("a:").Rets("a:", ""),

--- a/pkg/fsutil/claim_test.go
+++ b/pkg/fsutil/claim_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 var claimFileTests = []struct {
@@ -20,13 +20,13 @@ var claimFileTests = []struct {
 }
 
 func TestClaimFile(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
-	ApplyDir(Dir{
+	testutil.ApplyDir(testutil.Dir{
 		"a0.log": "",
 		"a1.log": "",
 		"a8.log": "",
-		"d":      Dir{}})
+		"d":      testutil.Dir{}})
 
 	for _, test := range claimFileTests {
 		name := claimFileAndGetName(test.dir, test.pattern)
@@ -37,7 +37,7 @@ func TestClaimFile(t *testing.T) {
 }
 
 func TestClaimFile_Concurrent(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
 	n := 9
 	ch := make(chan string, n)

--- a/pkg/parse/error_test.go
+++ b/pkg/parse/error_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/diag"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestGetError(t *testing.T) {
 	parseError := makeError()
-	Test(t, Fn("GetError", GetError), Table{
-		Args(parseError).Rets(parseError),
-		Args(errors.New("random error")).Rets((*Error)(nil)),
+	tt.Test(t, tt.Fn("GetError", GetError), tt.Table{
+		tt.Args(parseError).Rets(parseError),
+		tt.Args(errors.New("random error")).Rets((*Error)(nil)),
 	})
 }
 

--- a/pkg/parse/quote_test.go
+++ b/pkg/parse/quote_test.go
@@ -3,59 +3,59 @@ package parse
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestQuote(t *testing.T) {
-	Test(t, Fn("Quote", Quote).ArgsFmt("(%q)"), Table{
+	tt.Test(t, tt.Fn("Quote", Quote).ArgsFmt("(%q)"), tt.Table{
 		// Empty string is single-quoted.
-		Args("").Rets(`''`),
+		tt.Args("").Rets(`''`),
 
 		// Bareword when possible.
-		Args("x-y:z@h/d").Rets("x-y:z@h/d"),
+		tt.Args("x-y:z@h/d").Rets("x-y:z@h/d"),
 
 		// Single quote when there are special characters but no unprintable
 		// characters.
-		Args("x$y[]ef'").Rets("'x$y[]ef'''"),
+		tt.Args("x$y[]ef'").Rets("'x$y[]ef'''"),
 
 		// Tilde needs quoting only leading the expression.
-		Args("~x").Rets("'~x'"),
-		Args("x~").Rets("x~"),
+		tt.Args("~x").Rets("'~x'"),
+		tt.Args("x~").Rets("x~"),
 
 		// Double quote when there is unprintable char.
-		Args("a\nb").Rets(`"a\nb"`),
-		Args("\x1b\"\\").Rets(`"\e\"\\"`),
-		Args("\x00").Rets(`"\x00"`),
-		Args("\u0600").Rets(`"\u0600"`),         // Arabic number sign
-		Args("\U000110BD").Rets(`"\U000110bd"`), // Kathi number sign
+		tt.Args("a\nb").Rets(`"a\nb"`),
+		tt.Args("\x1b\"\\").Rets(`"\e\"\\"`),
+		tt.Args("\x00").Rets(`"\x00"`),
+		tt.Args("\u0600").Rets(`"\u0600"`),         // Arabic number sign
+		tt.Args("\U000110BD").Rets(`"\U000110bd"`), // Kathi number sign
 
 		// Commas and equal signs are always quoted, so that the quoted string is
 		// safe for use everywhere.
-		Args("a,b").Rets(`'a,b'`),
-		Args("a=b").Rets(`'a=b'`),
+		tt.Args("a,b").Rets(`'a,b'`),
+		tt.Args("a=b").Rets(`'a=b'`),
 	})
 }
 
 func TestQuoteAs(t *testing.T) {
-	Test(t, Fn("QuoteAs", QuoteAs).ArgsFmt("(%q, %s)"), Table{
+	tt.Test(t, tt.Fn("QuoteAs", QuoteAs).ArgsFmt("(%q, %s)"), tt.Table{
 		// DoubleQuote is always respected.
-		Args("", DoubleQuoted).Rets(`""`, DoubleQuoted),
-		Args("a", DoubleQuoted).Rets(`"a"`, DoubleQuoted),
+		tt.Args("", DoubleQuoted).Rets(`""`, DoubleQuoted),
+		tt.Args("a", DoubleQuoted).Rets(`"a"`, DoubleQuoted),
 
 		// SingleQuoted is respected when there is no unprintable character.
-		Args("", SingleQuoted).Rets(`''`, SingleQuoted),
-		Args("a", SingleQuoted).Rets(`'a'`, SingleQuoted),
-		Args("\n", SingleQuoted).Rets(`"\n"`, DoubleQuoted),
+		tt.Args("", SingleQuoted).Rets(`''`, SingleQuoted),
+		tt.Args("a", SingleQuoted).Rets(`'a'`, SingleQuoted),
+		tt.Args("\n", SingleQuoted).Rets(`"\n"`, DoubleQuoted),
 
 		// Bareword tested above in TestQuote.
 	})
 }
 
 func TestQuoteVariableName(t *testing.T) {
-	Test(t, Fn("QuoteVariableName", QuoteVariableName).ArgsFmt("(%q)"), Table{
-		Args("").Rets("''"),
-		Args("foo").Rets("foo"),
-		Args("a/b").Rets("'a/b'"),
-		Args("\x1b").Rets(`"\e"`),
+	tt.Test(t, tt.Fn("QuoteVariableName", QuoteVariableName).ArgsFmt("(%q)"), tt.Table{
+		tt.Args("").Rets("''"),
+		tt.Args("foo").Rets("foo"),
+		tt.Args("a/b").Rets("'a/b'"),
+		tt.Args("\x1b").Rets(`"\e"`),
 	})
 }

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/vals"
-	. "src.elv.sh/pkg/parse"
+	"src.elv.sh/pkg/parse"
 )
 
 func TestSourceAsStructMap(t *testing.T) {
-	vals.TestValue(t, Source{Name: "[tty]", Code: "echo"}).
+	vals.TestValue(t, parse.Source{Name: "[tty]", Code: "echo"}).
 		Kind("structmap").
 		Repr("[&name='[tty]' &code=<...> &is-file=$false]").
 		AllKeys("name", "code", "is-file")
 
-	vals.TestValue(t, Source{Name: "/etc/rc.elv", Code: "echo", IsFile: true}).
+	vals.TestValue(t, parse.Source{Name: "/etc/rc.elv", Code: "echo", IsFile: true}).
 		Index("is-file", true)
 }

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/pprof"
+	"src.elv.sh/pkg/pprof"
 	"src.elv.sh/pkg/prog"
 	"src.elv.sh/pkg/prog/progtest"
 	"src.elv.sh/pkg/testutil"
@@ -18,7 +18,7 @@ var (
 func TestProgram(t *testing.T) {
 	testutil.InTempDir(t)
 
-	Test(t, prog.Composite(&Program{}, noopProgram{}),
+	Test(t, prog.Composite(&pprof.Program{}, noopProgram{}),
 		ThatElvish("-cpuprofile", "cpuprof").DoesNothing(),
 		ThatElvish("-cpuprofile", "/a/bad/path").
 			WritesStderrContaining("Warning: cannot create CPU profile:"),

--- a/pkg/prog/prog_test.go
+++ b/pkg/prog/prog_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/prog"
+	"src.elv.sh/pkg/prog"
 	"src.elv.sh/pkg/prog/progtest"
 	"src.elv.sh/pkg/testutil"
 )
@@ -56,7 +56,7 @@ func TestSharedFlags(t *testing.T) {
 
 func TestSharedFlags_MultiplePrograms(t *testing.T) {
 	Test(t,
-		Composite(
+		prog.Composite(
 			&testProgram{sharedFlags: true, nextProgram: true},
 			&testProgram{sharedFlags: true}),
 		ThatElvish("-sock", "sock", "-db", "db", "-json").
@@ -71,8 +71,8 @@ func TestShowDeprecations(t *testing.T) {
 		ThatElvish("-deprecation-level", "42").DoesNothing(),
 	)
 
-	if DeprecationLevel != 42 {
-		t.Errorf("ShowDeprecations = %d, want 42", DeprecationLevel)
+	if prog.DeprecationLevel != 42 {
+		t.Errorf("ShowDeprecations = %d, want 42", prog.DeprecationLevel)
 	}
 }
 
@@ -86,14 +86,14 @@ func TestNoSuitableSubprogram(t *testing.T) {
 
 func TestComposite(t *testing.T) {
 	Test(t,
-		Composite(&testProgram{nextProgram: true}, &testProgram{writeOut: "program 2"}),
+		prog.Composite(&testProgram{nextProgram: true}, &testProgram{writeOut: "program 2"}),
 		ThatElvish().WritesStdout("program 2"),
 	)
 }
 
 func TestComposite_NoSuitableSubprogram(t *testing.T) {
 	Test(t,
-		Composite(&testProgram{nextProgram: true}, &testProgram{nextProgram: true}),
+		prog.Composite(&testProgram{nextProgram: true}, &testProgram{nextProgram: true}),
 		ThatElvish().
 			ExitsWith(2).
 			WritesStderr("internal error: no suitable subprogram\n"),
@@ -102,7 +102,7 @@ func TestComposite_NoSuitableSubprogram(t *testing.T) {
 
 func TestComposite_PreferEarlierSubprogram(t *testing.T) {
 	Test(t,
-		Composite(
+		prog.Composite(
 			&testProgram{writeOut: "program 1"}, &testProgram{writeOut: "program 2"}),
 		ThatElvish().WritesStdout("program 1"),
 	)
@@ -110,19 +110,19 @@ func TestComposite_PreferEarlierSubprogram(t *testing.T) {
 
 func TestBadUsageError(t *testing.T) {
 	Test(t,
-		&testProgram{returnErr: BadUsage("lorem ipsum")},
+		&testProgram{returnErr: prog.BadUsage("lorem ipsum")},
 		ThatElvish().ExitsWith(2).WritesStderrContaining("lorem ipsum\n"),
 	)
 }
 
 func TestExitError(t *testing.T) {
-	Test(t, &testProgram{returnErr: Exit(3)},
+	Test(t, &testProgram{returnErr: prog.Exit(3)},
 		ThatElvish().ExitsWith(3),
 	)
 }
 
 func TestExitError_0(t *testing.T) {
-	Test(t, &testProgram{returnErr: Exit(0)},
+	Test(t, &testProgram{returnErr: prog.Exit(0)},
 		ThatElvish().ExitsWith(0),
 	)
 }
@@ -135,11 +135,11 @@ type testProgram struct {
 	sharedFlags bool
 
 	flag        string
-	daemonPaths *DaemonPaths
+	daemonPaths *prog.DaemonPaths
 	json        *bool
 }
 
-func (p *testProgram) RegisterFlags(f *FlagSet) {
+func (p *testProgram) RegisterFlags(f *prog.FlagSet) {
 	if p.customFlag {
 		f.StringVar(&p.flag, "flag", "default", "a flag")
 	}
@@ -151,7 +151,7 @@ func (p *testProgram) RegisterFlags(f *FlagSet) {
 
 func (p *testProgram) Run(fds [3]*os.File, args []string) error {
 	if p.nextProgram {
-		return ErrNextProgram
+		return prog.ErrNextProgram
 	}
 	fds[1].WriteString(p.writeOut)
 	if p.customFlag {

--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestInteract(t *testing.T) {
 	setupHomePaths(t)
-	InTempDir(t)
-	MustWriteFile("rc.elv", "echo hello from rc.elv")
-	MustWriteFile("rc-dnc.elv", "echo $a")
-	MustWriteFile("rc-fail.elv", "fail bad")
+	testutil.InTempDir(t)
+	testutil.MustWriteFile("rc.elv", "echo hello from rc.elv")
+	testutil.MustWriteFile("rc-dnc.elv", "echo $a")
+	testutil.MustWriteFile("rc-fail.elv", "fail bad")
 
 	Test(t, &Program{},
 		thatElvishInteract().WithStdin("echo hello\n").WritesStdout("hello\n"),
@@ -33,7 +33,7 @@ func TestInteract(t *testing.T) {
 func TestInteract_DefaultRCPath(t *testing.T) {
 	home := setupHomePaths(t)
 	// Legacy RC path
-	MustWriteFile(
+	testutil.MustWriteFile(
 		filepath.Join(home, ".elvish", "rc.elv"), "echo hello legacy rc.elv")
 	// Note: non-legacy path is tested in interact_unix_test.go
 

--- a/pkg/shell/interact_unix_test.go
+++ b/pkg/shell/interact_unix_test.go
@@ -13,12 +13,12 @@ import (
 	"src.elv.sh/pkg/env"
 
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestInteract_NewRcFile_Default(t *testing.T) {
 	home := setupHomePaths(t)
-	MustWriteFile(
+	testutil.MustWriteFile(
 		filepath.Join(home, ".config", "elvish", "rc.elv"), "echo hello new rc.elv")
 
 	Test(t, &Program{},
@@ -28,8 +28,8 @@ func TestInteract_NewRcFile_Default(t *testing.T) {
 
 func TestInteract_NewRcFile_XDG_CONFIG_HOME(t *testing.T) {
 	setupHomePaths(t)
-	xdgConfigHome := Setenv(t, env.XDG_CONFIG_HOME, TempDir(t))
-	MustWriteFile(
+	xdgConfigHome := testutil.Setenv(t, env.XDG_CONFIG_HOME, testutil.TempDir(t))
+	testutil.MustWriteFile(
 		filepath.Join(xdgConfigHome, "elvish", "rc.elv"),
 		"echo hello XDG_CONFIG_HOME rc.elv")
 
@@ -39,14 +39,14 @@ func TestInteract_NewRcFile_XDG_CONFIG_HOME(t *testing.T) {
 }
 
 func TestInteract_ConnectsToDaemon(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
 	// Run the daemon in the same process for simplicity.
 	daemonDone := make(chan struct{})
 	defer func() {
 		select {
 		case <-daemonDone:
-		case <-time.After(Scaled(2 * time.Second)):
+		case <-time.After(testutil.Scaled(2 * time.Second)):
 			t.Errorf("timed out waiting for daemon to quit")
 		}
 	}()
@@ -58,7 +58,7 @@ func TestInteract_ConnectsToDaemon(t *testing.T) {
 	select {
 	case <-readyCh:
 		// Do nothing
-	case <-time.After(Scaled(2 * time.Second)):
+	case <-time.After(testutil.Scaled(2 * time.Second)):
 		t.Fatalf("timed out waiting for daemon to start")
 	}
 

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -7,12 +7,12 @@ import (
 
 	"src.elv.sh/pkg/env"
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestShell_LegacyLibPath(t *testing.T) {
 	home := setupHomePaths(t)
-	MustWriteFile(filepath.Join(home, ".elvish", "lib", "a.elv"), "echo mod a")
+	testutil.MustWriteFile(filepath.Join(home, ".elvish", "lib", "a.elv"), "echo mod a")
 
 	Test(t, &Program{},
 		ThatElvish("-c", "use a").WritesStdout("mod a\n"),
@@ -45,7 +45,7 @@ var incSHLVLTests = []struct {
 }
 
 func TestIncSHLVL(t *testing.T) {
-	Setenv(t, env.SHLVL, "")
+	testutil.Setenv(t, env.SHLVL, "")
 
 	for _, test := range incSHLVLTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -79,8 +79,8 @@ func TestIncSHLVL(t *testing.T) {
 
 // Common test utilities.
 
-func setupHomePaths(t Cleanuper) string {
-	Unsetenv(t, env.XDG_CONFIG_HOME)
-	Unsetenv(t, env.XDG_DATA_HOME)
-	return TempHome(t)
+func setupHomePaths(t testutil.Cleanuper) string {
+	testutil.Unsetenv(t, env.XDG_CONFIG_HOME)
+	testutil.Unsetenv(t, env.XDG_DATA_HOME)
+	return testutil.TempHome(t)
 }

--- a/pkg/store/db_store.go
+++ b/pkg/store/db_store.go
@@ -7,7 +7,7 @@ import (
 
 	bolt "go.etcd.io/bbolt"
 	"src.elv.sh/pkg/logutil"
-	. "src.elv.sh/pkg/store/storedefs"
+	"src.elv.sh/pkg/store/storedefs"
 )
 
 var logger = logutil.GetLogger("[store] ")
@@ -20,7 +20,7 @@ var initDB = map[string](func(*bolt.Tx) error){}
 // wg.Add(1) in the main goroutine before spawning another goroutine, and
 // call wg.Done() in the spawned goroutine after the operation is finished.
 type DBStore interface {
-	Store
+	storedefs.Store
 	Close() error
 }
 

--- a/pkg/store/dir.go
+++ b/pkg/store/dir.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	bolt "go.etcd.io/bbolt"
-	. "src.elv.sh/pkg/store/storedefs"
+	"src.elv.sh/pkg/store/storedefs"
 )
 
 // Parameters for directory history scores.
@@ -70,8 +70,8 @@ func (s *dbStore) DelDir(d string) error {
 
 // Dirs lists all directories in the directory history whose names are not
 // in the blacklist. The results are ordered by scores in descending order.
-func (s *dbStore) Dirs(blacklist map[string]struct{}) ([]Dir, error) {
-	var dirs []Dir
+func (s *dbStore) Dirs(blacklist map[string]struct{}) ([]storedefs.Dir, error) {
+	var dirs []storedefs.Dir
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketDir))
@@ -81,7 +81,7 @@ func (s *dbStore) Dirs(blacklist map[string]struct{}) ([]Dir, error) {
 			if _, ok := blacklist[d]; ok {
 				continue
 			}
-			dirs = append(dirs, Dir{
+			dirs = append(dirs, storedefs.Dir{
 				Path:  d,
 				Score: unmarshalScore(v),
 			})
@@ -92,7 +92,7 @@ func (s *dbStore) Dirs(blacklist map[string]struct{}) ([]Dir, error) {
 	return dirs, err
 }
 
-type dirList []Dir
+type dirList []storedefs.Dir
 
 func (dl dirList) Len() int {
 	return len(dl)

--- a/pkg/strutil/camel_to_dashed_test.go
+++ b/pkg/strutil/camel_to_dashed_test.go
@@ -3,14 +3,14 @@ package strutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestCamelToDashed(t *testing.T) {
-	Test(t, Fn("CamelToDashed", CamelToDashed), Table{
-		Args("CamelCase").Rets("camel-case"),
-		Args("camelCase").Rets("-camel-case"),
-		Args("HTTP").Rets("http"),
-		Args("HTTPRequest").Rets("http-request"),
+	tt.Test(t, tt.Fn("CamelToDashed", CamelToDashed), tt.Table{
+		tt.Args("CamelCase").Rets("camel-case"),
+		tt.Args("camelCase").Rets("-camel-case"),
+		tt.Args("HTTP").Rets("http"),
+		tt.Args("HTTPRequest").Rets("http-request"),
 	})
 }

--- a/pkg/strutil/chop_test.go
+++ b/pkg/strutil/chop_test.go
@@ -3,28 +3,28 @@ package strutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestChopLineEnding(t *testing.T) {
-	Test(t, Fn("ChopLineEnding", ChopLineEnding), Table{
-		Args("").Rets(""),
-		Args("text").Rets("text"),
-		Args("text\n").Rets("text"),
-		Args("text\r\n").Rets("text"),
+	tt.Test(t, tt.Fn("ChopLineEnding", ChopLineEnding), tt.Table{
+		tt.Args("").Rets(""),
+		tt.Args("text").Rets("text"),
+		tt.Args("text\n").Rets("text"),
+		tt.Args("text\r\n").Rets("text"),
 		// Only chop off one line ending
-		Args("text\n\n").Rets("text\n"),
+		tt.Args("text\n\n").Rets("text\n"),
 		// Preserve internal line endings
-		Args("text\ntext 2\n").Rets("text\ntext 2"),
+		tt.Args("text\ntext 2\n").Rets("text\ntext 2"),
 	})
 }
 
 func TestChopTerminator(t *testing.T) {
-	Test(t, Fn("ChopTerminator", ChopTerminator), Table{
-		Args("", byte('\x00')).Rets(""),
-		Args("foo", byte('\x00')).Rets("foo"),
-		Args("foo\x00", byte('\x00')).Rets("foo"),
-		Args("foo\x00\x00", byte('\x00')).Rets("foo\x00"),
-		Args("foo\x00bar\x00", byte('\x00')).Rets("foo\x00bar"),
+	tt.Test(t, tt.Fn("ChopTerminator", ChopTerminator), tt.Table{
+		tt.Args("", byte('\x00')).Rets(""),
+		tt.Args("foo", byte('\x00')).Rets("foo"),
+		tt.Args("foo\x00", byte('\x00')).Rets("foo"),
+		tt.Args("foo\x00\x00", byte('\x00')).Rets("foo\x00"),
+		tt.Args("foo\x00bar\x00", byte('\x00')).Rets("foo\x00bar"),
 	})
 }

--- a/pkg/testutil/recover_test.go
+++ b/pkg/testutil/recover_test.go
@@ -3,13 +3,13 @@ package testutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestRecover(t *testing.T) {
-	Test(t, Fn("Recover", Recover), Table{
-		Args(func() {}).Rets(nil),
-		Args(func() {
+	tt.Test(t, tt.Fn("Recover", Recover), tt.Table{
+		tt.Args(func() {}).Rets(nil),
+		tt.Args(func() {
 			panic("unreachable")
 		}).Rets("unreachable"),
 	})

--- a/pkg/ui/style_regions_test.go
+++ b/pkg/ui/style_regions_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/diag"
-	. "src.elv.sh/pkg/ui"
+	"src.elv.sh/pkg/ui"
 )
 
 var styleRegionsTests = []struct {
 	Name     string
 	String   string
-	Regions  []StylingRegion
-	WantText Text
+	Regions  []ui.StylingRegion
+	WantText ui.Text
 }{
 	{
 		Name:   "empty string and regions",
@@ -21,48 +21,48 @@ var styleRegionsTests = []struct {
 	{
 		Name:   "a single region",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("bar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("bar")),
 	},
 
 	{
 		Name:   "multiple continuous regions",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(3, 4), FgGreen, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(3, 4), ui.FgGreen, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("b", FgGreen), T("ar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("b", ui.FgGreen), ui.T("ar")),
 	},
 
 	{
 		Name:   "multiple discontinuous regions in wrong order",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(4, 5), FgGreen, 0},
-			{r(1, 3), FgRed, 0},
+		Regions: []ui.StylingRegion{
+			{r(4, 5), ui.FgGreen, 0},
+			{r(1, 3), ui.FgRed, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("b"), T("a", FgGreen), T("r")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("b"), ui.T("a", ui.FgGreen), ui.T("r")),
 	},
 	{
 		Name:   "regions with the same starting position but differeng priorities",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(1, 2), FgGreen, 1},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(1, 2), ui.FgGreen, 1},
 		},
-		WantText: Concat(T("f"), T("o", FgGreen), T("obar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("o", ui.FgGreen), ui.T("obar")),
 	},
 	{
 		Name:   "overlapping regions with different starting positions",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(2, 4), FgGreen, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(2, 4), ui.FgGreen, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("bar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("bar")),
 	},
 }
 
@@ -70,7 +70,7 @@ func r(a, b int) diag.Ranging { return diag.Ranging{From: a, To: b} }
 
 func TestStyleRegions(t *testing.T) {
 	for _, test := range styleRegionsTests {
-		text := StyleRegions(test.String, test.Regions)
+		text := ui.StyleRegions(test.String, test.Regions)
 		if !reflect.DeepEqual(text, test.WantText) {
 			t.Errorf("got %v, want %v", text, test.WantText)
 		}


### PR DESCRIPTION
TBD is what to do about packages `clitest`, `evaltest`, and `progtest`. All three have a small number of qualified imports and many more unqualified imports. My preference is to convert all of them to qualified imports with aliases `ct`, `et`, and `pt` respectively. But that may be a bridge too far.