### PR TITLE
Fix glob expansion that includes broken symlinks

### DIFF
--- a/0.19.0-release-notes.md
+++ b/0.19.0-release-notes.md
@@ -21,6 +21,9 @@ and compiled, even if it is not executed:
 -   Temporary assignment on an unset environment variables no longer leave it
     set to an empty string ([#1448](https://b.elv.sh/1448)).
 
+-   Glob expansion that includes broken symlinks no longer short-circuits the
+    expansion ([#1240](https://b.elv.sh/1240)).
+
 # Notable new features
 
 -   A new `inexact-num` converts its argument to an inexact number.

--- a/pkg/glob/glob.go
+++ b/pkg/glob/glob.go
@@ -72,19 +72,19 @@ func glob(segs []Segment, dir string, cb func(PathInfo) bool) bool {
 		elem := segs[0].(Literal).Data
 		segs = segs[2:]
 		dir += elem + "/"
-		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		if info, err := os.Lstat(dir); err != nil || !info.IsDir() {
 			return true
 		}
 	}
 
 	if len(segs) == 0 {
-		if info, err := os.Stat(dir); err == nil {
+		if info, err := os.Lstat(dir); err == nil {
 			return cb(PathInfo{dir, info})
 		}
 		return true
 	} else if len(segs) == 1 && IsLiteral(segs[0]) {
 		path := dir + segs[0].(Literal).Data
-		if info, err := os.Stat(path); err == nil {
+		if info, err := os.Lstat(path); err == nil {
 			return cb(PathInfo{path, info})
 		}
 		return true
@@ -161,7 +161,7 @@ func glob(segs []Segment, dir string, cb func(PathInfo) bool) bool {
 		name := info.Name()
 		if matchElement(segs, name) {
 			dirname := dir + name
-			info, err := os.Stat(dirname)
+			info, err := os.Lstat(dirname)
 			if err != nil {
 				return true
 			}


### PR DESCRIPTION
Glob expansion should use os.Lstat rather than os.Stat so that broken
symlinks don't stop glob expansion. It's not the place of glob expansion
to decide if a particular path is good.

The symlink test cases and logic were borrowed from
pkg/mods/path/path_test.go.

Fixes #1240