### PR TITLE
Correct the documentation for the `try` command

### DIFF
--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -2032,8 +2032,7 @@ try {
 }
 ```
 
-Only `try` and `try-block` are required. This control structure behaves as
-follows:
+This control structure behaves as follows:
 
 1.  The `try-block` is always executed first.
 
@@ -2084,9 +2083,9 @@ follows:
 5.  If the exception was not caught (i.e. `catch` is not present), it is
     rethrown.
 
-At least one of `catch` and `finally` must be present, since a lone
-`try { ... }` does not do anything on its own, and is almost certainly a
-mistake. To swallow exceptions, an explicit `catch` clause must be given.
+At least one of `catch` and `finally` must be present since a lone `try { ... }`
+does not do anything on its own and is almost certainly a mistake. To swallow
+exceptions an explicit `catch` clause must be given.
 
 Exceptions thrown in blocks other than `try-block` are not caught. If an
 exception was thrown and either `catch-block` or `finally-block` throws another


### PR DESCRIPTION
This came to light when a user commented on the IM channels that they
were surprised by this warning when the documentation says that "Only
try and try-block are required.":

    compilation error: try must be followed by a catch block or a finally block

P.S., The warning is because they had code that (presumably) looked like
`try { ... } except { ... }` that should now look like `try { ... }
catch { ... }`.