### PR TITLE
vi append command binding

### DIFF
--- a/pkg/edit/init.elv
+++ b/pkg/edit/init.elv
@@ -57,6 +57,7 @@ set command:binding = (binding-table [
   &b=   $move-dot-left-word~
   &h=   $move-dot-left~
   &i=   $close-mode~
+  &a=   { $move-dot-right~; $close-mode~ }
   &j=   $move-dot-down~
   &k=   $move-dot-up~
   &l=   $move-dot-right~


### PR DESCRIPTION
This adds https://vimhelp.org/insert.txt.html#a like key binding in command:binding.
It can be just tested with this on rc.elv. But I tought it would be better to make it as a default binding.

```
set edit:command:binding[a] = { edit:move-dot-right; edit:close-mode }
```