### PR TITLE
Add Makefile go version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 cover
 /_bin/
 /elvish
+
+# IDE
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 ELVISH_MAKE_BIN ?= $(or $(GOBIN),$(shell go env GOPATH)/bin)/elvish$(shell go env GOEXE)
 ELVISH_MAKE_BIN := $(subst \,/,$(ELVISH_MAKE_BIN))
+GO_MIN_VERSION ?= 1.18
 
 default: test get
 
 get:
+ifneq ($(shell printf '%s\ngo%s\n' $$(go version | grep -oE 'go[0-9.]+') $(GO_MIN_VERSION) | sort -rCV; echo $$?), 0)
+	$(error go version must >= $(GO_MIN_VERSION))
+endif
+
 	mkdir -p $(shell dirname $(ELVISH_MAKE_BIN))
 	go build -o $(ELVISH_MAKE_BIN) ./cmd/elvish
 


### PR DESCRIPTION
Fixes #1610 
To make the `make get` better to build elvish.

Test results:
1. with go1.15.5:
```
make get

Makefile:9: *** go version must >= 1.18.  Stop.
```
2. with go1.18:
```
make get           
       
mkdir -p /Users/apple/.gvm/pkgsets/go1.18.2/global/bin
go build -o /Users/apple/.gvm/pkgsets/go1.18.2/global/bin/elvish ./cmd/elvish

// build success :)
```