### PR TITLE
Make parse.Source naming more consistent

### DIFF
--- a/pkg/edit/builtins.go
+++ b/pkg/edit/builtins.go
@@ -209,7 +209,7 @@ func smartEnter(app cli.App) {
 }
 
 func isSyntaxComplete(code string) bool {
-	_, err := parse.Parse(parse.Source{Code: code}, parse.Config{})
+	_, err := parse.Parse(parse.Source{Name: "[syntax check]", Code: code}, parse.Config{})
 	if err != nil {
 		for _, e := range err.(*parse.Error).Entries {
 			if e.Context.From == len(code) {

--- a/pkg/edit/filter/compile.go
+++ b/pkg/edit/filter/compile.go
@@ -24,7 +24,7 @@ func Compile(q string) (Filter, error) {
 
 func parseFilter(q string) (*parse.Filter, error) {
 	qn := &parse.Filter{}
-	err := parse.ParseAs(parse.Source{Name: "filter", Code: q}, qn, parse.Config{})
+	err := parse.ParseAs(parse.Source{Name: "[filter]", Code: q}, qn, parse.Config{})
 	return qn, err
 }
 

--- a/pkg/edit/filter/compile_test.go
+++ b/pkg/edit/filter/compile_test.go
@@ -58,7 +58,7 @@ func TestCompile(t *testing.T) {
 			Filter("[re '[']").
 			DoesNotCompile("error parsing regexp: missing closing ]: `[`"),
 		That("invalid syntax results in parse error").
-			Filter("[and").DoesNotParse("parse error: 4-4 in filter: should be ']'"),
+			Filter("[and").DoesNotParse("parse error: 4-4 in [filter]: should be ']'"),
 
 		// Unsupported for now, but may be in future
 		That("options are not supported yet").

--- a/pkg/edit/highlight/highlight.go
+++ b/pkg/edit/highlight/highlight.go
@@ -31,7 +31,7 @@ func highlight(code string, cfg Config, lateCb func(ui.Text)) (ui.Text, []error)
 	var errors []error
 	var errorRegions []region
 
-	tree, errParse := parse.Parse(parse.Source{Name: "[tty]", Code: code}, parse.Config{})
+	tree, errParse := parse.Parse(parse.Source{Name: "[interactive]", Code: code}, parse.Config{})
 	if errParse != nil {
 		for _, err := range errParse.(*parse.Error).Entries {
 			if err.Context.From != len(code) {

--- a/pkg/edit/highlight_test.go
+++ b/pkg/edit/highlight_test.go
@@ -30,7 +30,7 @@ func TestHighlighter(t *testing.T) {
 	f.TestTTY(t,
 		"~> put $truex", Styles,
 		"   vvv ??????", term.DotHere, "\n",
-		"compilation error: 4-10 in [tty]: variable $truex not found",
+		"compilation error: 4-10 in [interactive]: variable $truex not found",
 	)
 }
 

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -436,7 +436,7 @@ func TestUse_SetsVariableCorrectlyIfModuleCallsExtendGlobal(t *testing.T) {
 	}
 	ev.ExtendBuiltin(BuildNs().AddGoFn("add-var", addVar))
 
-	err := ev.Eval(parse.Source{Code: "use a"}, EvalCfg{})
+	err := ev.Eval(parse.Source{Name: "[test]", Code: "use a"}, EvalCfg{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/eval/compiler_test.go
+++ b/pkg/eval/compiler_test.go
@@ -25,7 +25,7 @@ func testCompileTimeDeprecation(t *testing.T, code, wantWarning string, level in
 	ev := NewEvaler()
 	errOutput := new(bytes.Buffer)
 
-	parseErr, compileErr := ev.Check(parse.Source{Code: code}, errOutput)
+	parseErr, compileErr := ev.Check(parse.Source{Name: "[test]", Code: code}, errOutput)
 	if parseErr != nil {
 		t.Errorf("got parse err %v", parseErr)
 	}

--- a/pkg/eval/eval_test.go
+++ b/pkg/eval/eval_test.go
@@ -68,7 +68,7 @@ func TestMultipleEval(t *testing.T) {
 func TestEval_AlternativeGlobal(t *testing.T) {
 	ev := NewEvaler()
 	g := BuildNs().AddVar("a", vars.NewReadOnly("")).Ns()
-	err := ev.Eval(parse.Source{Code: "nop $a"}, EvalCfg{Global: g})
+	err := ev.Eval(parse.Source{Name: "[test]", Code: "nop $a"}, EvalCfg{Global: g})
 	if err != nil {
 		t.Errorf("got error %v, want nil", err)
 	}
@@ -84,11 +84,11 @@ func TestEval_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		ev.Eval(parse.Source{Code: "var a"}, EvalCfg{})
+		ev.Eval(parse.Source{Name: "[test]", Code: "var a"}, EvalCfg{})
 		wg.Done()
 	}()
 	go func() {
-		ev.Eval(parse.Source{Code: "var b"}, EvalCfg{})
+		ev.Eval(parse.Source{Name: "[test]", Code: "var b"}, EvalCfg{})
 		wg.Done()
 	}()
 	wg.Wait()
@@ -149,7 +149,7 @@ func TestCheck(t *testing.T) {
 	ev := NewEvaler()
 	for _, test := range checkTests {
 		t.Run(test.name, func(t *testing.T) {
-			parseErr, compileErr := ev.Check(parse.Source{Code: test.code}, nil)
+			parseErr, compileErr := ev.Check(parse.Source{Name: "[test]", Code: test.code}, nil)
 			if (parseErr != nil) != test.wantParseErr {
 				t.Errorf("got parse error %v, when wantParseErr = %v",
 					parseErr, test.wantParseErr)

--- a/pkg/eval/fuzz_test.go
+++ b/pkg/eval/fuzz_test.go
@@ -13,6 +13,6 @@ func FuzzCheck(f *testing.F) {
 	f.Add("put $x")
 	f.Add("put foo bar | each {|x| echo $x }")
 	f.Fuzz(func(t *testing.T, code string) {
-		NewEvaler().Check(parse.Source{Name: "fuzz", Code: code}, nil)
+		NewEvaler().Check(parse.Source{Name: "[fuzz]", Code: code}, nil)
 	})
 }

--- a/pkg/parse/parseutil/parseutil.go
+++ b/pkg/parse/parseutil/parseutil.go
@@ -9,7 +9,7 @@ import (
 
 // Wordify turns a piece of source code into words.
 func Wordify(src string) []string {
-	tree, _ := parse.Parse(parse.Source{Code: src}, parse.Config{})
+	tree, _ := parse.Parse(parse.Source{Name: "[unknown]", Code: src}, parse.Config{})
 	return wordifyInner(tree.Root, nil)
 }
 


### PR DESCRIPTION
Fixes #1545