### PR TITLE
elv.sh/get: add instructions for NetBSD and pkgsrc

### DIFF
--- a/website/get/prelude.md
+++ b/website/get/prelude.md
@@ -308,6 +308,22 @@ cd /usr/ports/shells/elvish
 make install
 ```
 
+## NetBSD / pkgsrc
+
+Elvish is [available in pkgsrc](https://pkgsrc.se/shells/elvish). To install
+from a binary package, run the following command:
+
+```elvish
+pkgin install elvish
+```
+
+To build the elvish package from source instead:
+
+```elvish
+cd /usr/pkgsrc/shells/elvish
+make package-install
+```
+
 ## OpenBSD
 
 Elvish is available in the official OpenBSD package repository. This will


### PR DESCRIPTION
pkgsrc is the native packaging system in NetBSD. It also supports dozens of other operating systems, such as macOS or Illumos.