### PR TITLE
Small doc fix for set-env

### DIFF
--- a/pkg/eval/builtin_fn_env.go
+++ b/pkg/eval/builtin_fn_env.go
@@ -34,7 +34,7 @@ var ErrNonExistentEnvVar = errors.New("non-existent environment variable")
 // Unset an environment variable. Example:
 //
 // ```elvish-transcript
-// ~> set E:X = foo
+// ~> set-env X foo
 // ~> unset-env X
 // ~> has-env X
 // ▶ $false


### PR DESCRIPTION
Replaces `set E:X = foo` with `set-env X foo` to be a bit more consistent with the others functions...