### PR TITLE
pkg/edit: implement edit:history:accept

### DIFF
--- a/pkg/cli/modes/histwalk.go
+++ b/pkg/cli/modes/histwalk.go
@@ -17,6 +17,8 @@ type Histwalk interface {
 	Prev() error
 	// Walk to the next entry in history.
 	Next() error
+	// Update buffer with current entry.
+	Accept() error
 }
 
 // HistwalkSpec specifies the configuration for the histwalk mode.
@@ -119,4 +121,16 @@ func (w *histwalk) updatePending() {
 			Content: cmd.Text[len(w.Prefix):],
 		}
 	})
+}
+
+func (w *histwalk) Accept() error {
+	cmd, _ := w.cursor.Get()
+	txt := cmd.Text[len(w.Prefix):]
+	w.attachedTo.MutateState(func(s *tk.CodeAreaState) {
+		s.Buffer = tk.CodeBuffer{
+			Content: txt,
+			Dot:     len(txt),
+		}
+	})
+	return nil
 }

--- a/pkg/edit/histwalk.d.elv
+++ b/pkg/edit/histwalk.d.elv
@@ -21,3 +21,6 @@ fn history:down-or-quit { }
 # Import command history entries that happened after the current session
 # started.
 fn history:fast-forward { }
+
+# Update buffer with current entry.
+fn history:accept { }

--- a/pkg/edit/histwalk.go
+++ b/pkg/edit/histwalk.go
@@ -20,8 +20,7 @@ func initHistWalk(ed *Editor, ev *eval.Evaler, hs *histStore, nb eval.NsBuilder)
 			AddGoFns(map[string]any{
 				"start": func() { notifyError(app, histwalkStart(app, hs, bindings)) },
 				"up":    func() { notifyError(app, histwalkDo(app, modes.Histwalk.Prev)) },
-
-				"down": func() { notifyError(app, histwalkDo(app, modes.Histwalk.Next)) },
+				"down":  func() { notifyError(app, histwalkDo(app, modes.Histwalk.Next)) },
 				"down-or-quit": func() {
 					err := histwalkDo(app, modes.Histwalk.Next)
 					if err == histutil.ErrEndOfHistory {
@@ -30,7 +29,7 @@ func initHistWalk(ed *Editor, ev *eval.Evaler, hs *histStore, nb eval.NsBuilder)
 						notifyError(app, err)
 					}
 				},
-
+				"accept":       func() { notifyError(app, histwalkDo(app, modes.Histwalk.Accept)) },
 				"fast-forward": hs.FastForward,
 			}))
 }
@@ -42,7 +41,8 @@ func histwalkStart(app cli.App, hs *histStore, bindings tk.Bindings) error {
 	}
 	buf := codeArea.CopyState().Buffer
 	w, err := modes.NewHistwalk(app, modes.HistwalkSpec{
-		Bindings: bindings, Store: hs, Prefix: buf.Content[:buf.Dot]})
+		Bindings: bindings, Store: hs, Prefix: buf.Content[:buf.Dot],
+	})
 	if w != nil {
 		app.PushAddon(w)
 	}

--- a/pkg/edit/histwalk_test.go
+++ b/pkg/edit/histwalk_test.go
@@ -30,6 +30,18 @@ func TestHistWalk_Down_EndOfHistory(t *testing.T) {
 func TestHistWalk_Accept(t *testing.T) {
 	f := startHistwalkTest(t)
 
+	evals(f.Evaler, `edit:history:accept`)
+	f.TTYCtrl.Inject(term.K('[', ui.Ctrl))
+
+	f.TestTTY(t,
+		"~> echo a", Styles,
+		"   vvvv  ", term.DotHere,
+	)
+}
+
+func TestHistWalk_Accept_Close(t *testing.T) {
+	f := startHistwalkTest(t)
+
 	f.TTYCtrl.Inject(term.K(ui.Right))
 	f.TestTTY(t,
 		"~> echo a", Styles,


### PR DESCRIPTION
It's api to and update codebuffer with current entry in histwalk mode.

Resolves #1636

With this new api, I was able to switch to command-mode directly from histwalk mode.
```
set edit:history:binding["Ctrl-["] =  { edit:history:accept; edit:close-mode; edit:command:start }
```

I'm not familiar with elvish code base. Please let me know it this api itself and it's implementation is correct.