### PR TITLE
Don't stop glob expansion when path stat fails

### DIFF
--- a/pkg/eval/glob.go
+++ b/pkg/eval/glob.go
@@ -247,7 +247,7 @@ func doGlob(gp globPattern, abort <-chan struct{}) ([]any, error) {
 			return true
 		}
 
-		if gp.TypeCb == nil || gp.TypeCb(pathInfo.Info.Mode()) {
+		if gp.TypeCb == nil || (pathInfo.Info != nil && gp.TypeCb(pathInfo.Info.Mode())) {
 			vs = append(vs, pathInfo.Path)
 		}
 		return true


### PR DESCRIPTION
Specifically, ignore EPERM errors returned by os.Lstat() since

a) that is not documented as a valid error on any system I currently have access to (which includes macOS, Linux, and FreeBSD), and

b) on macOS EPERM is only returned due to security restrictions on gathering information about the path and which should otherwise not short-circuit glob expansion by treating it as a fatal error.

We only care about EPERM if there is explicit filtering of the glob expansion; e.g., `put **[type:regular]`. Otherwise we should include the path name in the results and not prematurely terminate inclusion of glob matches.

Fixes #1674