### PR TITLE
Change how `exit` works so defers are run

### DIFF
--- a/pkg/shell/interact.go
+++ b/pkg/shell/interact.go
@@ -18,6 +18,7 @@ import (
 	"src.elv.sh/pkg/mods/daemon"
 	"src.elv.sh/pkg/mods/store"
 	"src.elv.sh/pkg/parse"
+	"src.elv.sh/pkg/prog"
 	"src.elv.sh/pkg/strutil"
 	"src.elv.sh/pkg/sys"
 	"src.elv.sh/pkg/ui"
@@ -133,6 +134,10 @@ func interact(ev *eval.Evaler, fds [3]*os.File, cfg *interactCfg) {
 func handlePanic() {
 	r := recover()
 	if r != nil {
+		if e := prog.GetExitStatus(r); e != nil {
+			// The panic is a result of an `exit` command so do the actual exit.
+			os.Exit(e.Status)
+		}
 		println()
 		print(sys.DumpStack())
 		println()


### PR DESCRIPTION
This replaces the direct use of os.Exit() in the `exit` implementation with a panic so that deferred functions are run. For example, those involved in saving profiling data.

This also adds a sanity check to the value of the `exit` command. Every UNIX like system requires the value to be in the range [0..255]. So use that limit for now. It is true that Windows supports the range [0..2^32) but I don't see a good reason to support that at this time. If we find it useful to support a different range on non-UNIX systems the check can always be abstracted out into platform specific validation.

Fixes #1377