### PR TITLE
lsp: provide `doc:show` in hover, if available

### DIFF
--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -9,7 +9,9 @@ import (
 	"src.elv.sh/pkg/diag"
 	"src.elv.sh/pkg/edit/complete"
 	"src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/mods/doc"
 	"src.elv.sh/pkg/parse"
+	"src.elv.sh/pkg/parse/parseutil"
 )
 
 var (
@@ -20,12 +22,19 @@ var (
 )
 
 type server struct {
-	evaler  *eval.Evaler
-	content map[lsp.DocumentURI]string
+	evaler    *eval.Evaler
+	content   map[lsp.DocumentURI]string
+	parseTree map[lsp.DocumentURI]struct {
+		parse.Tree
+		error
+	}
 }
 
 func newServer() *server {
-	return &server{eval.NewEvaler(), make(map[lsp.DocumentURI]string)}
+	return &server{eval.NewEvaler(), make(map[lsp.DocumentURI]string), make(map[lsp.DocumentURI]struct {
+		parse.Tree
+		error
+	})}
 }
 
 func handler(s *server) jsonrpc2.Handler {
@@ -33,7 +42,7 @@ func handler(s *server) jsonrpc2.Handler {
 		"initialize":              s.initialize,
 		"textDocument/didOpen":    convertMethod(s.didOpen),
 		"textDocument/didChange":  convertMethod(s.didChange),
-		"textDocument/hover":      s.hover,
+		"textDocument/hover":      convertMethod(s.hover),
 		"textDocument/completion": convertMethod(s.completion),
 
 		"textDocument/didClose": noop,
@@ -85,6 +94,7 @@ func (s *server) initialize(_ context.Context, _ json.RawMessage) (any, error) {
 				},
 			},
 			CompletionProvider: &lsp.CompletionOptions{},
+			HoverProvider:      true,
 		},
 	}, nil
 }
@@ -92,7 +102,7 @@ func (s *server) initialize(_ context.Context, _ json.RawMessage) (any, error) {
 func (s *server) didOpen(ctx context.Context, params lsp.DidOpenTextDocumentParams) (any, error) {
 	uri, content := params.TextDocument.URI, params.TextDocument.Text
 	s.content[uri] = content
-	go publishDiagnostics(ctx, uri, content)
+	go s.publishDiagnostics(ctx, uri, content)
 	return nil, nil
 }
 
@@ -101,12 +111,41 @@ func (s *server) didChange(ctx context.Context, params lsp.DidChangeTextDocument
 	// support that; see the initialize method.
 	uri, content := params.TextDocument.URI, params.ContentChanges[0].Text
 	s.content[uri] = content
-	go publishDiagnostics(ctx, uri, content)
+	go s.publishDiagnostics(ctx, uri, content)
 	return nil, nil
 }
 
-func (s *server) hover(_ context.Context, rawParams json.RawMessage) (any, error) {
-	return lsp.Hover{}, nil
+func (s *server) hover(_ context.Context, params lsp.TextDocumentPositionParams) (any, error) {
+	uri := params.TextDocument.URI
+	content, ok := s.content[uri]
+	if !ok {
+		return lsp.Hover{}, nil
+	}
+	_, ok = s.parseTree[uri]
+	// Usually we should have a parseTree available for `uri` (via didChange, didOpen)
+	// If we don't then generate it!
+	if !ok {
+		tree, err := parse.Parse(parse.Source{Name: string(uri), Code: content}, parse.Config{})
+		// Cache the parse tree and error, if any
+		s.parseTree[uri] = struct {
+			parse.Tree
+			error
+		}{tree, err}
+	}
+	pos := lspPositionToIdx(content, params.Position)
+
+	need_doc_for, err := parseutil.LeafTextAtPos(s.parseTree[uri].Root, pos)
+	if err != nil {
+		return lsp.Hover{}, nil
+	}
+	doc, err := doc.MarkdownShowMaybe(need_doc_for, 80)
+	if err != nil {
+		return lsp.Hover{}, nil
+	}
+	return lsp.Hover{
+		Contents: []lsp.MarkedString{{Value: doc, Language: "markdown"}},
+		Range:    nil,
+	}, nil
 }
 
 func (s *server) completion(_ context.Context, params lsp.CompletionParams) (any, error) {
@@ -147,13 +186,18 @@ func (s *server) completion(_ context.Context, params lsp.CompletionParams) (any
 	return lspItems, nil
 }
 
-func publishDiagnostics(ctx context.Context, uri lsp.DocumentURI, content string) {
+func (s *server) publishDiagnostics(ctx context.Context, uri lsp.DocumentURI, content string) {
 	conn(ctx).Notify(ctx, "textDocument/publishDiagnostics",
-		lsp.PublishDiagnosticsParams{URI: uri, Diagnostics: diagnostics(uri, content)})
+		lsp.PublishDiagnosticsParams{URI: uri, Diagnostics: s.diagnostics(uri, content)})
 }
 
-func diagnostics(uri lsp.DocumentURI, content string) []lsp.Diagnostic {
-	_, err := parse.Parse(parse.Source{Name: string(uri), Code: content}, parse.Config{})
+func (s *server) diagnostics(uri lsp.DocumentURI, content string) []lsp.Diagnostic {
+	tree, err := parse.Parse(parse.Source{Name: string(uri), Code: content}, parse.Config{})
+	// Cache the parse tree and any error. We use this cached parse tree in hovers, for instance
+	s.parseTree[uri] = struct {
+		parse.Tree
+		error
+	}{tree, err}
 	if err == nil {
 		return []lsp.Diagnostic{}
 	}

--- a/pkg/mods/doc/doc.go
+++ b/pkg/mods/doc/doc.go
@@ -47,6 +47,20 @@ type showOptions struct{ Width int }
 
 func (opts *showOptions) SetDefaultOptions() {}
 
+func MarkdownShowMaybe(name string, width int) (string, error) {
+	doc, err := source(name)
+	if err != nil {
+		doc, err = source("builtin:" + name)
+		if err != nil {
+			return "", err
+		}
+	}
+	codec := &md.FmtCodec{
+		Width: width,
+	}
+	return md.RenderString(fmt.Sprintf("# %s\n\n%s", name, doc), codec), nil
+}
+
 func show(fm *eval.Frame, opts showOptions, fqname string) error {
 	doc, err := source(fqname)
 	if err != nil {

--- a/pkg/parse/parseutil/parseutil.go
+++ b/pkg/parse/parseutil/parseutil.go
@@ -2,6 +2,7 @@
 package parseutil
 
 import (
+	"fmt"
 	"strings"
 
 	"src.elv.sh/pkg/parse"
@@ -11,6 +12,24 @@ import (
 func Wordify(src string) []string {
 	tree, _ := parse.Parse(parse.Source{Name: "[unknown]", Code: src}, parse.Config{})
 	return wordifyInner(tree.Root, nil)
+}
+
+func LeafTextAtPos(n parse.Node, pos int) (string, error) {
+	if len(parse.Children(n)) == 0 {
+		text := parse.SourceText(n)
+		rnge := n.Range()
+		if pos >= rnge.From && pos < rnge.To {
+			return text, nil
+		}
+		return "", fmt.Errorf("no leaf parse.Node at document pos %d found", pos)
+	}
+	for _, ch := range parse.Children(n) {
+		text, err := LeafTextAtPos(ch, pos)
+		if err == nil {
+			return text, err
+		}
+	}
+	return "", fmt.Errorf("no leaf parse.Node at document pos %d found", pos)
 }
 
 func wordifyInner(n parse.Node, words []string) []string {


### PR DESCRIPTION
I am new to elvish. I am enjoying elvish very much, thank you!

The built in LSP feature in elvish is very useful but a bit basic at the moment. 

One thing that I am running into while reading or writing elvish scripts in an editor (where I am connected to a `elvish -lsp`) is that I constantly need to refer to the documentation about a particular function (e.g. `printf` etc) in order to learn the finer aspects of the function.

This means I need to constantly do `doc:show` in the shell or refer to the elvish website and this breaks my editing "flow".

This PR automatically shows the `doc:show` (if available) for anything on the cursor **in a hover.**

The implementation is quite simple and it could be more sophisticated but it's working quite well for me.