### PR TITLE
to-nums and from-nums: handling binary I/O

### DIFF
--- a/pkg/eval/builtin_fn_str.d.elv
+++ b/pkg/eval/builtin_fn_str.d.elv
@@ -33,6 +33,12 @@
 # ```
 fn wcswidth {|string| }
 
+# Convert bytes from the byte input to nums
+fn to-nums {}
+
+# Convert nums from the value input to bytes
+fn from-nums {}
+
 # Convert arguments to string values.
 #
 # ```elvish-transcript

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -44,7 +44,7 @@ func toNums(fm *Frame, args ...any) error {
 	in := fm.InputFile()
 	out := fm.ValueOutput()
 	for true {
-		c := make([]byte, 1)
+		c := []byte{0}
 		n, err := in.Read(c)
 		if(n != 1 || err != nil) {
 			break
@@ -87,7 +87,7 @@ func fromNums(fm *Frame, args ...any) error {
 		if(err != nil) {
 			return err
 		}
-		c := make([]byte, 1)
+		c := []byte{0}
 		c[0] = t
 		n, err := out.Write(c)
 

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"io"
 
 	"src.elv.sh/pkg/eval/vals"
 	"src.elv.sh/pkg/wcwidth"
@@ -46,7 +47,10 @@ func toNums(fm *Frame, args ...any) error {
 	for true {
 		c := []byte{0}
 		n, err := in.Read(c)
-		if(n != 1 || err != nil) {
+		if(n != 1) {
+			if(err != nil && err != io.EOF) {
+				return err
+			}
 			break
 		}
 		err = out.Put(int(c[0]))
@@ -75,7 +79,6 @@ func numToByte(v any) (byte, error) {
 }
 
 func fromNums(fm *Frame, args ...any) error {
-
 	in := fm.InputChan()
 	out := fm.ByteOutput()
 	for true {
@@ -89,9 +92,9 @@ func fromNums(fm *Frame, args ...any) error {
 		}
 		c := []byte{0}
 		c[0] = t
-		n, err := out.Write(c)
+		_, err = out.Write(c)
 
-		if(err != nil || n != 1) {
+		if(err != nil) {
 			return err
 		}
 	}


### PR DESCRIPTION
## Rationale
Traditional shells don't do binary I/O. Elvish should fix this. This PR will add two builtins, `to-nums` which converts from the binary input stream to the value output stream as bytes, and `from-nums`, which does the reverse.
Both work, but aren't production ready yet. 
I apologize for the (lack of) code quality, this is my first time writing Go. Please tell me if something doesn't seem right.
## TODO
- [x] eliminate heap allocation with make
- [ ] make both accept a `maximum` parameter
- [ ] write documentation
- [x] proper error handling
- [ ] fix not responding to ^C when reading from the tty
## Example
```
> print 'amogus'"\n" | to-nums
▶ (num 97)
▶ (num 109)
▶ (num 111)
▶ (num 103)
▶ (num 117)
▶ (num 115)
▶ (num 10)
> put (num 115) (num 117) (num 115) (num 10) | from-nums
sus
```