### PR TITLE
Correctly encode strings with invalid UTF-8

### DIFF
--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -73,8 +73,9 @@ func TestMapLiteral(t *testing.T) {
 func TestStringLiteral(t *testing.T) {
 	Test(t,
 		That(`put 'such \"''literal'`).Puts(`such \"'literal`),
-		That(`put "much \n\033[31;1m$cool\033[m"`).
-			Puts("much \n\033[31;1m$cool\033[m"),
+		That(`put "much \n\033[31;1m$cool\033[m"`).Puts("much \n\033[31;1m$cool\033[m"),
+		That(`put "x\302\222\302\214y"`).Puts("x\u0092\u008cy"),
+		That(`put "x\u0092\u008cy"`).Puts("x\u0092\u008cy"),
 	)
 }
 

--- a/pkg/eval/value_test.go
+++ b/pkg/eval/value_test.go
@@ -16,6 +16,7 @@ var reprTests = []struct {
 	{"a\nb", `"a\nb"`},
 	{"foo bar", "'foo bar'"},
 	{"a\x00b", `"a\x00b"`},
+	{"a\033b", `"a\eb"`},
 	{true, "$true"},
 	{false, "$false"},
 	{vals.EmptyList, "[]"},

--- a/pkg/parse/quote_test.go
+++ b/pkg/parse/quote_test.go
@@ -24,8 +24,7 @@ func TestQuote(t *testing.T) {
 
 		// Double quote when there is unprintable char.
 		Args("a\nb").Rets(`"a\nb"`),
-		Args("\x1b\"\\").Rets(`"\e\"\\"`),
-		Args("\x00").Rets(`"\x00"`),
+		Args("\000\x1b\"\\").Rets(`"\x00\e\"\\"`),
 		Args("\u0600").Rets(`"\u0600"`),         // Arabic number sign
 		Args("\U000110BD").Rets(`"\U000110bd"`), // Kathi number sign
 
@@ -47,6 +46,9 @@ func TestQuoteAs(t *testing.T) {
 		Args("a", SingleQuoted).Rets(`'a'`, SingleQuoted),
 		Args("\n", SingleQuoted).Rets(`"\n"`, DoubleQuoted),
 
+		// Verify bareword invalid UTF-8 case.
+		Args("bad\xffUTF-8", Bareword).Rets(`"bad\xffUTF-8"`, DoubleQuoted),
+
 		// Bareword tested above in TestQuote.
 	})
 }
@@ -57,5 +59,6 @@ func TestQuoteVariableName(t *testing.T) {
 		Args("foo").Rets("foo"),
 		Args("a/b").Rets("'a/b'"),
 		Args("\x1b").Rets(`"\e"`),
+		Args("bad\xffUTF-8").Rets(`"bad\xffUTF-8"`),
 	})
 }

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -118,6 +118,8 @@ represents Unicode codepoints in hexadecimal):
 
     -   `\r` is U+000D CR (carriage return).
 
+    -   `\e` is U+001B ESC (escape).
+
     -   `\"` is U+0022, the double quote `"` itself.
 
     -   `\\` is U+005C, the backslash `\` itself.
@@ -135,8 +137,8 @@ represents Unicode codepoints in hexadecimal):
     be used to write arbitrary byte sequences that are not necessary valid UTF-8
     sequences.
 
-    **Note**: `\0`, while supported by C, is invalid in Elvish; write `\000`
-    instead.
+    **Note**: `\0`, while supported by C, is invalid in Elvish; write `\x00` or
+    `\000` instead.
 
 -   The following escape sequences encode any Unicode codepoint using their
     numeric values:


### PR DESCRIPTION
In addition to fixing the encoding bugs standardize on \xNN notation for
bytes rather than \uNNNN; e.g., \x00 rather than \u0000.

Also, update the documentation for double-quoted strings to include the
\e sequence.

Fixes #1528