### PR TITLE
README: Fix Matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use.
 User groups (all connected thanks to [Matrix](https://matrix.org)):
 [![Gitter](https://img.shields.io/badge/gitter-elves/elvish-blue.svg?logo=gitter-white)](https://gitter.im/elves/elvish)
 [![Telegram Group](https://img.shields.io/badge/telegram-@elvish-blue.svg)](https://telegram.me/elvish)
-[![#users:elves.sh](https://img.shields.io/badge/matrix-%23users:elv.sh-blue.svg)](https://matrix.to/#/#users:elves.sh)
+[![#users:elv.sh](https://img.shields.io/badge/matrix-%23users:elv.sh-blue.svg)](https://matrix.to/#/#users:elv.sh)
 
 ## Documentation
 


### PR DESCRIPTION
The readme Matrix link currently points to `#users:elves.sh`. Since elves.sh is NXDOMAIN, and the website lists `#users:elv.sh` as the Matrix room, I think this is what was meant here.