### PR TITLE
Fix `path:temp-file` documentation

### DIFF
--- a/pkg/mods/path/path.go
+++ b/pkg/mods/path/path.go
@@ -316,16 +316,16 @@ func tempDir(opts mktempOpt, args ...string) (string, error) {
 // ~> echo hello > $f
 // ~> cat $f[name]
 // hello
-// ~> var f = (path:temp-file) x-
+// ~> var f = (path:temp-file x-)
 // ~> put $f[name]
 // ▶ /tmp/x-RANDOMSTR
-// ~> var f = (path:temp-file) 'x-*.y'
+// ~> var f = (path:temp-file 'x-*.y')
 // ~> put $f[name]
 // ▶ /tmp/x-RANDOMSTR.y
-// ~> var f = (path:temp-file) &dir=.
+// ~> var f = (path:temp-file &dir=.)
 // ~> put $f[name]
 // ▶ elvish-RANDOMSTR
-// ~> var f = (path:temp-file) &dir=/some/dir
+// ~> var f = (path:temp-file &dir=/some/dir)
 // ~> put $f[name]
 // ▶ /some/dir/elvish-RANDOMSTR
 // ```


### PR DESCRIPTION
There were incorrect function calls in the examples.