### PR TITLE
Change `make lint` to be comprehensive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = upto,nd,ba,doas,fo,struc,shouldbe,iterm,lates,testof
-skip = ./vscode/node_modules,./vscode/dist
+ignore-words-list = ro,upto,nd,doas,fo,shouldbe,iterm,lates,testof
+skip = ./.git,./vscode/node_modules,./vscode/dist,./website/*.html,./website/_dst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install codespell
-      run: pip install codespell==2.1.0
+      run: pip install codespell==2.2.1
     - name: Run codespell
       run: codespell
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ GNU Make is required.
 
 The [`tools`](tools) directory contains scripts too complex to fit in the
 `Makefile`. Among them, [`tools/pre-push`](tools/pre-push) can be used as a Git
-hook, and covers a large subset (but not all) of CI checks.
+hook, and covers all of the CI checks.
 
 ## Testing changes
 
@@ -145,26 +145,14 @@ Some of the generation rules depend on the `stringer` tool. Install with
 
 ## Code hygiene
 
-Some basic aspects of code hygiene are checked in the CI.
+Some basic aspects of code hygiene are checked in the continuous-integration
+environment. You are encouraged to install the lint tools and run them before
+opening a pull-request.
 
-### Formatting
+### Installing Lint Tools Used By This Project
 
-Install [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to
-format Go files, and [prettier](https://prettier.io/) to format Markdown files.
-
-```sh
-go install golang.org/x/tools/cmd/goimports@latest
-npm install --global prettier@2.7.1
-```
-
-Once you have installed the tools, use `make style` to format Go and Markdown
-files. If you prefer, you can also configure your editor to run these commands
-automatically when saving Go or Markdown sources.
-
-Use `make checkstyle` to check if all Go and Markdown files are properly
-formatted.
-
-### Linting
+You'll need several tools to check that your changes do not introduce "lint";
+that is, style or correctness issues.
 
 Install [staticcheck](https://staticcheck.io):
 
@@ -176,9 +164,13 @@ The other linter Elvish uses is the standard `go vet` command. Elvish doesn't
 use golint since it is
 [deprecated and frozen](https://github.com/golang/go/issues/38968).
 
-Use `make lint` to run `staticcheck` and `go vet`.
+Install [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to
+format Go files, and [prettier](https://prettier.io/) to format Markdown files.
 
-### Spell checking
+```sh
+go install golang.org/x/tools/cmd/goimports@latest
+npm install --global prettier@2.7.1
+```
 
 Install [codespell](https://github.com/codespell-project/codespell) to check
 spelling:
@@ -187,18 +179,26 @@ spelling:
 pip install --user codespell==2.1.0
 ```
 
-Use `make codespell` to run it.
+### Checking For Lint Problems
 
-### Running all checks
+Run `make lint` to execute all lint checks.
 
-Use this command to run all checks:
+The lint tests are run by the continuous-integration environment. It is
+recommended that you use `tools/pre-push`. That script will run `make lint`,
+`make test`, and also perform some other sanity checks such as a
+cross-compilation succeeding. Thus helping ensure you aren't surprised by CI
+failures due to style, spelling, and other lint mistakes as well as more
+fundamental problems (e.g., unit tests failing). See the comment at the top of
+`tools/pre-push` for how to use it.
 
-```sh
-make test checkstyle lint codespell
-```
+There are also `make` targets for each individual lint tool if you want to run a
+specific lint check. See the `Makefile` for details.
 
-You can put this in `.git/hooks/pre-push` to ensure that your published commits
-pass all the checks.
+### Fixing Style Problems
+
+Run `make style` to format Go and Markdown files. If you prefer, you can also
+configure your editor to run that command automatically when saving Go or
+Markdown files.
 
 ## Licensing
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,11 @@ style:
 	find . -name '*.go' | xargs gofmt -s -w
 	find . -name '*.md' | xargs prettier --write
 
-# Check if the style of the Go and Markdown files is correct without modifying
-# those files.
+# Ensure the project has zero lint.
+lint: checkstyle-go checkstyle-md check-content codelint
+	make -C website check-rellinks
+	make codespell
+
 checkstyle: checkstyle-go checkstyle-md
 
 checkstyle-go:
@@ -43,14 +46,14 @@ checkstyle-go:
 checkstyle-md:
 	./tools/checkstyle-md.sh
 
-lint:
+codelint:
 	./tools/lint.sh
 
 codespell:
-	codespell --skip .git
+	./tools/codespell.sh
 
 check-content:
 	./tools/check-content.sh
 
-.SILENT: checkstyle-go checkstyle-md lint
-.PHONY: default get generate test cover style checkstyle checkstyle-go checkstyle-md lint codespell check-content
+.SILENT: check-content checkstyle-go checkstyle-md codelint codespell lint
+.PHONY: default get generate test cover style checkstyle checkstyle-go checkstyle-md lint codelint codespell check-content

--- a/pkg/cli/term/reader_unix.go
+++ b/pkg/cli/term/reader_unix.go
@@ -278,8 +278,8 @@ var g3Seq = map[rune]ui.Key{
 // expressible using the escape sequences described below.
 
 // CSI-style key sequences identified by the last rune. For instance, \e[A is
-// Up. When modified, two numerical arguments are added, the first always beging
-// 1 and the second identifying the modifier. For instance, \e[1;5A is Ctrl-Up.
+// Up. When modified, two numerical arguments are added, the first always being
+// "1" and the second identifying the modifier. For instance, \e[1;5A is Ctrl-Up.
 var csiSeqByLast = map[rune]ui.Key{
 	// xterm, urxvt, tmux
 	'A': ui.K(ui.Up), 'B': ui.K(ui.Down), 'C': ui.K(ui.Right), 'D': ui.K(ui.Left),

--- a/tools/check-content.sh
+++ b/tools/check-content.sh
@@ -1,17 +1,33 @@
-#!/bin/sh -e
+#!/bin/sh
 
 # Check Go source files for disallowed content.
+status=0
 
-echo 'Disallowed import of net/rpc:'
-if find . -name '*.go' | xargs grep '"net/rpc"'; then
-    exit 1
-else
-    echo '  None!'
+x="$(find . -name '*.go' | xargs grep '"net/rpc"')"
+if [ "$x" != "" ]; then
+    echo
+    echo '==================================='
+    echo 'Go files should not import net/rpc:'
+    echo '==================================='
+    echo
+    echo "$x"
+    status=1
 fi
 
-echo 'Disallowed call of unix.{Umask,Getrlimit,Setrlimit}'
-if find . -name '*.go' | egrep -v '\./pkg/(mods/unix|daemon|testutil)' | xargs egrep 'unix\.(Umask|Getrlimit|Setrlimit)'; then
-    exit 1
-else
-    echo '  None!'
+x="$(find . -name '*.go' |
+        egrep -v '\./pkg/(mods/unix|daemon|testutil)' |
+        xargs egrep 'unix\.(Umask|Getrlimit|Setrlimit)')"
+if test "$x" != ""; then
+    echo
+    echo '==================================================='
+    echo 'Disallowed call of unix.{Umask,Getrlimit,Setrlimit}'
+    echo '==================================================='
+    echo
+    echo "$x"
+    status=1
 fi
+
+if test "$CI" != ""; then
+    exit $status
+fi
+exit 0

--- a/tools/checkstyle-go.sh
+++ b/tools/checkstyle-go.sh
@@ -1,15 +1,33 @@
 #!/bin/sh -e
 
-# Check if the style of the Go source files is correct without modifying those
-# files.
+# Verify the style of the Go source files without modifying them.
+status=0
 
-# The grep is needed because `goimports -d` and `gofmt -d` always exits with 0.
+x="$(find . -name '*.go' | xargs goimports -d)"
+if [ "$x" != "" ]; then
+    echo
+    echo '==================================='
+    echo 'Go files need these import changes:'
+    echo '==================================='
+    echo
+    echo "$x"
+    echo
+    status=1
+fi
 
-echo 'Go files need these changes:'
-if find . -name '*.go' | xargs goimports -d | grep .; then
-    exit 1
+x="$(find . -name '*.go' | xargs gofmt -s -d)"
+if [ "$x" != "" ]; then
+    echo
+    echo '==========================================='
+    echo 'Go files need that need formatting changes:'
+    echo '==========================================='
+    echo
+    echo "$x"
+    echo
+    status=1
 fi
-if find . -name '*.go' | xargs gofmt -s -d | grep .; then
-    exit 1
+
+if test "$CI" != ""; then
+    exit $status
 fi
-echo '  None!'
+exit 0

--- a/tools/checkstyle-md.sh
+++ b/tools/checkstyle-md.sh
@@ -13,16 +13,29 @@
 # be reformatted without actually modifying those files.
 
 if test "$CI" = ""; then
-    echo 'Markdown files that need changes:'
-    ! find . -name '*.md' |
-        xargs prettier --list-different |
-        sed 's/^/  /' | grep . && echo '  None!'
-else
-    echo 'Markdown files need these changes:'
-    if ! find . -name '*.md' | xargs prettier --check >/dev/null; then
-        find . -name '*.md' | xargs prettier --write >/dev/null
-        find . -name '*.md' | xargs git diff
-        exit 1
+    # Presumably we're being run interactively by a developer.
+    x="$(find . -name '*.md' | xargs prettier --list-different || true)"
+    if test "$x" != ""; then
+        echo
+        echo '==========================================='
+        echo 'Markdown files that need formatting changes'
+        echo '(run "make style" to fix the problems):'
+        echo '==========================================='
+        echo
+        echo "$x"
+        echo
     fi
-    echo '  None!'
+    exit 0
+fi
+
+if ! find . -name '*.md' | xargs prettier --check >/dev/null; then
+    echo
+    echo '=================================='
+    echo 'Markdown files need these changes:'
+    echo '=================================='
+    echo
+    find . -name '*.md' | xargs prettier --write >/dev/null
+    find . -name '*.md' | xargs git diff
+    echo
+    exit 1
 fi

--- a/tools/codespell.sh
+++ b/tools/codespell.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Check if the source code has any spelling errors.
+status=0
+
+x="$(codespell)"
+if [ "$x" != "" ]; then
+    echo
+    echo '========================================'
+    echo 'Spelling errors identified by codepsell:'
+    echo '========================================'
+    echo
+    echo "$x"
+    echo
+    status=1
+fi
+
+if test "$CI" != ""; then
+    exit $status
+fi
+exit 0

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -5,21 +5,21 @@
 #   cd .git/hooks # from repo root
 #   ln -s ../../tools/pre-push .
 
-if ! git diff HEAD --quiet; then
-    if git diff --cached --quiet; then
-        echo 'Local changes exist and none is staged; stashing.'
-        git stash
-        trap 'r=$?; git stash pop; trap - EXIT; exit $r' EXIT INT HUP TERM
-    else
-        echo 'Local changes exist and some are staged; not stashing.'
-        echo 'Make a commit, stash all the changes, or unstage all the changes.'
-        exit 1
-	fi
+if ! git diff-index --quiet HEAD; then
+    echo 'Local changes exist.'
+    echo 'Add those changes to the commit(s), stash them, or revert them.'
+    echo
+    git status
+    exit 1
 fi
 
-make test checkstyle lint codespell
-make -C website check-rellinks
-# A quick cross compilation test. Not exhaustive, but will catch most issues.
+# Verify the project is lint free and the tests pass. This simulates what is
+# done in CI and we want to cause the checks to fail with a non-zero status.
+export CI=yes
+make lint
+make test
+
+# A quick cross-compilation test. Not exhaustive, but will catch most issues.
 if test `go env GOOS` = windows; then
     GOOS=linux GOARCH=amd64 go build ./...
 else

--- a/website/Makefile
+++ b/website/Makefile
@@ -37,6 +37,7 @@ else
 	@: ttyshot generation disabled by default
 endif
 
+.SILENT: check-rellinks gen
 .PHONY: gen docset publish check-rellinks clean
 
 # Don't remove intermediate targets

--- a/website/blog/0.11-release-notes.md
+++ b/website/blog/0.11-release-notes.md
@@ -130,7 +130,7 @@ As usual, prebuilt binaries can be found in [get](../get/).
 -   Elvish now handles SIGHUP by relaying it to the entire process group
     ([#494](https://github.com/elves/elvish/issues/494)).
 
--   The daemon now detects the path of the Elvish executable more reliabily,
+-   The daemon now detects the path of the Elvish executable more reliably,
     notably when Elvish is used as login shell
     ([#496](https://github.com/elves/elvish/issues/496)).
 


### PR DESCRIPTION
I (almost) always run `make lint` on a change I plan on turning into a pull-request. However, the usefulness of that is limited because it only performs two Go source code lint checks. Which is a small fraction of the actual lint checks run in the continuous integration environment. Which means that I am regularly surprised by CI failures due to lint checks I didn't think to run because I expected `make lint` to run all the checks run by the CI environment.

This change modifies the top-level "lint" target to run all the lint checks. Also, with this change `make lint` produces no output if there is no lint.