### PR TITLE
Implement edit:command-abbr

### DIFF
--- a/0.19.0-release-notes.md
+++ b/0.19.0-release-notes.md
@@ -1,5 +1,5 @@
 This is the draft release notes for 0.19.0, scheduled to be released around
-2020-07-01.
+2022-07-01.
 
 # Breaking changes
 
@@ -26,3 +26,6 @@ and compiled, even if it is not executed:
     the Go float64 type is the only underlying inexact number type for now. Its
     behavior may change in future if there are more underlying types for inexact
     numbers.
+
+-   A new type of interactive abbreviation: `edit:command-abbr`
+    ([#1472](https://b.elv.sh/1472)).

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -130,15 +130,16 @@ func NewApp(spec AppSpec) App {
 	lp.RedrawCb(a.redraw)
 
 	a.codeArea = tk.NewCodeArea(tk.CodeAreaSpec{
-		Bindings:      spec.CodeAreaBindings,
-		Highlighter:   a.Highlighter.Get,
-		Prompt:        a.Prompt.Get,
-		RPrompt:       a.RPrompt.Get,
-		Abbreviations: spec.Abbreviations,
-		QuotePaste:    spec.QuotePaste,
-		OnSubmit:      a.CommitCode,
-		State:         spec.CodeAreaState,
+		Bindings:    spec.CodeAreaBindings,
+		Highlighter: a.Highlighter.Get,
+		Prompt:      a.Prompt.Get,
+		RPrompt:     a.RPrompt.Get,
+		QuotePaste:  spec.QuotePaste,
+		OnSubmit:    a.CommitCode,
+		State:       spec.CodeAreaState,
 
+		SimpleAbbreviations:    spec.SimpleAbbreviations,
+		CommandAbbreviations:   spec.CommandAbbreviations,
 		SmallWordAbbreviations: spec.SmallWordAbbreviations,
 	})
 

--- a/pkg/cli/app_spec.go
+++ b/pkg/cli/app_spec.go
@@ -19,9 +19,10 @@ type AppSpec struct {
 
 	GlobalBindings   tk.Bindings
 	CodeAreaBindings tk.Bindings
-	Abbreviations    func(f func(abbr, full string))
 	QuotePaste       func() bool
 
+	SimpleAbbreviations    func(f func(abbr, full string))
+	CommandAbbreviations   func(f func(abbr, full string))
 	SmallWordAbbreviations func(f func(abbr, full string))
 
 	CodeAreaState tk.CodeAreaState

--- a/pkg/cli/tk/codearea_test.go
+++ b/pkg/cli/tk/codearea_test.go
@@ -274,7 +274,7 @@ var codeAreaHandleTests = []handleTest{
 	{
 		Name: "abbreviation expansion",
 		Given: NewCodeArea(CodeAreaSpec{
-			Abbreviations: func(f func(abbr, full string)) {
+			SimpleAbbreviations: func(f func(abbr, full string)) {
 				f("dn", "/dev/null")
 			},
 		}),
@@ -284,7 +284,7 @@ var codeAreaHandleTests = []handleTest{
 	{
 		Name: "abbreviation expansion 2",
 		Given: NewCodeArea(CodeAreaSpec{
-			Abbreviations: func(f func(abbr, full string)) {
+			SimpleAbbreviations: func(f func(abbr, full string)) {
 				f("||", " | less")
 			},
 		}),
@@ -294,7 +294,7 @@ var codeAreaHandleTests = []handleTest{
 	{
 		Name: "abbreviation expansion after other content",
 		Given: NewCodeArea(CodeAreaSpec{
-			Abbreviations: func(f func(abbr, full string)) {
+			SimpleAbbreviations: func(f func(abbr, full string)) {
 				f("||", " | less")
 			},
 		}),
@@ -304,7 +304,7 @@ var codeAreaHandleTests = []handleTest{
 	{
 		Name: "abbreviation expansion preferring longest",
 		Given: NewCodeArea(CodeAreaSpec{
-			Abbreviations: func(f func(abbr, full string)) {
+			SimpleAbbreviations: func(f func(abbr, full string)) {
 				f("n", "none")
 				f("dn", "/dev/null")
 			},
@@ -315,7 +315,7 @@ var codeAreaHandleTests = []handleTest{
 	{
 		Name: "abbreviation expansion interrupted by function key",
 		Given: NewCodeArea(CodeAreaSpec{
-			Abbreviations: func(f func(abbr, full string)) {
+			SimpleAbbreviations: func(f func(abbr, full string)) {
 				f("dn", "/dev/null")
 			},
 		}),
@@ -364,6 +364,36 @@ var codeAreaHandleTests = []handleTest{
 		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "gh ", Dot: 3}},
 	},
 	{
+		Name: "command abbreviation expansion",
+		Given: NewCodeArea(CodeAreaSpec{
+			CommandAbbreviations: func(f func(abbr, full string)) {
+				f("eh", "echo hello")
+			},
+		}),
+		Events:       []term.Event{term.K('e'), term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "echo hello ", Dot: 11}},
+	},
+	{
+		Name: "command abbreviation expansion not at start of line",
+		Given: NewCodeArea(CodeAreaSpec{
+			CommandAbbreviations: func(f func(abbr, full string)) {
+				f("eh", "echo hello")
+			},
+		}),
+		Events:       []term.Event{term.K('x'), term.K('|'), term.K('e'), term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "x|echo hello ", Dot: 13}},
+	},
+	{
+		Name: "no command abbreviation expansion when not in command position",
+		Given: NewCodeArea(CodeAreaSpec{
+			CommandAbbreviations: func(f func(abbr, full string)) {
+				f("eh", "echo hello")
+			},
+		}),
+		Events:       []term.Event{term.K('x'), term.K(' '), term.K('e'), term.K('h'), term.K(' ')},
+		WantNewState: CodeAreaState{Buffer: CodeBuffer{Content: "x eh ", Dot: 5}},
+	},
+	{
 		Name: "key bindings",
 		Given: NewCodeArea(CodeAreaSpec{Bindings: MapBindings{
 			term.K('a'): func(w Widget) {
@@ -409,7 +439,7 @@ func TestCodeArea_Handle_UnhandledEvents(t *testing.T) {
 
 func TestCodeArea_Handle_AbbreviationExpansionInterruptedByExternalMutation(t *testing.T) {
 	w := NewCodeArea(CodeAreaSpec{
-		Abbreviations: func(f func(abbr, full string)) {
+		SimpleAbbreviations: func(f func(abbr, full string)) {
 			f("dn", "/dev/null")
 		},
 	})


### PR DESCRIPTION
It turns out that the "small word" abbreviation mechanism I added isn't
really what I, or most users, want. What users really want, at least
most of the time, is the Fish shell abbreviation behavior of expanding
an abbreviation only in the command head position.

Resolves #1472