### PR TITLE
improve consistency and readability by eliminating unnecessary dot imports 

### DIFF
--- a/pkg/cli/modes/mode_test.go
+++ b/pkg/cli/modes/mode_test.go
@@ -11,6 +11,8 @@ import (
 	"src.elv.sh/pkg/ui"
 )
 
+var Args = tt.Args
+
 func TestModeLine(t *testing.T) {
 	testModeLine(t, tt.Fn("Line", modeLine))
 }
@@ -22,9 +24,9 @@ func TestModePrompt(t *testing.T) {
 
 func testModeLine(t *testing.T, fn *tt.FnToTest) {
 	tt.Test(t, fn, tt.Table{
-		tt.Args("TEST", false).Rets(
+		Args("TEST", false).Rets(
 			ui.T("TEST", ui.Bold, ui.FgWhite, ui.BgMagenta)),
-		tt.Args("TEST", true).Rets(
+		Args("TEST", true).Rets(
 			ui.Concat(
 				ui.T("TEST", ui.Bold, ui.FgWhite, ui.BgMagenta),
 				ui.T(" "))),

--- a/pkg/cli/term/event.go
+++ b/pkg/cli/term/event.go
@@ -1,6 +1,8 @@
 package term
 
-import "src.elv.sh/pkg/ui"
+import (
+	"src.elv.sh/pkg/ui"
+)
 
 // Event represents an event that can be read from the terminal.
 type Event interface {

--- a/pkg/cli/tk/codearea_test.go
+++ b/pkg/cli/tk/codearea_test.go
@@ -10,6 +10,8 @@ import (
 	"src.elv.sh/pkg/ui"
 )
 
+var Args = tt.Args
+
 var bb = term.NewBufferBuilder
 
 func p(t ui.Text) func() ui.Text { return func() ui.Text { return t } }
@@ -454,15 +456,15 @@ func TestCodeAreaState_ApplyPending(t *testing.T) {
 		return s
 	}
 	tt.Test(t, tt.Fn("applyPending", applyPending), tt.Table{
-		tt.Args(CodeAreaState{Buffer: CodeBuffer{}, Pending: PendingCode{0, 0, "ls"}}).
+		Args(CodeAreaState{Buffer: CodeBuffer{}, Pending: PendingCode{0, 0, "ls"}}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "ls", Dot: 2}, Pending: PendingCode{}}),
-		tt.Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, Pending: PendingCode{0, 0, "ls"}}).
+		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, Pending: PendingCode{0, 0, "ls"}}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "lsx", Dot: 3}, Pending: PendingCode{}}),
 		// No-op when Pending is empty.
-		tt.Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}}).
+		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "x", Dot: 1}}),
 		// HideRPrompt is kept intact.
-		tt.Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, HideRPrompt: true}).
+		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, HideRPrompt: true}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "x", Dot: 1}, HideRPrompt: true}),
 	})
 }

--- a/pkg/cli/tk/colview_test.go
+++ b/pkg/cli/tk/colview_test.go
@@ -125,11 +125,11 @@ func TestColView_Handle(t *testing.T) {
 func TestDistribute(t *testing.T) {
 	tt.Test(t, tt.Fn("distribute", distribute), tt.Table{
 		// Nice integer distributions.
-		tt.Args(10, []int{1, 1}).Rets([]int{5, 5}),
-		tt.Args(10, []int{2, 3}).Rets([]int{4, 6}),
-		tt.Args(10, []int{1, 2, 2}).Rets([]int{2, 4, 4}),
+		Args(10, []int{1, 1}).Rets([]int{5, 5}),
+		Args(10, []int{2, 3}).Rets([]int{4, 6}),
+		Args(10, []int{1, 2, 2}).Rets([]int{2, 4, 4}),
 		// Approximate integer distributions.
-		tt.Args(10, []int{1, 1, 1}).Rets([]int{3, 3, 4}),
-		tt.Args(5, []int{1, 1, 1}).Rets([]int{1, 2, 2}),
+		Args(10, []int{1, 1, 1}).Rets([]int{3, 3, 4}),
+		Args(5, []int{1, 1, 1}).Rets([]int{1, 2, 2}),
 	})
 }

--- a/pkg/cli/tk/listbox_window_test.go
+++ b/pkg/cli/tk/listbox_window_test.go
@@ -6,8 +6,6 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
-var Args = tt.Args
-
 func TestGetVerticalWindow(t *testing.T) {
 	tt.Test(t, tt.Fn("getVerticalWindow", getVerticalWindow), tt.Table{
 		// selected = 0: always show a widow starting from 0, regardless of

--- a/pkg/edit/buf_to_html_test.go
+++ b/pkg/edit/buf_to_html_test.go
@@ -7,22 +7,24 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestBufToHTML(t *testing.T) {
 	tt.Test(t, tt.Fn("bufToHTML", bufToHTML), tt.Table{
 		// Just plain text.
-		tt.Args(
+		Args(
 			bb().Write("abc").Buffer(),
 		).Rets(
 			`abc` + "\n",
 		),
 		// Just styled text.
-		tt.Args(
+		Args(
 			bb().WriteStringSGR("abc", "31").Buffer(),
 		).Rets(
 			`<span class="sgr-31">abc</span>` + "\n",
 		),
 		// Mixing plain and styled texts.
-		tt.Args(
+		Args(
 			bb().
 				WriteStringSGR("abc", "31").
 				Write(" def ").
@@ -32,7 +34,7 @@ func TestBufToHTML(t *testing.T) {
 			`<span class="sgr-31">abc</span> def <span class="sgr-1">xyz</span>` + "\n",
 		),
 		// Multiple lines.
-		tt.Args(
+		Args(
 			bb().
 				WriteStringSGR("abc", "31").
 				Newline().Write("def").

--- a/pkg/edit/builtins_test.go
+++ b/pkg/edit/builtins_test.go
@@ -349,18 +349,18 @@ func TestBuiltins_FocusedWidgetNotCodeArea(t *testing.T) {
 
 func TestMoveDotLeftRight(t *testing.T) {
 	tt.Test(t, tt.Fn("moveDotLeft", moveDotLeft), tt.Table{
-		tt.Args("foo", 0).Rets(0),
-		tt.Args("bar", 3).Rets(2),
-		tt.Args("精灵", 0).Rets(0),
-		tt.Args("精灵", 3).Rets(0),
-		tt.Args("精灵", 6).Rets(3),
+		Args("foo", 0).Rets(0),
+		Args("bar", 3).Rets(2),
+		Args("精灵", 0).Rets(0),
+		Args("精灵", 3).Rets(0),
+		Args("精灵", 6).Rets(3),
 	})
 	tt.Test(t, tt.Fn("moveDotRight", moveDotRight), tt.Table{
-		tt.Args("foo", 0).Rets(1),
-		tt.Args("bar", 3).Rets(3),
-		tt.Args("精灵", 0).Rets(3),
-		tt.Args("精灵", 3).Rets(6),
-		tt.Args("精灵", 6).Rets(6),
+		Args("foo", 0).Rets(1),
+		Args("bar", 3).Rets(3),
+		Args("精灵", 0).Rets(3),
+		Args("精灵", 3).Rets(6),
+		Args("精灵", 6).Rets(6),
 	})
 }
 
@@ -369,24 +369,24 @@ func TestMoveDotSOLEOL(t *testing.T) {
 	// Index:
 	//         012 34567
 	tt.Test(t, tt.Fn("moveDotSOL", moveDotSOL), tt.Table{
-		tt.Args(buffer, 0).Rets(0),
-		tt.Args(buffer, 1).Rets(0),
-		tt.Args(buffer, 2).Rets(0),
-		tt.Args(buffer, 3).Rets(0),
-		tt.Args(buffer, 4).Rets(4),
-		tt.Args(buffer, 5).Rets(4),
-		tt.Args(buffer, 6).Rets(4),
-		tt.Args(buffer, 7).Rets(4),
+		Args(buffer, 0).Rets(0),
+		Args(buffer, 1).Rets(0),
+		Args(buffer, 2).Rets(0),
+		Args(buffer, 3).Rets(0),
+		Args(buffer, 4).Rets(4),
+		Args(buffer, 5).Rets(4),
+		Args(buffer, 6).Rets(4),
+		Args(buffer, 7).Rets(4),
 	})
 	tt.Test(t, tt.Fn("moveDotEOL", moveDotEOL), tt.Table{
-		tt.Args(buffer, 0).Rets(3),
-		tt.Args(buffer, 1).Rets(3),
-		tt.Args(buffer, 2).Rets(3),
-		tt.Args(buffer, 3).Rets(3),
-		tt.Args(buffer, 4).Rets(7),
-		tt.Args(buffer, 5).Rets(7),
-		tt.Args(buffer, 6).Rets(7),
-		tt.Args(buffer, 7).Rets(7),
+		Args(buffer, 0).Rets(3),
+		Args(buffer, 1).Rets(3),
+		Args(buffer, 2).Rets(3),
+		Args(buffer, 3).Rets(3),
+		Args(buffer, 4).Rets(7),
+		Args(buffer, 5).Rets(7),
+		Args(buffer, 6).Rets(7),
+		Args(buffer, 7).Rets(7),
 	})
 }
 
@@ -397,33 +397,33 @@ func TestMoveDotUpDown(t *testing.T) {
 	// + 10 *  0        1
 
 	tt.Test(t, tt.Fn("moveDotUp", moveDotUp), tt.Table{
-		tt.Args(buffer, 0).Rets(0),  // a -> a
-		tt.Args(buffer, 1).Rets(1),  // b -> b
-		tt.Args(buffer, 2).Rets(2),  // c -> c
-		tt.Args(buffer, 3).Rets(3),  // EOL1 -> EOL1
-		tt.Args(buffer, 4).Rets(0),  // 精 -> a
-		tt.Args(buffer, 7).Rets(2),  // 灵 -> c
-		tt.Args(buffer, 10).Rets(3), // 语 -> EOL1
-		tt.Args(buffer, 13).Rets(3), // EOL2 -> EOL1
-		tt.Args(buffer, 14).Rets(4), // d -> 精
-		tt.Args(buffer, 15).Rets(4), // e -> 精 (jump left half width)
-		tt.Args(buffer, 16).Rets(7), // f -> 灵
-		tt.Args(buffer, 17).Rets(7), // EOL3 -> 灵 (jump left half width)
+		Args(buffer, 0).Rets(0),  // a -> a
+		Args(buffer, 1).Rets(1),  // b -> b
+		Args(buffer, 2).Rets(2),  // c -> c
+		Args(buffer, 3).Rets(3),  // EOL1 -> EOL1
+		Args(buffer, 4).Rets(0),  // 精 -> a
+		Args(buffer, 7).Rets(2),  // 灵 -> c
+		Args(buffer, 10).Rets(3), // 语 -> EOL1
+		Args(buffer, 13).Rets(3), // EOL2 -> EOL1
+		Args(buffer, 14).Rets(4), // d -> 精
+		Args(buffer, 15).Rets(4), // e -> 精 (jump left half width)
+		Args(buffer, 16).Rets(7), // f -> 灵
+		Args(buffer, 17).Rets(7), // EOL3 -> 灵 (jump left half width)
 	})
 
 	tt.Test(t, tt.Fn("moveDotDown", moveDotDown), tt.Table{
-		tt.Args(buffer, 0).Rets(4),   // a -> 精
-		tt.Args(buffer, 1).Rets(4),   // b -> 精 (jump left half width)
-		tt.Args(buffer, 2).Rets(7),   // c -> 灵
-		tt.Args(buffer, 3).Rets(7),   // EOL1 -> 灵 (jump left half width)
-		tt.Args(buffer, 4).Rets(14),  // 精 -> d
-		tt.Args(buffer, 7).Rets(16),  // 灵 -> f
-		tt.Args(buffer, 10).Rets(17), // 语 -> EOL3
-		tt.Args(buffer, 13).Rets(17), // EOL2 -> EOL3
-		tt.Args(buffer, 14).Rets(14), // d -> d
-		tt.Args(buffer, 15).Rets(15), // e -> e
-		tt.Args(buffer, 16).Rets(16), // f -> f
-		tt.Args(buffer, 17).Rets(17), // EOL3 -> EOL3
+		Args(buffer, 0).Rets(4),   // a -> 精
+		Args(buffer, 1).Rets(4),   // b -> 精 (jump left half width)
+		Args(buffer, 2).Rets(7),   // c -> 灵
+		Args(buffer, 3).Rets(7),   // EOL1 -> 灵 (jump left half width)
+		Args(buffer, 4).Rets(14),  // 精 -> d
+		Args(buffer, 7).Rets(16),  // 灵 -> f
+		Args(buffer, 10).Rets(17), // 语 -> EOL3
+		Args(buffer, 13).Rets(17), // EOL2 -> EOL3
+		Args(buffer, 14).Rets(14), // d -> d
+		Args(buffer, 15).Rets(15), // e -> e
+		Args(buffer, 16).Rets(16), // f -> f
+		Args(buffer, 17).Rets(17), // EOL3 -> EOL3
 	})
 }
 
@@ -453,86 +453,86 @@ var wordMoveTestBuffer = "cd ~/downloads; rm -rf 2018aug07-pics/*;"
 var (
 	// word boundaries: 0 3 16 19 23
 	moveDotLeftWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(0),
-		tt.Args(wordMoveTestBuffer, 1).Rets(0),
-		tt.Args(wordMoveTestBuffer, 2).Rets(0),
-		tt.Args(wordMoveTestBuffer, 3).Rets(0),
-		tt.Args(wordMoveTestBuffer, 4).Rets(3),
-		tt.Args(wordMoveTestBuffer, 16).Rets(3),
-		tt.Args(wordMoveTestBuffer, 19).Rets(16),
-		tt.Args(wordMoveTestBuffer, 23).Rets(19),
-		tt.Args(wordMoveTestBuffer, 40).Rets(23),
+		Args(wordMoveTestBuffer, 0).Rets(0),
+		Args(wordMoveTestBuffer, 1).Rets(0),
+		Args(wordMoveTestBuffer, 2).Rets(0),
+		Args(wordMoveTestBuffer, 3).Rets(0),
+		Args(wordMoveTestBuffer, 4).Rets(3),
+		Args(wordMoveTestBuffer, 16).Rets(3),
+		Args(wordMoveTestBuffer, 19).Rets(16),
+		Args(wordMoveTestBuffer, 23).Rets(19),
+		Args(wordMoveTestBuffer, 40).Rets(23),
 	}
 	moveDotRightWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(3),
-		tt.Args(wordMoveTestBuffer, 1).Rets(3),
-		tt.Args(wordMoveTestBuffer, 2).Rets(3),
-		tt.Args(wordMoveTestBuffer, 3).Rets(16),
-		tt.Args(wordMoveTestBuffer, 16).Rets(19),
-		tt.Args(wordMoveTestBuffer, 19).Rets(23),
-		tt.Args(wordMoveTestBuffer, 23).Rets(40),
+		Args(wordMoveTestBuffer, 0).Rets(3),
+		Args(wordMoveTestBuffer, 1).Rets(3),
+		Args(wordMoveTestBuffer, 2).Rets(3),
+		Args(wordMoveTestBuffer, 3).Rets(16),
+		Args(wordMoveTestBuffer, 16).Rets(19),
+		Args(wordMoveTestBuffer, 19).Rets(23),
+		Args(wordMoveTestBuffer, 23).Rets(40),
 	}
 
 	// small-word boundaries: 0 3 5 14 16 19 20 23 32 33 37
 	moveDotLeftSmallWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(0),
-		tt.Args(wordMoveTestBuffer, 1).Rets(0),
-		tt.Args(wordMoveTestBuffer, 2).Rets(0),
-		tt.Args(wordMoveTestBuffer, 3).Rets(0),
-		tt.Args(wordMoveTestBuffer, 4).Rets(3),
-		tt.Args(wordMoveTestBuffer, 5).Rets(3),
-		tt.Args(wordMoveTestBuffer, 14).Rets(5),
-		tt.Args(wordMoveTestBuffer, 16).Rets(14),
-		tt.Args(wordMoveTestBuffer, 19).Rets(16),
-		tt.Args(wordMoveTestBuffer, 20).Rets(19),
-		tt.Args(wordMoveTestBuffer, 23).Rets(20),
-		tt.Args(wordMoveTestBuffer, 32).Rets(23),
-		tt.Args(wordMoveTestBuffer, 33).Rets(32),
-		tt.Args(wordMoveTestBuffer, 37).Rets(33),
-		tt.Args(wordMoveTestBuffer, 40).Rets(37),
+		Args(wordMoveTestBuffer, 0).Rets(0),
+		Args(wordMoveTestBuffer, 1).Rets(0),
+		Args(wordMoveTestBuffer, 2).Rets(0),
+		Args(wordMoveTestBuffer, 3).Rets(0),
+		Args(wordMoveTestBuffer, 4).Rets(3),
+		Args(wordMoveTestBuffer, 5).Rets(3),
+		Args(wordMoveTestBuffer, 14).Rets(5),
+		Args(wordMoveTestBuffer, 16).Rets(14),
+		Args(wordMoveTestBuffer, 19).Rets(16),
+		Args(wordMoveTestBuffer, 20).Rets(19),
+		Args(wordMoveTestBuffer, 23).Rets(20),
+		Args(wordMoveTestBuffer, 32).Rets(23),
+		Args(wordMoveTestBuffer, 33).Rets(32),
+		Args(wordMoveTestBuffer, 37).Rets(33),
+		Args(wordMoveTestBuffer, 40).Rets(37),
 	}
 	moveDotRightSmallWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(3),
-		tt.Args(wordMoveTestBuffer, 1).Rets(3),
-		tt.Args(wordMoveTestBuffer, 2).Rets(3),
-		tt.Args(wordMoveTestBuffer, 3).Rets(5),
-		tt.Args(wordMoveTestBuffer, 5).Rets(14),
-		tt.Args(wordMoveTestBuffer, 14).Rets(16),
-		tt.Args(wordMoveTestBuffer, 16).Rets(19),
-		tt.Args(wordMoveTestBuffer, 19).Rets(20),
-		tt.Args(wordMoveTestBuffer, 20).Rets(23),
-		tt.Args(wordMoveTestBuffer, 23).Rets(32),
-		tt.Args(wordMoveTestBuffer, 32).Rets(33),
-		tt.Args(wordMoveTestBuffer, 33).Rets(37),
-		tt.Args(wordMoveTestBuffer, 37).Rets(40),
+		Args(wordMoveTestBuffer, 0).Rets(3),
+		Args(wordMoveTestBuffer, 1).Rets(3),
+		Args(wordMoveTestBuffer, 2).Rets(3),
+		Args(wordMoveTestBuffer, 3).Rets(5),
+		Args(wordMoveTestBuffer, 5).Rets(14),
+		Args(wordMoveTestBuffer, 14).Rets(16),
+		Args(wordMoveTestBuffer, 16).Rets(19),
+		Args(wordMoveTestBuffer, 19).Rets(20),
+		Args(wordMoveTestBuffer, 20).Rets(23),
+		Args(wordMoveTestBuffer, 23).Rets(32),
+		Args(wordMoveTestBuffer, 32).Rets(33),
+		Args(wordMoveTestBuffer, 33).Rets(37),
+		Args(wordMoveTestBuffer, 37).Rets(40),
 	}
 
 	// alnum-word boundaries: 0 5 16 20 23 33
 	moveDotLeftAlnumWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(0),
-		tt.Args(wordMoveTestBuffer, 1).Rets(0),
-		tt.Args(wordMoveTestBuffer, 2).Rets(0),
-		tt.Args(wordMoveTestBuffer, 3).Rets(0),
-		tt.Args(wordMoveTestBuffer, 4).Rets(0),
-		tt.Args(wordMoveTestBuffer, 5).Rets(0),
-		tt.Args(wordMoveTestBuffer, 6).Rets(5),
-		tt.Args(wordMoveTestBuffer, 16).Rets(5),
-		tt.Args(wordMoveTestBuffer, 20).Rets(16),
-		tt.Args(wordMoveTestBuffer, 23).Rets(20),
-		tt.Args(wordMoveTestBuffer, 33).Rets(23),
-		tt.Args(wordMoveTestBuffer, 40).Rets(33),
+		Args(wordMoveTestBuffer, 0).Rets(0),
+		Args(wordMoveTestBuffer, 1).Rets(0),
+		Args(wordMoveTestBuffer, 2).Rets(0),
+		Args(wordMoveTestBuffer, 3).Rets(0),
+		Args(wordMoveTestBuffer, 4).Rets(0),
+		Args(wordMoveTestBuffer, 5).Rets(0),
+		Args(wordMoveTestBuffer, 6).Rets(5),
+		Args(wordMoveTestBuffer, 16).Rets(5),
+		Args(wordMoveTestBuffer, 20).Rets(16),
+		Args(wordMoveTestBuffer, 23).Rets(20),
+		Args(wordMoveTestBuffer, 33).Rets(23),
+		Args(wordMoveTestBuffer, 40).Rets(33),
 	}
 	moveDotRightAlnumWordTests = tt.Table{
-		tt.Args(wordMoveTestBuffer, 0).Rets(5),
-		tt.Args(wordMoveTestBuffer, 1).Rets(5),
-		tt.Args(wordMoveTestBuffer, 2).Rets(5),
-		tt.Args(wordMoveTestBuffer, 3).Rets(5),
-		tt.Args(wordMoveTestBuffer, 4).Rets(5),
-		tt.Args(wordMoveTestBuffer, 5).Rets(16),
-		tt.Args(wordMoveTestBuffer, 16).Rets(20),
-		tt.Args(wordMoveTestBuffer, 20).Rets(23),
-		tt.Args(wordMoveTestBuffer, 23).Rets(33),
-		tt.Args(wordMoveTestBuffer, 33).Rets(40),
+		Args(wordMoveTestBuffer, 0).Rets(5),
+		Args(wordMoveTestBuffer, 1).Rets(5),
+		Args(wordMoveTestBuffer, 2).Rets(5),
+		Args(wordMoveTestBuffer, 3).Rets(5),
+		Args(wordMoveTestBuffer, 4).Rets(5),
+		Args(wordMoveTestBuffer, 5).Rets(16),
+		Args(wordMoveTestBuffer, 16).Rets(20),
+		Args(wordMoveTestBuffer, 20).Rets(23),
+		Args(wordMoveTestBuffer, 23).Rets(33),
+		Args(wordMoveTestBuffer, 33).Rets(40),
 	}
 )
 

--- a/pkg/edit/highlight/theme.go
+++ b/pkg/edit/highlight/theme.go
@@ -1,6 +1,8 @@
 package highlight
 
-import "src.elv.sh/pkg/ui"
+import (
+	"src.elv.sh/pkg/ui"
+)
 
 var stylingFor = map[string]ui.Styling{
 	barewordRegion:     nil,

--- a/pkg/edit/highlight_test.go
+++ b/pkg/edit/highlight_test.go
@@ -41,10 +41,10 @@ func TestCheck(t *testing.T) {
 	ev.ExtendGlobal(eval.BuildNs().AddVar("good", vars.FromInit(0)))
 
 	tt.Test(t, tt.Fn("check", check), tt.Table{
-		tt.Args(ev, mustParse("")).Rets(noError),
-		tt.Args(ev, mustParse("echo $good")).Rets(noError),
+		Args(ev, mustParse("")).Rets(noError),
+		Args(ev, mustParse("echo $good")).Rets(noError),
 		// TODO: Check the range of the returned error
-		tt.Args(ev, mustParse("echo $bad")).Rets(anyError),
+		Args(ev, mustParse("echo $bad")).Rets(anyError),
 	})
 }
 
@@ -95,38 +95,38 @@ func TestMakeHasCommand(t *testing.T) {
 
 	tt.Test(t, tt.Fn("hasCommand", hasCommand), tt.Table{
 		// Builtin special form
-		tt.Args(ev, "if").Rets(true),
+		Args(ev, "if").Rets(true),
 
 		// Builtin function
-		tt.Args(ev, "put").Rets(true),
+		Args(ev, "put").Rets(true),
 
 		// User-defined function
-		tt.Args(ev, "good").Rets(true),
+		Args(ev, "good").Rets(true),
 
 		// Function in modules
-		tt.Args(ev, "a:good").Rets(true),
-		tt.Args(ev, "a:b:good").Rets(true),
-		tt.Args(ev, "a:bad").Rets(false),
-		tt.Args(ev, "a:b:bad").Rets(false),
+		Args(ev, "a:good").Rets(true),
+		Args(ev, "a:b:good").Rets(true),
+		Args(ev, "a:bad").Rets(false),
+		Args(ev, "a:b:bad").Rets(false),
 
 		// Non-searching directory and external
-		tt.Args(ev, "./a").Rets(true),
-		tt.Args(ev, "a/b").Rets(true),
-		tt.Args(ev, "a/b/c/executable").Rets(true),
-		tt.Args(ev, "./bad").Rets(false),
-		tt.Args(ev, "a/bad").Rets(false),
+		Args(ev, "./a").Rets(true),
+		Args(ev, "a/b").Rets(true),
+		Args(ev, "a/b/c/executable").Rets(true),
+		Args(ev, "./bad").Rets(false),
+		Args(ev, "a/bad").Rets(false),
 
 		// External in PATH
-		tt.Args(ev, "external").Rets(true),
-		tt.Args(ev, "@external").Rets(true),
-		tt.Args(ev, "ex:tern:al").Rets(colonInFilenameOk),
+		Args(ev, "external").Rets(true),
+		Args(ev, "@external").Rets(true),
+		Args(ev, "ex:tern:al").Rets(colonInFilenameOk),
 		// With explicit e:
-		tt.Args(ev, "e:external").Rets(true),
-		tt.Args(ev, "e:bad-external").Rets(false),
+		Args(ev, "e:external").Rets(true),
+		Args(ev, "e:bad-external").Rets(false),
 
 		// Non-existent
-		tt.Args(ev, "bad").Rets(false),
-		tt.Args(ev, "a:").Rets(false),
+		Args(ev, "bad").Rets(false),
+		Args(ev, "a:").Rets(false),
 	})
 }
 

--- a/pkg/eval/compile_value_test.go
+++ b/pkg/eval/compile_value_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
@@ -79,8 +79,8 @@ func TestStringLiteral(t *testing.T) {
 }
 
 func TestTilde(t *testing.T) {
-	home := InTempHome(t)
-	ApplyDir(Dir{"file1": "", "file2": ""})
+	home := testutil.InTempHome(t)
+	testutil.ApplyDir(testutil.Dir{"file1": "", "file2": ""})
 
 	Test(t,
 		// Tilde

--- a/pkg/eval/exception_test.go
+++ b/pkg/eval/exception_test.go
@@ -19,8 +19,8 @@ import (
 func TestReason(t *testing.T) {
 	err := errors.New("ordinary error")
 	tt.Test(t, tt.Fn("Reason", Reason), tt.Table{
-		tt.Args(err).Rets(err),
-		tt.Args(makeException(err)).Rets(err),
+		Args(err).Rets(err),
+		Args(makeException(err)).Rets(err),
 	})
 }
 
@@ -86,15 +86,15 @@ func TestPipelineError_Fields(t *testing.T) {
 
 func TestErrorMethods(t *testing.T) {
 	tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
-		tt.Args(makeException(errors.New("err"))).Rets("err"),
+		Args(makeException(errors.New("err"))).Rets("err"),
 
-		tt.Args(MakePipelineError([]Exception{
+		Args(MakePipelineError([]Exception{
 			makeException(errors.New("err1")),
 			makeException(errors.New("err2"))})).Rets("(err1 | err2)"),
 
-		tt.Args(Return).Rets("return"),
-		tt.Args(Break).Rets("break"),
-		tt.Args(Continue).Rets("continue"),
-		tt.Args(Flow(1000)).Rets("!(BAD FLOW: 1000)"),
+		Args(Return).Rets("return"),
+		Args(Break).Rets("break"),
+		Args(Continue).Rets("continue"),
+		Args(Flow(1000)).Rets("!(BAD FLOW: 1000)"),
 	})
 }

--- a/pkg/eval/exception_unix_test.go
+++ b/pkg/eval/exception_unix_test.go
@@ -15,24 +15,24 @@ import (
 
 func TestExternalCmdExit_Error(t *testing.T) {
 	tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
-		tt.Args(ExternalCmdExit{0x0, "ls", 1}).Rets("ls exited with 0"),
-		tt.Args(ExternalCmdExit{0x100, "ls", 1}).Rets("ls exited with 1"),
+		Args(ExternalCmdExit{0x0, "ls", 1}).Rets("ls exited with 0"),
+		Args(ExternalCmdExit{0x100, "ls", 1}).Rets("ls exited with 1"),
 		// Note: all Unix'es have SIGINT = 2, but syscall package has different
 		// string in gccgo("Interrupt") and gc("interrupt").
-		tt.Args(ExternalCmdExit{0x2, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String()),
+		Args(ExternalCmdExit{0x2, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String()),
 		// 0x80 + signal for core dumped
-		tt.Args(ExternalCmdExit{0x82, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String() + " (core dumped)"),
+		Args(ExternalCmdExit{0x82, "ls", 1}).Rets("ls killed by signal " + syscall.SIGINT.String() + " (core dumped)"),
 		// 0x7f + signal<<8 for stopped
-		tt.Args(ExternalCmdExit{0x27f, "ls", 1}).Rets("ls stopped by signal " + syscall.SIGINT.String() + " (pid=1)"),
+		Args(ExternalCmdExit{0x27f, "ls", 1}).Rets("ls stopped by signal " + syscall.SIGINT.String() + " (pid=1)"),
 	})
 	if runtime.GOOS == "linux" {
 		tt.Test(t, tt.Fn("Error", error.Error), tt.Table{
 			// 0x057f + cause<<16 for trapped. SIGTRAP is 5 on all Unix'es but have
 			// different string representations on different OSes.
-			tt.Args(ExternalCmdExit{0x1057f, "ls", 1}).Rets(fmt.Sprintf(
+			Args(ExternalCmdExit{0x1057f, "ls", 1}).Rets(fmt.Sprintf(
 				"ls stopped by signal %s (pid=1) (trapped 1)", syscall.SIGTRAP)),
 			// 0xff is the only exit code that is not exited, signaled or stopped.
-			tt.Args(ExternalCmdExit{0xff, "ls", 1}).Rets("ls has unknown WaitStatus 255"),
+			Args(ExternalCmdExit{0xff, "ls", 1}).Rets("ls has unknown WaitStatus 255"),
 		})
 	}
 }

--- a/pkg/eval/external_cmd_unix_internal_test.go
+++ b/pkg/eval/external_cmd_unix_internal_test.go
@@ -10,20 +10,20 @@ import (
 
 	"src.elv.sh/pkg/env"
 	"src.elv.sh/pkg/parse"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestExec_Argv0Argv(t *testing.T) {
-	dir := InTempDir(t)
-	ApplyDir(Dir{
-		"bin": Dir{
-			"elvish": File{Perm: 0755},
-			"cat":    File{Perm: 0755},
+	dir := testutil.InTempDir(t)
+	testutil.ApplyDir(testutil.Dir{
+		"bin": testutil.Dir{
+			"elvish": testutil.File{Perm: 0755},
+			"cat":    testutil.File{Perm: 0755},
 		},
 	})
 
-	Setenv(t, "PATH", dir+"/bin")
-	Setenv(t, env.SHLVL, "1")
+	testutil.Setenv(t, "PATH", dir+"/bin")
+	testutil.Setenv(t, env.SHLVL, "1")
 
 	var tests = []struct {
 		name      string
@@ -104,7 +104,7 @@ func TestDecSHLVL(t *testing.T) {
 
 func testDecSHLVL(t *testing.T, oldValue, newValue string) {
 	t.Helper()
-	Setenv(t, env.SHLVL, oldValue)
+	testutil.Setenv(t, env.SHLVL, oldValue)
 
 	decSHLVL()
 	if gotValue := os.Getenv(env.SHLVL); gotValue != newValue {

--- a/pkg/eval/options_test.go
+++ b/pkg/eval/options_test.go
@@ -4,8 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
+
+var Args = tt.Args
 
 type opts struct {
 	Foo string
@@ -24,7 +26,7 @@ func TestScanOptions(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("scanOptions", wrapper), Table{
+	tt.Test(t, tt.Fn("scanOptions", wrapper), tt.Table{
 		Args(RawOptions{"foo": "lorem ipsum"}, opts{}).
 			Rets(opts{Foo: "lorem ipsum"}, nil),
 		Args(RawOptions{"bar": 20}, opts{bar: 10}).

--- a/pkg/eval/vals/aliased_types_test.go
+++ b/pkg/eval/vals/aliased_types_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestMakeMap_PanicsWithOddNumberOfArguments(t *testing.T) {
-	Test(t, Fn("Recover", testutil.Recover), Table{
+	tt.Test(t, tt.Fn("Recover", testutil.Recover), tt.Table{
 		//lint:ignore SA5012 testing panic
 		Args(func() { MakeMap("foo") }).Rets("odd number of arguments to MakeMap"),
 	})

--- a/pkg/eval/vals/assoc_test.go
+++ b/pkg/eval/vals/assoc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customAssocer struct{}
@@ -17,7 +17,7 @@ func (a customAssocer) Assoc(k, v any) (any, error) {
 }
 
 func TestAssoc(t *testing.T) {
-	Test(t, Fn("Assoc", Assoc), Table{
+	tt.Test(t, tt.Fn("Assoc", Assoc), tt.Table{
 		Args("0123", "0", "foo").Rets("foo123", nil),
 		Args("0123", "1..3", "bar").Rets("0bar3", nil),
 		Args("0123", "1..3", 12).Rets(nil, errReplacementMustBeString),

--- a/pkg/eval/vals/bool_test.go
+++ b/pkg/eval/vals/bool_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customBooler struct{ b bool }
@@ -13,7 +13,7 @@ func (b customBooler) Bool() bool { return b.b }
 type customNonBooler struct{}
 
 func TestBool(t *testing.T) {
-	Test(t, Fn("Bool", Bool), Table{
+	tt.Test(t, tt.Fn("Bool", Bool), tt.Table{
 		Args(nil).Rets(false),
 
 		Args(true).Rets(true),

--- a/pkg/eval/vals/concat_test.go
+++ b/pkg/eval/vals/concat_test.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // An implementation for Concatter that accepts strings, returns a special
@@ -34,7 +34,7 @@ func (rconcatter) RConcat(lhs any) (any, error) {
 }
 
 func TestConcat(t *testing.T) {
-	Test(t, Fn("Concat", Concat), Table{
+	tt.Test(t, tt.Fn("Concat", Concat), tt.Table{
 		Args("foo", "bar").Rets("foobar", nil),
 		// string+number
 		Args("foo", 2).Rets("foo2", nil),

--- a/pkg/eval/vals/conversion_test.go
+++ b/pkg/eval/vals/conversion_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/errs"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type someType struct {
@@ -23,14 +23,14 @@ func TestScanToGo_ConcreteTypeDst(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
 		// int
 		Args("12", 0).Rets(12),
 		Args("0x12", 0).Rets(0x12),
 		Args(12.0, 0).Rets(0, errMustBeInteger),
 		Args(0.5, 0).Rets(0, errMustBeInteger),
-		Args(someType{}, 0).Rets(Any, errMustBeInteger),
-		Args("x", 0).Rets(Any, cannotParseAs{"integer", "x"}),
+		Args(someType{}, 0).Rets(tt.Any, errMustBeInteger),
+		Args("x", 0).Rets(tt.Any, cannotParseAs{"integer", "x"}),
 
 		// float64
 		Args(23, 0.0).Rets(23.0),
@@ -38,20 +38,20 @@ func TestScanToGo_ConcreteTypeDst(t *testing.T) {
 		Args(1.2, 0.0).Rets(1.2),
 		Args("23", 0.0).Rets(23.0),
 		Args("0x23", 0.0).Rets(float64(0x23)),
-		Args(someType{}, 0.0).Rets(Any, errMustBeNumber),
-		Args("x", 0.0).Rets(Any, cannotParseAs{"number", "x"}),
+		Args(someType{}, 0.0).Rets(tt.Any, errMustBeNumber),
+		Args("x", 0.0).Rets(tt.Any, cannotParseAs{"number", "x"}),
 
 		// rune
 		Args("x", ' ').Rets('x'),
-		Args(someType{}, ' ').Rets(Any, errMustBeString),
-		Args("\xc3\x28", ' ').Rets(Any, errMustBeValidUTF8), // Invalid UTF8
-		Args("ab", ' ').Rets(Any, errMustHaveSingleRune),
+		Args(someType{}, ' ').Rets(tt.Any, errMustBeString),
+		Args("\xc3\x28", ' ').Rets(tt.Any, errMustBeValidUTF8), // Invalid UTF8
+		Args("ab", ' ').Rets(tt.Any, errMustHaveSingleRune),
 
 		// Other types don't undergo any conversion, as long as the types match
 		Args("foo", "").Rets("foo"),
 		Args(someType{"foo"}, someType{}).Rets(someType{"foo"}),
 		Args(nil, nil).Rets(nil),
-		Args("x", someType{}).Rets(Any, WrongType{"!!vals.someType", "string"}),
+		Args("x", someType{}).Rets(tt.Any, WrongType{"!!vals.someType", "string"}),
 	})
 }
 
@@ -62,7 +62,7 @@ func TestScanToGo_NumDst(t *testing.T) {
 		return n, err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
 		// Strings are automatically converted
 		Args("12").Rets(12),
 		Args(z).Rets(bigInt(z)),
@@ -74,8 +74,8 @@ func TestScanToGo_NumDst(t *testing.T) {
 		Args(big.NewRat(1, 2)).Rets(big.NewRat(1, 2)),
 		Args(12.0).Rets(12.0),
 
-		Args("bad").Rets(Any, cannotParseAs{"number", "bad"}),
-		Args(EmptyList).Rets(Any, errMustBeNumber),
+		Args("bad").Rets(tt.Any, cannotParseAs{"number", "bad"}),
+		Args(EmptyList).Rets(tt.Any, errMustBeNumber),
 	})
 }
 
@@ -86,10 +86,10 @@ func TestScanToGo_InterfaceDst(t *testing.T) {
 		return l, err
 	}
 
-	Test(t, Fn("ScanToGo", scanToGo), Table{
+	tt.Test(t, tt.Fn("ScanToGo", scanToGo), tt.Table{
 		Args(EmptyList).Rets(EmptyList),
 
-		Args("foo").Rets(Any, WrongType{"!!vector.Vector", "string"}),
+		Args("foo").Rets(tt.Any, WrongType{"!!vector.Vector", "string"}),
 	})
 }
 
@@ -109,7 +109,7 @@ func TestScanListToGo(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanListToGo", scanListToGo), Table{
+	tt.Test(t, tt.Fn("ScanListToGo", scanListToGo), tt.Table{
 		Args(MakeList("1", "2"), []int{}).Rets([]int{1, 2}),
 		Args(MakeList("1", "2"), []string{}).Rets([]string{"1", "2"}),
 
@@ -142,7 +142,7 @@ func TestScanListElementsToGo(t *testing.T) {
 		return vals, err
 	}
 
-	Test(t, Fn("ScanListElementsToGo", scanListElementsToGo), Table{
+	tt.Test(t, tt.Fn("ScanListElementsToGo", scanListElementsToGo), tt.Table{
 		Args(MakeList("1", "2"), 0, 0).Rets([]any{1, 2}),
 		Args(MakeList("1", "2"), "", "").Rets([]any{"1", "2"}),
 		Args(MakeList("1", "2"), 0, Optional(0)).Rets([]any{1, 2}),
@@ -176,7 +176,7 @@ func TestScanMapToGo(t *testing.T) {
 		return ptr.Elem().Interface(), err
 	}
 
-	Test(t, Fn("ScanListToGo", scanMapToGo), Table{
+	tt.Test(t, tt.Fn("ScanListToGo", scanMapToGo), tt.Table{
 		Args(MakeMap("foo", "1"), aStruct{}).Rets(aStruct{Foo: 1}),
 		// More fields is OK
 		Args(MakeMap("foo", "1", "bar", "x"), aStruct{}).Rets(aStruct{Foo: 1}),
@@ -192,7 +192,7 @@ func TestScanMapToGo(t *testing.T) {
 }
 
 func TestFromGo(t *testing.T) {
-	Test(t, Fn("FromGo", FromGo), Table{
+	tt.Test(t, tt.Fn("FromGo", FromGo), tt.Table{
 		// BigInt -> int, when in range
 		Args(bigInt(z)).Rets(bigInt(z)),
 		Args(big.NewInt(100)).Rets(100),

--- a/pkg/eval/vals/dissoc_test.go
+++ b/pkg/eval/vals/dissoc_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type dissocer struct{}
@@ -11,7 +11,7 @@ type dissocer struct{}
 func (dissocer) Dissoc(any) any { return "custom ret" }
 
 func TestDissoc(t *testing.T) {
-	Test(t, Fn("Dissoc", Dissoc), Table{
+	tt.Test(t, tt.Fn("Dissoc", Dissoc), tt.Table{
 		Args(MakeMap("k1", "v1", "k2", "v2"), "k1").Rets(eq(MakeMap("k2", "v2"))),
 		Args(dissocer{}, "x").Rets("custom ret"),
 		Args("", "x").Rets(nil),

--- a/pkg/eval/vals/equal_test.go
+++ b/pkg/eval/vals/equal_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type customEqualer struct{ ret bool }
@@ -15,7 +15,7 @@ func (c customEqualer) Equal(any) bool { return c.ret }
 type customStruct struct{ a, b string }
 
 func TestEqual(t *testing.T) {
-	Test(t, Fn("Equal", Equal), Table{
+	tt.Test(t, tt.Fn("Equal", Equal), tt.Table{
 		Args(nil, nil).Rets(true),
 		Args(nil, "").Rets(false),
 

--- a/pkg/eval/vals/errors_test.go
+++ b/pkg/eval/vals/errors_test.go
@@ -3,11 +3,11 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestErrors(t *testing.T) {
-	Test(t, Fn("error.Error", error.Error), Table{
+	tt.Test(t, tt.Fn("error.Error", error.Error), tt.Table{
 		Args(cannotIterate{"num"}).Rets("cannot iterate num"),
 		Args(cannotIterateKeysOf{"num"}).Rets("cannot iterate keys of num"),
 	})

--- a/pkg/eval/vals/has_key_test.go
+++ b/pkg/eval/vals/has_key_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type hasKeyer struct{ key any }
@@ -11,7 +11,7 @@ type hasKeyer struct{ key any }
 func (h hasKeyer) HasKey(k any) bool { return k == h.key }
 
 func TestHasKey(t *testing.T) {
-	Test(t, Fn("HasKey", HasKey), Table{
+	tt.Test(t, tt.Fn("HasKey", HasKey), tt.Table{
 		// Map
 		Args(MakeMap("k", "v"), "k").Rets(true),
 		Args(MakeMap("k", "v"), "bad").Rets(false),

--- a/pkg/eval/vals/hash_test.go
+++ b/pkg/eval/vals/hash_test.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 
 	"src.elv.sh/pkg/persistent/hash"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type hasher struct{}
@@ -23,7 +23,7 @@ func TestHash(t *testing.T) {
 	z.Add(z, big.NewInt(9))
 	// z = 5 << wordSize + 9
 
-	Test(t, Fn("Hash", Hash), Table{
+	tt.Test(t, tt.Fn("Hash", Hash), tt.Table{
 		Args(false).Rets(uint32(0)),
 		Args(true).Rets(uint32(1)),
 		Args(1).Rets(uint32(1)),

--- a/pkg/eval/vals/index_test.go
+++ b/pkg/eval/vals/index_test.go
@@ -6,7 +6,7 @@ import (
 
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 var (
@@ -16,13 +16,13 @@ var (
 )
 
 func TestIndex(t *testing.T) {
-	Test(t, Fn("Index", Index), Table{
+	tt.Test(t, tt.Fn("Index", Index), tt.Table{
 		// String indices
 		Args("abc", "0").Rets("a", nil),
 		Args("abc", 0).Rets("a", nil),
 		Args("你好", "0").Rets("你", nil),
 		Args("你好", "3").Rets("好", nil),
-		Args("你好", "2").Rets(Any, errIndexNotAtRuneBoundary),
+		Args("你好", "2").Rets(tt.Any, errIndexNotAtRuneBoundary),
 		// String slices with half-open range.
 		Args("abc", "1..2").Rets("b", nil),
 		Args("abc", "1..").Rets("bc", nil),
@@ -36,8 +36,8 @@ func TestIndex(t *testing.T) {
 		Args("abc", "..=").Rets("abc", nil),
 		Args("abc", "..=-1").Rets("abc", nil),
 		// String slices not at rune boundary.
-		Args("你好", "2..").Rets(Any, errIndexNotAtRuneBoundary),
-		Args("你好", "..2").Rets(Any, errIndexNotAtRuneBoundary),
+		Args("你好", "2..").Rets(tt.Any, errIndexNotAtRuneBoundary),
+		Args("你好", "..2").Rets(tt.Any, errIndexNotAtRuneBoundary),
 
 		// List indices
 		// ============
@@ -45,23 +45,23 @@ func TestIndex(t *testing.T) {
 		// Simple indices: 0 <= i < n.
 		Args(li4, "0").Rets("foo", nil),
 		Args(li4, "3").Rets("ipsum", nil),
-		Args(li0, "0").Rets(Any, errs.OutOfRange{
+		Args(li0, "0").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "-1", Actual: "0"}),
-		Args(li4, "4").Rets(Any, errs.OutOfRange{
+		Args(li4, "4").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "3", Actual: "4"}),
-		Args(li4, "5").Rets(Any, errs.OutOfRange{
+		Args(li4, "5").Rets(tt.Any, errs.OutOfRange{
 			What: "index", ValidLow: "0", ValidHigh: "3", Actual: "5"}),
-		Args(li4, z).Rets(Any,
+		Args(li4, z).Rets(tt.Any,
 			errs.OutOfRange{What: "index", ValidLow: "0", ValidHigh: "3", Actual: z}),
 		// Negative indices: -n <= i < 0.
 		Args(li4, "-1").Rets("ipsum", nil),
 		Args(li4, "-4").Rets("foo", nil),
-		Args(li4, "-5").Rets(Any, errs.OutOfRange{
+		Args(li4, "-5").Rets(tt.Any, errs.OutOfRange{
 			What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-5"}),
-		Args(li4, "-"+z).Rets(Any,
+		Args(li4, "-"+z).Rets(tt.Any,
 			errs.OutOfRange{What: "negative index", ValidLow: "-4", ValidHigh: "-1", Actual: "-" + z}),
 		// Float indices are not allowed even if the value is an integer.
-		Args(li4, 0.0).Rets(Any, errIndexMustBeInteger),
+		Args(li4, 0.0).Rets(tt.Any, errIndexMustBeInteger),
 
 		// Integer indices are allowed.
 		Args(li4, 0).Rets("foo", nil),
@@ -110,15 +110,15 @@ func TestIndex(t *testing.T) {
 				ValidLow: "-1", ValidHigh: "-1", Actual: "-2"}),
 
 		// Malformed list indices.
-		Args(li4, "a").Rets(Any, errIndexMustBeInteger),
+		Args(li4, "a").Rets(tt.Any, errIndexMustBeInteger),
 		// TODO(xiaq): Make the error more accurate.
-		Args(li4, "1:3:2").Rets(Any, errIndexMustBeInteger),
+		Args(li4, "1:3:2").Rets(tt.Any, errIndexMustBeInteger),
 
 		// Map indices
 		// ============
 
 		Args(m, "foo").Rets("bar", nil),
-		Args(m, "bad").Rets(Any, NoSuchKey("bad")),
+		Args(m, "bad").Rets(tt.Any, NoSuchKey("bad")),
 
 		// Not indexable
 		Args(1, "foo").Rets(nil, errNotIndexable),
@@ -132,7 +132,7 @@ func TestIndex_File(t *testing.T) {
 		t.Skip("create file:", err)
 	}
 
-	Test(t, Fn("Index", Index), Table{
+	tt.Test(t, tt.Fn("Index", Index), tt.Table{
 		Args(f, "fd").Rets(int(f.Fd()), nil),
 		Args(f, "name").Rets(f.Name(), nil),
 		Args(f, "x").Rets(nil, NoSuchKey("x")),

--- a/pkg/eval/vals/iterate_keys_test.go
+++ b/pkg/eval/vals/iterate_keys_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func vs(xs ...any) []any { return xs }
@@ -17,11 +17,11 @@ func (k keysIterator) IterateKeys(f func(any) bool) {
 type nonKeysIterator struct{}
 
 func TestIterateKeys(t *testing.T) {
-	Test(t, Fn("collectKeys", collectKeys), Table{
+	tt.Test(t, tt.Fn("collectKeys", collectKeys), tt.Table{
 		Args(MakeMap("k1", "v1", "k2", "v2")).Rets(vs("k1", "k2"), nil),
 		Args(keysIterator{vs("lorem", "ipsum")}).Rets(vs("lorem", "ipsum")),
 		Args(nonKeysIterator{}).Rets(
-			Any, cannotIterateKeysOf{"!!vals.nonKeysIterator"}),
+			tt.Any, cannotIterateKeysOf{"!!vals.nonKeysIterator"}),
 	})
 }
 

--- a/pkg/eval/vals/iterate_test.go
+++ b/pkg/eval/vals/iterate_test.go
@@ -3,7 +3,7 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // An implementation of Iterator.
@@ -17,7 +17,7 @@ func (i iterator) Iterate(f func(any) bool) {
 type nonIterator struct{}
 
 func TestCanIterate(t *testing.T) {
-	Test(t, Fn("CanIterate", CanIterate), Table{
+	tt.Test(t, tt.Fn("CanIterate", CanIterate), tt.Table{
 		Args("foo").Rets(true),
 		Args(MakeList("foo", "bar")).Rets(true),
 		Args(iterator{vs("a", "b")}).Rets(true),
@@ -26,7 +26,7 @@ func TestCanIterate(t *testing.T) {
 }
 
 func TestCollect(t *testing.T) {
-	Test(t, Fn("Collect", Collect), Table{
+	tt.Test(t, tt.Fn("Collect", Collect), tt.Table{
 		Args("foo").Rets(vs("f", "o", "o"), nil),
 		Args(MakeList("foo", "bar")).Rets(vs("foo", "bar"), nil),
 		Args(iterator{vs("a", "b")}).Rets(vs("a", "b"), nil),

--- a/pkg/eval/vals/kind_test.go
+++ b/pkg/eval/vals/kind_test.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type xtype int
 
 func TestKind(t *testing.T) {
-	Test(t, Fn("Kind", Kind), Table{
+	tt.Test(t, tt.Fn("Kind", Kind), tt.Table{
 		Args(nil).Rets("nil"),
 		Args(true).Rets("bool"),
 		Args("").Rets("string"),
@@ -22,9 +22,7 @@ func TestKind(t *testing.T) {
 		Args(os.Stdin).Rets("file"),
 		Args(EmptyList).Rets("list"),
 		Args(EmptyMap).Rets("map"),
-
 		Args(xtype(0)).Rets("!!vals.xtype"),
-
 		Args(os.Stdin).Rets("file"),
 	})
 }

--- a/pkg/eval/vals/len_test.go
+++ b/pkg/eval/vals/len_test.go
@@ -3,11 +3,11 @@ package vals
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestLen(t *testing.T) {
-	Test(t, Fn("Len", Len), Table{
+	tt.Test(t, tt.Fn("Len", Len), tt.Table{
 		Args("foobar").Rets(6),
 		Args(10).Rets(-1),
 	})

--- a/pkg/eval/vals/num_test.go
+++ b/pkg/eval/vals/num_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/testutil"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 // Test utilities.
@@ -25,7 +25,7 @@ const (
 )
 
 func TestParseNum(t *testing.T) {
-	Test(t, Fn("ParseNum", ParseNum), Table{
+	tt.Test(t, tt.Fn("ParseNum", ParseNum), tt.Table{
 		Args("1").Rets(1),
 
 		Args(z).Rets(bigInt(z)),
@@ -43,7 +43,7 @@ func TestParseNum(t *testing.T) {
 }
 
 func TestUnifyNums(t *testing.T) {
-	Test(t, Fn("UnifyNums", UnifyNums), Table{
+	tt.Test(t, tt.Fn("UnifyNums", UnifyNums), tt.Table{
 		Args([]Num{1, 2, 3, 4}, Int).
 			Rets([]int{1, 2, 3, 4}),
 
@@ -74,18 +74,17 @@ func TestUnifyNums(t *testing.T) {
 }
 
 func TestUnifyNums2(t *testing.T) {
-	Test(t, Fn("UnifyNums2", UnifyNums2), Table{
+	tt.Test(t, tt.Fn("UnifyNums2", UnifyNums2), tt.Table{
 		Args(1, 2, Int).Rets(1, 2),
 		Args(1, bigInt(z), Int).Rets(big.NewInt(1), bigInt(z)),
 		Args(1, big.NewRat(1, 2), Int).Rets(big.NewRat(1, 1), big.NewRat(1, 2)),
 		Args(1, 2.0, Int).Rets(1.0, 2.0),
-
 		Args(1, 2, BigInt).Rets(big.NewInt(1), big.NewInt(2)),
 	})
 }
 
 func TestInvalidNumType(t *testing.T) {
-	Test(t, Fn("Recover", testutil.Recover), Table{
+	tt.Test(t, tt.Fn("Recover", testutil.Recover), tt.Table{
 		Args(func() { UnifyNums([]Num{int32(0)}, 0) }).Rets("invalid num type int32"),
 		Args(func() { PromoteToBigInt(int32(0)) }).Rets("invalid num type int32"),
 		Args(func() { PromoteToBigRat(int32(0)) }).Rets("invalid num type int32"),

--- a/pkg/eval/vals/repr_test.go
+++ b/pkg/eval/vals/repr_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 type reprer struct{}
@@ -16,7 +16,7 @@ func (reprer) Repr(int) string { return "<reprer>" }
 type nonReprer struct{}
 
 func TestReprPlain(t *testing.T) {
-	Test(t, Fn("ReprPlain", ReprPlain), Table{
+	tt.Test(t, tt.Fn("ReprPlain", ReprPlain), tt.Table{
 		Args(nil).Rets("$nil"),
 
 		Args(false).Rets("$false"),

--- a/pkg/eval/vals/string_test.go
+++ b/pkg/eval/vals/string_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestToString(t *testing.T) {
-	Test(t, Fn("ToString", ToString), Table{
+	tt.Test(t, tt.Fn("ToString", ToString), tt.Table{
 		// string
 		Args("a").Rets("a"),
 

--- a/pkg/eval/vals/testutils_test.go
+++ b/pkg/eval/vals/testutils_test.go
@@ -1,6 +1,8 @@
 package vals
 
-import "src.elv.sh/pkg/tt"
+import (
+	"src.elv.sh/pkg/tt"
+)
 
 // Returns a tt.Matcher that matches using the Equal function.
 func eq(r any) tt.Matcher { return equalMatcher{r} }

--- a/pkg/eval/var_parse_test.go
+++ b/pkg/eval/var_parse_test.go
@@ -8,8 +8,6 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
-var Args = tt.Args
-
 func TestSplitSigil(t *testing.T) {
 	tt.Test(t, tt.Fn("SplitSigil", SplitSigil), tt.Table{
 		Args("").Rets("", ""),

--- a/pkg/eval/vars/blackhole_test.go
+++ b/pkg/eval/vars/blackhole_test.go
@@ -6,6 +6,8 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestBlackhole(t *testing.T) {
 	v := NewBlackhole()
 	err := v.Set("foo")
@@ -20,7 +22,7 @@ func TestBlackhole(t *testing.T) {
 
 func TestIsBlackhole(t *testing.T) {
 	tt.Test(t, tt.Fn("IsBlackhole", IsBlackhole), tt.Table{
-		tt.Args(NewBlackhole()).Rets(true),
-		tt.Args(FromInit("")).Rets(false),
+		Args(NewBlackhole()).Rets(true),
+		Args(FromInit("")).Rets(false),
 	})
 }

--- a/pkg/eval/vars/read_only_test.go
+++ b/pkg/eval/vars/read_only_test.go
@@ -7,8 +7,6 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
-var Args = tt.Args
-
 func TestNewReadOnly(t *testing.T) {
 	v := NewReadOnly("haha")
 	if v.Get() != "haha" {

--- a/pkg/fsutil/claim_test.go
+++ b/pkg/fsutil/claim_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 var claimFileTests = []struct {
@@ -20,13 +20,13 @@ var claimFileTests = []struct {
 }
 
 func TestClaimFile(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
-	ApplyDir(Dir{
+	testutil.ApplyDir(testutil.Dir{
 		"a0.log": "",
 		"a1.log": "",
 		"a8.log": "",
-		"d":      Dir{}})
+		"d":      testutil.Dir{}})
 
 	for _, test := range claimFileTests {
 		name := claimFileAndGetName(test.dir, test.pattern)
@@ -37,7 +37,7 @@ func TestClaimFile(t *testing.T) {
 }
 
 func TestClaimFile_Concurrent(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
 	n := 9
 	ch := make(chan string, n)

--- a/pkg/parse/error_test.go
+++ b/pkg/parse/error_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/diag"
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
+
+var Args = tt.Args
 
 func TestGetError(t *testing.T) {
 	parseError := makeError()
-	Test(t, Fn("GetError", GetError), Table{
+	tt.Test(t, tt.Fn("GetError", GetError), tt.Table{
 		Args(parseError).Rets(parseError),
 		Args(errors.New("random error")).Rets((*Error)(nil)),
 	})

--- a/pkg/parse/pprint_test.go
+++ b/pkg/parse/pprint_test.go
@@ -10,7 +10,7 @@ import (
 var n = mustParse("ls $x[0]$y[1];echo done >/redir-dest")
 
 var pprintASTTests = tt.Table{
-	tt.Args(n).Rets(
+	Args(n).Rets(
 		`Chunk
   Pipeline/Form
     Compound/Indexing/Primary ExprCtx=CmdExpr Type=Bareword Value="ls"
@@ -38,7 +38,7 @@ func TestPPrintAST(t *testing.T) {
 }
 
 var pprintParseTreeTests = tt.Table{
-	tt.Args(n).Rets(
+	Args(n).Rets(
 		`Chunk "ls $x[0]$y...redir-dest" 0-36
   Pipeline/Form "ls $x[0]$y[1]" 0-13
     Compound/Indexing/Primary "ls" 0-2

--- a/pkg/parse/quote_test.go
+++ b/pkg/parse/quote_test.go
@@ -3,11 +3,11 @@ package parse
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestQuote(t *testing.T) {
-	Test(t, Fn("Quote", Quote).ArgsFmt("(%q)"), Table{
+	tt.Test(t, tt.Fn("Quote", Quote).ArgsFmt("(%q)"), tt.Table{
 		// Empty string is single-quoted.
 		Args("").Rets(`''`),
 
@@ -37,7 +37,7 @@ func TestQuote(t *testing.T) {
 }
 
 func TestQuoteAs(t *testing.T) {
-	Test(t, Fn("QuoteAs", QuoteAs).ArgsFmt("(%q, %s)"), Table{
+	tt.Test(t, tt.Fn("QuoteAs", QuoteAs).ArgsFmt("(%q, %s)"), tt.Table{
 		// DoubleQuote is always respected.
 		Args("", DoubleQuoted).Rets(`""`, DoubleQuoted),
 		Args("a", DoubleQuoted).Rets(`"a"`, DoubleQuoted),
@@ -52,7 +52,7 @@ func TestQuoteAs(t *testing.T) {
 }
 
 func TestQuoteVariableName(t *testing.T) {
-	Test(t, Fn("QuoteVariableName", QuoteVariableName).ArgsFmt("(%q)"), Table{
+	tt.Test(t, tt.Fn("QuoteVariableName", QuoteVariableName).ArgsFmt("(%q)"), tt.Table{
 		Args("").Rets("''"),
 		Args("foo").Rets("foo"),
 		Args("a/b").Rets("'a/b'"),

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/eval/vals"
-	. "src.elv.sh/pkg/parse"
+	"src.elv.sh/pkg/parse"
 )
 
 func TestSourceAsStructMap(t *testing.T) {
-	vals.TestValue(t, Source{Name: "[tty]", Code: "echo"}).
+	vals.TestValue(t, parse.Source{Name: "[tty]", Code: "echo"}).
 		Kind("structmap").
 		Repr("[&name='[tty]' &code=<...> &is-file=$false]").
 		AllKeys("name", "code", "is-file")
 
-	vals.TestValue(t, Source{Name: "/etc/rc.elv", Code: "echo", IsFile: true}).
+	vals.TestValue(t, parse.Source{Name: "/etc/rc.elv", Code: "echo", IsFile: true}).
 		Index("is-file", true)
 }

--- a/pkg/shell/interact_test.go
+++ b/pkg/shell/interact_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestInteract(t *testing.T) {
 	setupHomePaths(t)
-	InTempDir(t)
-	MustWriteFile("rc.elv", "echo hello from rc.elv")
-	MustWriteFile("rc-dnc.elv", "echo $a")
-	MustWriteFile("rc-fail.elv", "fail bad")
+	testutil.InTempDir(t)
+	testutil.MustWriteFile("rc.elv", "echo hello from rc.elv")
+	testutil.MustWriteFile("rc-dnc.elv", "echo $a")
+	testutil.MustWriteFile("rc-fail.elv", "fail bad")
 
 	Test(t, &Program{},
 		thatElvishInteract().WithStdin("echo hello\n").WritesStdout("hello\n"),
@@ -33,7 +33,7 @@ func TestInteract(t *testing.T) {
 func TestInteract_DefaultRCPath(t *testing.T) {
 	home := setupHomePaths(t)
 	// Legacy RC path
-	MustWriteFile(
+	testutil.MustWriteFile(
 		filepath.Join(home, ".elvish", "rc.elv"), "echo hello legacy rc.elv")
 	// Note: non-legacy path is tested in interact_unix_test.go
 

--- a/pkg/shell/interact_unix_test.go
+++ b/pkg/shell/interact_unix_test.go
@@ -13,12 +13,12 @@ import (
 	"src.elv.sh/pkg/env"
 
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestInteract_NewRcFile_Default(t *testing.T) {
 	home := setupHomePaths(t)
-	MustWriteFile(
+	testutil.MustWriteFile(
 		filepath.Join(home, ".config", "elvish", "rc.elv"), "echo hello new rc.elv")
 
 	Test(t, &Program{},
@@ -28,8 +28,8 @@ func TestInteract_NewRcFile_Default(t *testing.T) {
 
 func TestInteract_NewRcFile_XDG_CONFIG_HOME(t *testing.T) {
 	setupHomePaths(t)
-	xdgConfigHome := Setenv(t, env.XDG_CONFIG_HOME, TempDir(t))
-	MustWriteFile(
+	xdgConfigHome := testutil.Setenv(t, env.XDG_CONFIG_HOME, testutil.TempDir(t))
+	testutil.MustWriteFile(
 		filepath.Join(xdgConfigHome, "elvish", "rc.elv"),
 		"echo hello XDG_CONFIG_HOME rc.elv")
 
@@ -39,14 +39,14 @@ func TestInteract_NewRcFile_XDG_CONFIG_HOME(t *testing.T) {
 }
 
 func TestInteract_ConnectsToDaemon(t *testing.T) {
-	InTempDir(t)
+	testutil.InTempDir(t)
 
 	// Run the daemon in the same process for simplicity.
 	daemonDone := make(chan struct{})
 	defer func() {
 		select {
 		case <-daemonDone:
-		case <-time.After(Scaled(2 * time.Second)):
+		case <-time.After(testutil.Scaled(2 * time.Second)):
 			t.Errorf("timed out waiting for daemon to quit")
 		}
 	}()
@@ -58,7 +58,7 @@ func TestInteract_ConnectsToDaemon(t *testing.T) {
 	select {
 	case <-readyCh:
 		// Do nothing
-	case <-time.After(Scaled(2 * time.Second)):
+	case <-time.After(testutil.Scaled(2 * time.Second)):
 		t.Fatalf("timed out waiting for daemon to start")
 	}
 

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -7,12 +7,12 @@ import (
 
 	"src.elv.sh/pkg/env"
 	. "src.elv.sh/pkg/prog/progtest"
-	. "src.elv.sh/pkg/testutil"
+	"src.elv.sh/pkg/testutil"
 )
 
 func TestShell_LegacyLibPath(t *testing.T) {
 	home := setupHomePaths(t)
-	MustWriteFile(filepath.Join(home, ".elvish", "lib", "a.elv"), "echo mod a")
+	testutil.MustWriteFile(filepath.Join(home, ".elvish", "lib", "a.elv"), "echo mod a")
 
 	Test(t, &Program{},
 		ThatElvish("-c", "use a").WritesStdout("mod a\n"),
@@ -45,7 +45,7 @@ var incSHLVLTests = []struct {
 }
 
 func TestIncSHLVL(t *testing.T) {
-	Setenv(t, env.SHLVL, "")
+	testutil.Setenv(t, env.SHLVL, "")
 
 	for _, test := range incSHLVLTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -79,8 +79,8 @@ func TestIncSHLVL(t *testing.T) {
 
 // Common test utilities.
 
-func setupHomePaths(t Cleanuper) string {
-	Unsetenv(t, env.XDG_CONFIG_HOME)
-	Unsetenv(t, env.XDG_DATA_HOME)
-	return TempHome(t)
+func setupHomePaths(t testutil.Cleanuper) string {
+	testutil.Unsetenv(t, env.XDG_CONFIG_HOME)
+	testutil.Unsetenv(t, env.XDG_DATA_HOME)
+	return testutil.TempHome(t)
 }

--- a/pkg/strutil/camel_to_dashed_test.go
+++ b/pkg/strutil/camel_to_dashed_test.go
@@ -3,11 +3,13 @@ package strutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestCamelToDashed(t *testing.T) {
-	Test(t, Fn("CamelToDashed", CamelToDashed), Table{
+	tt.Test(t, tt.Fn("CamelToDashed", CamelToDashed), tt.Table{
 		Args("CamelCase").Rets("camel-case"),
 		Args("camelCase").Rets("-camel-case"),
 		Args("HTTP").Rets("http"),

--- a/pkg/strutil/chop_test.go
+++ b/pkg/strutil/chop_test.go
@@ -3,11 +3,11 @@ package strutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
 func TestChopLineEnding(t *testing.T) {
-	Test(t, Fn("ChopLineEnding", ChopLineEnding), Table{
+	tt.Test(t, tt.Fn("ChopLineEnding", ChopLineEnding), tt.Table{
 		Args("").Rets(""),
 		Args("text").Rets("text"),
 		Args("text\n").Rets("text"),
@@ -20,7 +20,7 @@ func TestChopLineEnding(t *testing.T) {
 }
 
 func TestChopTerminator(t *testing.T) {
-	Test(t, Fn("ChopTerminator", ChopTerminator), Table{
+	tt.Test(t, tt.Fn("ChopTerminator", ChopTerminator), tt.Table{
 		Args("", byte('\x00')).Rets(""),
 		Args("foo", byte('\x00')).Rets("foo"),
 		Args("foo\x00", byte('\x00')).Rets("foo"),

--- a/pkg/testutil/recover_test.go
+++ b/pkg/testutil/recover_test.go
@@ -3,11 +3,13 @@ package testutil
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/tt"
+	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestRecover(t *testing.T) {
-	Test(t, Fn("Recover", Recover), Table{
+	tt.Test(t, tt.Fn("Recover", Recover), tt.Table{
 		Args(func() {}).Rets(nil),
 		Args(func() {
 			panic("unreachable")

--- a/pkg/ui/mark_lines_test.go
+++ b/pkg/ui/mark_lines_test.go
@@ -6,14 +6,16 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
+var Args = tt.Args
+
 func TestMarkLines(t *testing.T) {
 	stylesheet := RuneStylesheet{
 		'-': Inverse,
 		'x': Stylings(FgBlue, BgGreen),
 	}
 	tt.Test(t, tt.Fn("MarkLines", MarkLines), tt.Table{
-		tt.Args("foo  bar foobar").Rets(T("foo  bar foobar")),
-		tt.Args(
+		Args("foo  bar foobar").Rets(T("foo  bar foobar")),
+		Args(
 			"foo  bar foobar", stylesheet,
 			"---  xxx ------",
 		).Rets(
@@ -24,7 +26,7 @@ func TestMarkLines(t *testing.T) {
 				T(" "),
 				T("foobar", Inverse)),
 		),
-		tt.Args(
+		Args(
 			"foo  bar foobar", stylesheet,
 			"---",
 		).Rets(
@@ -32,7 +34,7 @@ func TestMarkLines(t *testing.T) {
 				T("foo", Inverse),
 				T("  bar foobar")),
 		),
-		tt.Args(
+		Args(
 			"plain1",
 			"plain2",
 			"foo  bar foobar\n", stylesheet,

--- a/pkg/ui/parse_sgr_test.go
+++ b/pkg/ui/parse_sgr_test.go
@@ -8,36 +8,36 @@ import (
 
 func TestParseSGREscapedText(t *testing.T) {
 	tt.Test(t, tt.Fn("ParseSGREscapedText", ParseSGREscapedText), tt.Table{
-		tt.Args("").Rets(Text(nil)),
-		tt.Args("text").Rets(T("text")),
-		tt.Args("\033[1mbold").Rets(T("bold", Bold)),
-		tt.Args("\033[1mbold\033[31mbold red").Rets(
+		Args("").Rets(Text(nil)),
+		Args("text").Rets(T("text")),
+		Args("\033[1mbold").Rets(T("bold", Bold)),
+		Args("\033[1mbold\033[31mbold red").Rets(
 			Concat(T("bold", Bold), T("bold red", Bold, FgRed))),
-		tt.Args("\033[1mbold\033[;31mred").Rets(
+		Args("\033[1mbold\033[;31mred").Rets(
 			Concat(T("bold", Bold), T("red", FgRed))),
 		// Non-SGR CSI sequences are removed.
-		tt.Args("\033[Atext").Rets(T("text")),
+		Args("\033[Atext").Rets(T("text")),
 		// Control characters not part of CSI escape sequences are left
 		// untouched.
-		tt.Args("t\x01ext").Rets(T("t\x01ext")),
+		Args("t\x01ext").Rets(T("t\x01ext")),
 	})
 }
 
 func TestStyleFromSGR(t *testing.T) {
 	tt.Test(t, tt.Fn("StyleFromSGR", StyleFromSGR), tt.Table{
-		tt.Args("1").Rets(Style{Bold: true}),
+		Args("1").Rets(Style{Bold: true}),
 		// Invalid codes are ignored
-		tt.Args("1;invalid;10000").Rets(Style{Bold: true}),
+		Args("1;invalid;10000").Rets(Style{Bold: true}),
 		// ANSI colors.
-		tt.Args("31;42").Rets(Style{Foreground: Red, Background: Green}),
+		Args("31;42").Rets(Style{Foreground: Red, Background: Green}),
 		// ANSI bright colors.
-		tt.Args("91;102").
+		Args("91;102").
 			Rets(Style{Foreground: BrightRed, Background: BrightGreen}),
 		// XTerm 256 color.
-		tt.Args("38;5;1;48;5;2").
+		Args("38;5;1;48;5;2").
 			Rets(Style{Foreground: XTerm256Color(1), Background: XTerm256Color(2)}),
 		// True colors.
-		tt.Args("38;2;1;2;3;48;2;10;20;30").
+		Args("38;2;1;2;3;48;2;10;20;30").
 			Rets(Style{
 				Foreground: TrueColor(1, 2, 3), Background: TrueColor(10, 20, 30)}),
 	})

--- a/pkg/ui/style_regions_test.go
+++ b/pkg/ui/style_regions_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"src.elv.sh/pkg/diag"
-	. "src.elv.sh/pkg/ui"
+	"src.elv.sh/pkg/ui"
 )
 
 var styleRegionsTests = []struct {
 	Name     string
 	String   string
-	Regions  []StylingRegion
-	WantText Text
+	Regions  []ui.StylingRegion
+	WantText ui.Text
 }{
 	{
 		Name:   "empty string and regions",
@@ -21,48 +21,48 @@ var styleRegionsTests = []struct {
 	{
 		Name:   "a single region",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("bar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("bar")),
 	},
 
 	{
 		Name:   "multiple continuous regions",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(3, 4), FgGreen, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(3, 4), ui.FgGreen, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("b", FgGreen), T("ar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("b", ui.FgGreen), ui.T("ar")),
 	},
 
 	{
 		Name:   "multiple discontinuous regions in wrong order",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(4, 5), FgGreen, 0},
-			{r(1, 3), FgRed, 0},
+		Regions: []ui.StylingRegion{
+			{r(4, 5), ui.FgGreen, 0},
+			{r(1, 3), ui.FgRed, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("b"), T("a", FgGreen), T("r")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("b"), ui.T("a", ui.FgGreen), ui.T("r")),
 	},
 	{
 		Name:   "regions with the same starting position but differeng priorities",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(1, 2), FgGreen, 1},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(1, 2), ui.FgGreen, 1},
 		},
-		WantText: Concat(T("f"), T("o", FgGreen), T("obar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("o", ui.FgGreen), ui.T("obar")),
 	},
 	{
 		Name:   "overlapping regions with different starting positions",
 		String: "foobar",
-		Regions: []StylingRegion{
-			{r(1, 3), FgRed, 0},
-			{r(2, 4), FgGreen, 0},
+		Regions: []ui.StylingRegion{
+			{r(1, 3), ui.FgRed, 0},
+			{r(2, 4), ui.FgGreen, 0},
 		},
-		WantText: Concat(T("f"), T("oo", FgRed), T("bar")),
+		WantText: ui.Concat(ui.T("f"), ui.T("oo", ui.FgRed), ui.T("bar")),
 	},
 }
 
@@ -70,7 +70,7 @@ func r(a, b int) diag.Ranging { return diag.Ranging{From: a, To: b} }
 
 func TestStyleRegions(t *testing.T) {
 	for _, test := range styleRegionsTests {
-		text := StyleRegions(test.String, test.Regions)
+		text := ui.StyleRegions(test.String, test.Regions)
 		if !reflect.DeepEqual(text, test.WantText) {
 			t.Errorf("got %v, want %v", text, test.WantText)
 		}

--- a/pkg/ui/styling_test.go
+++ b/pkg/ui/styling_test.go
@@ -10,13 +10,13 @@ import (
 func TestStyleText(t *testing.T) {
 	tt.Test(t, tt.Fn("StyleText", StyleText), tt.Table{
 		// Foreground color
-		tt.Args(T("foo"), FgRed).
+		Args(T("foo"), FgRed).
 			Rets(Text{&Segment{Style{Foreground: Red}, "foo"}}),
 		// Override existing foreground
-		tt.Args(Text{&Segment{Style{Foreground: Green}, "foo"}}, FgRed).
+		Args(Text{&Segment{Style{Foreground: Green}, "foo"}}, FgRed).
 			Rets(Text{&Segment{Style{Foreground: Red}, "foo"}}),
 		// Multiple segments
-		tt.Args(Text{
+		Args(Text{
 			&Segment{Style{}, "foo"},
 			&Segment{Style{Foreground: Green}, "bar"}}, FgRed).
 			Rets(Text{
@@ -24,41 +24,41 @@ func TestStyleText(t *testing.T) {
 				&Segment{Style{Foreground: Red}, "bar"},
 			}),
 		// Background color
-		tt.Args(T("foo"), BgRed).
+		Args(T("foo"), BgRed).
 			Rets(Text{&Segment{Style{Background: Red}, "foo"}}),
 		// Bold, false -> true
-		tt.Args(T("foo"), Bold).
+		Args(T("foo"), Bold).
 			Rets(Text{&Segment{Style{Bold: true}, "foo"}}),
 		// Bold, true -> true
-		tt.Args(Text{&Segment{Style{Bold: true}, "foo"}}, Bold).
+		Args(Text{&Segment{Style{Bold: true}, "foo"}}, Bold).
 			Rets(Text{&Segment{Style{Bold: true}, "foo"}}),
 		// No Bold, true -> false
-		tt.Args(Text{&Segment{Style{Bold: true}, "foo"}}, NoBold).
+		Args(Text{&Segment{Style{Bold: true}, "foo"}}, NoBold).
 			Rets(Text{&Segment{Style{}, "foo"}}),
 		// No Bold, false -> false
-		tt.Args(T("foo"), NoBold).Rets(T("foo")),
+		Args(T("foo"), NoBold).Rets(T("foo")),
 		// Toggle Bold, true -> false
-		tt.Args(Text{&Segment{Style{Bold: true}, "foo"}}, ToggleBold).
+		Args(Text{&Segment{Style{Bold: true}, "foo"}}, ToggleBold).
 			Rets(Text{&Segment{Style{}, "foo"}}),
 		// Toggle Bold, false -> true
-		tt.Args(T("foo"), ToggleBold).
+		Args(T("foo"), ToggleBold).
 			Rets(Text{&Segment{Style{Bold: true}, "foo"}}),
 		// For the remaining bool transformers, we only check one case; the rest
 		// should be similar to "bold".
 		// Dim.
-		tt.Args(T("foo"), Dim).
+		Args(T("foo"), Dim).
 			Rets(Text{&Segment{Style{Dim: true}, "foo"}}),
 		// Italic.
-		tt.Args(T("foo"), Italic).
+		Args(T("foo"), Italic).
 			Rets(Text{&Segment{Style{Italic: true}, "foo"}}),
 		// Underlined.
-		tt.Args(T("foo"), Underlined).
+		Args(T("foo"), Underlined).
 			Rets(Text{&Segment{Style{Underlined: true}, "foo"}}),
 		// Blink.
-		tt.Args(T("foo"), Blink).
+		Args(T("foo"), Blink).
 			Rets(Text{&Segment{Style{Blink: true}, "foo"}}),
 		// Inverse.
-		tt.Args(T("foo"), Inverse).
+		Args(T("foo"), Inverse).
 			Rets(Text{&Segment{Style{Inverse: true}, "foo"}}),
 		// TODO: Test nil styling.
 	})

--- a/pkg/ui/text_test.go
+++ b/pkg/ui/text_test.go
@@ -7,8 +7,6 @@ import (
 	"src.elv.sh/pkg/tt"
 )
 
-var Args = tt.Args
-
 func TestT(t *testing.T) {
 	tt.Test(t, tt.Fn("T", T), tt.Table{
 		Args("test").Rets(Text{&Segment{Text: "test"}}),


### PR DESCRIPTION
This is based on my earlier P.R. to eliminate unnecessary dot imports and improve consistency. It does not change the dot imports of packages being tested (even if the dot import isn't strictly necessary).