### PR TITLE
Documentation typo to a backslash on Windows

### DIFF
--- a/pkg/mods/path/path.go
+++ b/pkg/mods/path/path.go
@@ -38,7 +38,7 @@ var Ns = eval.BuildNsNamed("path").
 
 //elvdoc:var separator
 //
-// OS-specific path separator. Forward slash (`/`) on UNIX and backslash (`\\`)
+// OS-specific path separator. Forward slash (`/`) on UNIX and backslash (`\`)
 // on Windows. This variable is read-only.
 
 //elvdoc:fn abs


### PR DESCRIPTION
While working on other changes I noticed that
https://elv.sh/ref/path.html#path:separator used a double backslash for the Windows example while it should have used a single backslash.