### PR TITLE
Unless

### DIFF
--- a/0.19.0-release-notes.md
+++ b/0.19.0-release-notes.md
@@ -32,3 +32,6 @@ and compiled, even if it is not executed:
 
 -   A new type of interactive abbreviation: `edit:command-abbr`
     ([#1472](https://b.elv.sh/1472)).
+
+-   New control flow conditional: `unless`
+    ([#1555](https://b.elv.sh/1555)).

--- a/0.19.0-release-notes.md
+++ b/0.19.0-release-notes.md
@@ -33,5 +33,4 @@ and compiled, even if it is not executed:
 -   A new type of interactive abbreviation: `edit:command-abbr`
     ([#1472](https://b.elv.sh/1472)).
 
--   New control flow conditional: `unless`
-    ([#1555](https://b.elv.sh/1555)).
+-   A new control flow conditional `unless` ([#1555](https://b.elv.sh/1555)).

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -315,6 +315,15 @@ func TestIf(t *testing.T) {
 	)
 }
 
+func TestUnless(t *testing.T) {
+	Test(t,
+		That("unless true { put then }").DoesNothing(),
+		That("unless $false { put then }").Puts("then"),
+		// Exception in condition expression
+		That("unless (fail x) { }").Throws(FailError{"x"}, "fail x"),
+	)
+}
+
 func TestTry(t *testing.T) {
 	Test(t,
 		That("try { nop } catch { put bad } else { put good }").Puts("good"),

--- a/pkg/eval/builtin_special_test.go
+++ b/pkg/eval/builtin_special_test.go
@@ -319,6 +319,8 @@ func TestUnless(t *testing.T) {
 	Test(t,
 		That("unless true { put then }").DoesNothing(),
 		That("unless $false { put then }").Puts("then"),
+		That("unless $false { put then } else { put else }").Puts("then"),
+		That("unless $true { put then } else { put else }").Puts("else"),
 		// Exception in condition expression
 		That("unless (fail x) { }").Throws(FailError{"x"}, "fail x"),
 	)

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -1984,8 +1984,8 @@ unless <condition> {
 }
 ```
 
-The `unless` special command evaluates the condition to a booleanly true 
-value and skips its body.
+The `unless` special command evaluates the condition to a booleanly true value
+and skips its body.
 
 The condition part is an expression, not a command like in other shells.
 Example:
@@ -2028,10 +2028,10 @@ unless ?(test -d ~/.asdf) {
 However, for Elvish's builtin predicates that output values instead of throw
 exceptions, the output capture construct `()` should be used.
 
-**Note**: Similarly to the `if` command, the `unless` command itself doesn't 
-introduce a new scope. For example, `unless (var x = foo; put $x) { }` will leave
-the variable `$x` defined. However, the body block introduces a new scope because 
-it is a [lambdas](#function).
+**Note**: Similarly to the `if` command, the `unless` command itself doesn't
+introduce a new scope. For example, `unless (var x = foo; put $x) { }` will
+leave the variable `$x` defined. However, the body block introduces a new scope
+because it is a [lambdas](#function).
 
 ## Conditional loop: `while` {#while}
 

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -1981,11 +1981,14 @@ Syntax:
 ```elvish-transcript
 unless <condition> {
     <body>
+} else {
+    <else-body>
 }
 ```
 
-The `unless` special command evaluates the condition to a booleanly true value
-and skips its body.
+The `unless` special command evaluates the condition to a booleanly true value,
+skips its body and executes the else body, if the else body is present. It is
+the negation of the `if` special command except no `elif` clauses are allowed.
 
 The condition part is an expression, not a command like in other shells.
 Example:
@@ -2010,6 +2013,8 @@ evaluate to multiple values, in which case they are and'ed:
 ```elvish
 unless (put $true $false) {
     echo "will be executed"
+} else {
+    echo "will not be executed"
 }
 ```
 

--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -1972,6 +1972,67 @@ exceptions, the output capture construct `()` should be used.
 `if (var x = foo; put $x) { }` will leave the variable `$x` defined. However,
 the body blocks introduce new scopes because they are [lambdas](#function).
 
+## Condition: `unless` {#unless}
+
+**TODO**: Document the syntax notation, and add more examples.
+
+Syntax:
+
+```elvish-transcript
+unless <condition> {
+    <body>
+}
+```
+
+The `unless` special command evaluates the condition to a booleanly true 
+value and skips its body.
+
+The condition part is an expression, not a command like in other shells.
+Example:
+
+```elvish
+unless (path:is-dir ~/.asdf) {
+    echo "no asdf install found"
+}
+```
+
+Is equivalent to:
+
+```elvish
+if (not (path:is-dir ~/.asdf) {
+   echo "no asdf install found"
+}
+```
+
+The condition part must be syntactically a single expression, but it can
+evaluate to multiple values, in which case they are and'ed:
+
+```elvish
+unless (put $true $false) {
+    echo "will be executed"
+}
+```
+
+If the expression evaluates to 0 values, it is considered true, consistent with
+how `and` works.
+
+Tip: a combination of `unless` and `?()` gives you a semantics close to other
+shells:
+
+```elvish
+unless ?(test -d ~/.asdf) {
+    mkdir ~/.asdf
+}
+```
+
+However, for Elvish's builtin predicates that output values instead of throw
+exceptions, the output capture construct `()` should be used.
+
+**Note**: Similarly to the `if` command, the `unless` command itself doesn't 
+introduce a new scope. For example, `unless (var x = foo; put $x) { }` will leave
+the variable `$x` defined. However, the body block introduces a new scope because 
+it is a [lambdas](#function).
+
 ## Conditional loop: `while` {#while}
 
 Syntax:


### PR DESCRIPTION
I liked `unless` from Common Lisp and Perl and thought it might be handy in Elvish. Of course it's redundant because `if (not <cond> ...` is the same thing, but I think it reads better and is less cumbersome to look at and type (which is probably why it's in Lisp and Perl).

I also have the beginnings of a `when` branch, but I'll wait on feedback for doing anymore with that