### PR TITLE
Validate generated code is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+    - name: Install go-stringer
+      run: go install golang.org/x/tools/cmd/stringer@latest
     - name: Run check-content.sh
       run: ./tools/check-content.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,20 +110,21 @@ func Foo() { }
 func foo() { }
 ```
 
-## Generating code
-
-Elvish uses generated code in a few places. As is the usual case with Go
-projects, they are committed into the repo, and if you change the input of a
-generated file you should re-generate it.
-
-Use the standard command, `go generate ./...` to regenerate all files.
-
-Some of the generation rules depend on the `stringer` tool. Install with
-`go install golang.org/x/tools/cmd/stringer@latest`.
-
 ## Code hygiene
 
 Some basic aspects of code hygiene are checked in the CI.
+
+### Generated code
+
+Elvish uses generated code in a few places. As is the usual case for Go projects
+the generated code is committed into the repo. If you change the input of a
+generated file you must re-generate it. The CI environment validates generated
+code is unchanged as does the `tools/pre-push` script you can use as a git hook.
+
+Use the standard command, `go generate ./...`, to regenerate all files.
+
+Note: Some of the generation rules depend on the `stringer` tool. Install with
+`go install golang.org/x/tools/cmd/stringer@latest`.
 
 ### Formatting
 

--- a/tools/check-content.sh
+++ b/tools/check-content.sh
@@ -1,17 +1,39 @@
 #!/bin/sh -e
 
-# Check Go source files for disallowed content.
+# Check Go source files for disallowed or stale content.
 
-echo 'Disallowed import of net/rpc:'
-if find . -name '*.go' | xargs grep '"net/rpc"'; then
+# Verify the generated code is up to date.
+go generate ./...
+exit 0
+x="$(git diff || true)"
+if test "$x" != ""; then
+    echo "======================================================================"
+    echo "Generated Go code is out of date. See"
+    echo "https://github.com/elves/elvish/blob/master/CONTRIBUTING.md#generated-code"
+    echo "======================================================================"
+    echo "$x"
     exit 1
-else
-    echo '  None!'
 fi
 
-echo 'Disallowed call of unix.{Umask,Getrlimit,Setrlimit}'
-if find . -name '*.go' | egrep -v '\./pkg/(mods/unix|daemon|testutil)' | xargs egrep 'unix\.(Umask|Getrlimit|Setrlimit)'; then
+# Verify the code does not include undesired package imports.
+x="$(find . -name '*.go' |
+    xargs grep '"net/rpc"' 2>&1 || true)"
+if test "$x" != ""; then
+    echo "======================================================================"
+    echo 'Disallowed import of net/rpc.'
+    echo "======================================================================"
+    echo "$x"
     exit 1
-else
-    echo '  None!'
+fi
+
+# Verify the code does not include undesired uses of stdlib functions other
+# than in specific, platform specific, Elvish packages.
+x="$(find . -name '*.go' | egrep -v '\./pkg/(mods/unix|daemon|testutil)' |
+    xargs egrep 'unix\.(Umask|Getrlimit|Setrlimit)' 2>&1 || true)"
+if test "$x" != ""; then
+    echo "======================================================================"
+    echo 'Disallowed call of unix.{Umask,Getrlimit,Setrlimit}.'
+    echo "======================================================================"
+    echo "$x"
+    exit 1
 fi

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -14,8 +14,12 @@ if ! git diff HEAD --quiet; then
         echo 'Local changes exist and some are staged; not stashing.'
         echo 'Make a commit, stash all the changes, or unstage all the changes.'
         exit 1
-	fi
+    fi
 fi
+
+# This script is run by the CI environment but is not run by the `make`
+# targets below.
+./tools/check-content.sh
 
 make test checkstyle lint codespell
 make -C website check-rellinks


### PR DESCRIPTION
While working on a change to augment `make lint` to be more comprehensive I noticed that `go generate ./...` produced unexpected errors on my system (see below). This augments the CI environment checks to verify that the generated code is up to date. This also augments the pre-push script to perform the checks by the tools/check-content script run by the CI environment.

FWIW: The errors shown below were because my version of the `stringer` tool was out of date (fixed by running `go install golang.org/x/tools/stringer@latest`) Regardless, the point of this change is that the pre-push script and the CI environment should verify that the generated code is up to date. This change adds those checks.

> go generate ./...
stringer: internal error: package "fmt" without types was imported from "src.elv.sh/pkg/getopt"
pkg/getopt/getopt.go:11: running "stringer": exit status 1 stringer: internal error: package "fmt" without types was imported from "src.elv.sh/pkg/md"
pkg/md/md.go:163: running "stringer": exit status 1 stringer: internal error: package "fmt" without types was imported from "src.elv.sh/pkg/parse"
pkg/parse/parse.go:11: running "stringer": exit status 1
Exception: go exited with 1
[tty 102], line 1: go generate ./...