### PR TITLE
Add to-yaml, from-yaml builtins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,7 @@ golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1i
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -138,6 +138,22 @@ func TestFromJson(t *testing.T) {
 	)
 }
 
+func TestFromYAML(t *testing.T) {
+	Test(t,
+		That(`echo 'a:
+    - 1
+    - 2
+k: v
+---
+foo' | from-yaml`).
+			Puts(vals.MakeMap("k", "v", "a", vals.MakeList(1, 2)),
+				"foo"),
+		That(`echo '[null, "foo"]' | from-yaml`).Puts(
+			vals.MakeList(nil, "foo")),
+		// thatOutputErrorIsBubbled(`echo '[]' | from-yaml`),
+	)
+}
+
 func TestToLines(t *testing.T) {
 	Test(t,
 		That(`put "l\norem" ipsum | to-lines`).Prints("l\norem\nipsum\n"),
@@ -164,6 +180,23 @@ func TestToJson(t *testing.T) {
 `),
 		That(`put [$nil foo] | to-json`).Prints("[null,\"foo\"]\n"),
 		thatOutputErrorIsBubbled("to-json [foo]"),
+	)
+}
+
+func TestToYAML(t *testing.T) {
+	Test(t,
+		That(`put [&k=v &a=[1 2]] foo | to-yaml`).
+			Prints(`a:
+    - "1"
+    - "2"
+k: v
+---
+foo
+`),
+		That(`put [$nil foo] | to-yaml`).Prints(`- null
+- foo
+`),
+		// thatOutputErrorIsBubbled("to-yaml [foo]"),
 	)
 }
 


### PR DESCRIPTION
When writing a script to handle yaml, It's quite annoying as no language supports yaml format natively and have to install dependancies. If it's json, jq works fine, but cli tools for yaml like `yq` is quite annoying as there's quite many different versions of it. It would be quite useful if elvish can natively support various formats just like json.

fixes #1155