### PR TITLE
Implement `path:remove`

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -2,6 +2,8 @@ Draft release notes for Elvish 0.20.0.
 
 # Notable new features
 
+-   A new `path:remove` command ([#1659](https://b.elv.sh/1659)).
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/mods/path/path.d.elv
+++ b/pkg/mods/path/path.d.elv
@@ -197,3 +197,36 @@ fn temp-dir {|&dir='' pattern?| }
 # ▶ /some/dir/elvish-RANDOMSTR
 # ```
 fn temp-file {|&dir='' pattern?| }
+
+# Removes one or more path names.
+#
+# If passed zero path names it does nothing; otherwise, it iterates over the
+# list of path names and attempts to remove each one. If a path name does not
+# exist or cannot be removed (perhaps because it is a non-empty directory or
+# permissions do not allow the operation) an exception is raised.
+#
+# Like the traditional Unix `rm` command an error processing a path name does
+# not immediately terminate processing the list of path names. This command
+# attempts to remove the remaining path names. This can result in a "multiple
+# error" exception that documents each path that could not be removed.
+#
+# If the `&ignore-missing` option is set to true a path name that does not
+# exist is silently ignored.
+#
+# If the `&recursive` option is true a path name that refers to a directory is
+# removed recursively. If this option is false then attempting to remove a
+# directory that is not empty will fail.
+#
+# ```elvish-transcript
+# ~> mkdir elv
+# ~> mkdir elv/d
+# ~> touch elv/a
+# ~> touch elv/d/a
+# ~> path:remove elv/x
+# Exception: path does not exist: elv/x
+# ~> path:remove &ignore-missing elv/x
+# ~> path:remove elv
+# Exception: remove elv/d: directory not empty
+# ~> path:remove &recursive elv
+# ```
+fn remove {|&ignore-missing=$false &recursive=$false path...| }

--- a/pkg/mods/path/path.go
+++ b/pkg/mods/path/path.go
@@ -3,9 +3,12 @@ package path
 
 import (
 	_ "embed"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
+	"src.elv.sh/pkg/errutil"
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vars"
@@ -30,6 +33,7 @@ var Ns = eval.BuildNsNamed("path").
 		"is-dir":        isDir,
 		"is-regular":    isRegular,
 		"join":          filepath.Join,
+		"remove":        remove,
 		"temp-dir":      tempDir,
 		"temp-file":     tempFile,
 	}).Ns()
@@ -97,4 +101,54 @@ func tempFile(opts mktempOpt, args ...string) (*os.File, error) {
 	}
 
 	return os.CreateTemp(opts.Dir, pattern)
+}
+
+type rmOpts struct {
+	IgnoreMissing bool
+	Recursive     bool
+}
+
+func (opts *rmOpts) SetDefaultOptions() {}
+
+// remove deletes filesystem paths.
+func remove(opts rmOpts, args ...string) error {
+	var returnErr error
+	for _, path := range args {
+		err := recursiveRemove(path, opts.Recursive, opts.IgnoreMissing)
+		returnErr = errutil.Multi(returnErr, err)
+	}
+	return returnErr
+}
+
+// recursiveRemove deletes a filesystem path. It optimistically hopes that any
+// path that refers to a non-directory or an empty directory. If a directory is
+// not empty, and the `recursive` option is true, it will attempt to do a
+// depth-first removal of the path.
+func recursiveRemove(path string, recursive bool, ignoreMissing bool) error {
+	err := os.Remove(path)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		if ignoreMissing {
+			return nil
+		}
+	} else if isDirNotEmpty(err.(*fs.PathError).Unwrap()) {
+		if !recursive {
+			return err
+		}
+		dirEntries, suberr := os.ReadDir(path)
+		if suberr != nil {
+			return errutil.Multi(err, suberr)
+		}
+		err = nil
+		for _, f := range dirEntries {
+			path := filepath.Join(path, f.Name())
+			suberr := recursiveRemove(path, recursive, ignoreMissing)
+			err = errutil.Multi(err, suberr)
+		}
+		suberr = os.Remove(path)
+		return errutil.Multi(err, suberr)
+	}
+	return err
 }

--- a/pkg/mods/path/path_test.go
+++ b/pkg/mods/path/path_test.go
@@ -139,6 +139,50 @@ func TestPath_Symlink(t *testing.T) {
 	)
 }
 
+var removeDir = testutil.Dir{
+	"a": "",
+	"d": testutil.Dir{
+		"b": "",
+		"e": testutil.Dir{
+			"f": "",
+		},
+		"c": "",
+	},
+}
+
+var removeSymlinks = []struct {
+	path   string
+	target string
+}{
+	{"s-bad", "/argle/bargle"},
+	{"d/s-f", "b"},
+}
+
+func TestPathRemove(t *testing.T) {
+	tmpdir := testutil.InTempDir(t)
+	testutil.ApplyDir(removeDir)
+	for _, link := range removeSymlinks {
+		err := os.Symlink(link.target, link.path)
+		if err != nil {
+			// Creating symlinks requires a special permission on Windows. If
+			// the user doesn't have that permission, just skip the whole test.
+			t.Skip(err)
+		}
+	}
+
+	TestWithSetup(t, importModules,
+		That("path:remove").DoesNothing(),
+		That("path:remove does-not-exist").Throws(ErrorWithType(&os.PathError{})),
+		That("path:remove &ignore-missing does-not-exist").DoesNothing(),
+		That("path:remove "+filepath.Join(tmpdir, "d", "e")).Throws(ErrorWithType(&os.PathError{})),
+		That("put d/**").Puts("d/e/f", "d/b", "d/c", "d/e", "d/s-f"),
+		That("path:remove &recursive "+filepath.Join(tmpdir, "d", "e")).DoesNothing(),
+		That("put d/**").Puts("d/b", "d/c", "d/s-f"),
+		That("path:remove &recursive *").DoesNothing(),
+		That("put **").Throws(eval.ErrWildcardNoMatch),
+	)
+}
+
 func importModules(ev *eval.Evaler) {
 	ev.ExtendGlobal(eval.BuildNs().AddNs("path", Ns).AddNs("file", file.Ns))
 }

--- a/pkg/mods/path/path_unix.go
+++ b/pkg/mods/path/path_unix.go
@@ -2,4 +2,16 @@
 
 package path
 
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
 const devTty = "/dev/tty"
+
+// isDirNotEmpty returns a bool that indicates whether the error corresponds to a
+// platform specific syscall error that indicates a directory is not empty.
+func isDirNotEmpty(err error) bool {
+	return errors.Is(err, unix.ENOTEMPTY)
+}

--- a/pkg/mods/path/path_windows.go
+++ b/pkg/mods/path/path_windows.go
@@ -1,3 +1,17 @@
+//go:build windows
+
 package path
 
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
 const devTty = "CON"
+
+// isDirNotEmpty returns a bool that indicates whether the error corresponds to a
+// platform specific syscall error that indicates a directory is not empty.
+func isDirNotEmpty(err error) bool {
+	return errors.Is(err, windows.ERROR_DIR_NOT_EMPTY)
+}


### PR DESCRIPTION
I considered adhering more closely to the traditional Unix `rm` and `rmdir` commands. For example, by implementing each independently and supporting the `--force` option. However, I concluded there are insufficient reasons to do so. In particular, the POSIX `--force` (or `-f`) option is most often used solely for its side-effect of making elimination of a non-existent path a non-error. I also don't like that `-f` also fixes permission errors to allow allow removing files. If we decide that feature is needed it should be added under a distinct option (e.g. `&fix-perms`).

Related: #1659