### PR TITLE
Implement `path:stat`

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -2,6 +2,8 @@ Draft release notes for Elvish 0.20.0.
 
 # Notable new features
 
+-   A new `path:stat` command ([#1659](https://b.elv.sh/1659)).
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/mods/path/path.d.elv
+++ b/pkg/mods/path/path.d.elv
@@ -197,3 +197,107 @@ fn temp-dir {|&dir='' pattern?| }
 # ▶ /some/dir/elvish-RANDOMSTR
 # ```
 fn temp-file {|&dir='' pattern?| }
+
+# Output a pseudo-map containing metadata about one or more paths.
+#
+# If passed zero path names it does nothing; otherwise, it iterates over the
+# list of path names and attempts to determine the characteristics of each
+# path. It outputs a [psuedo-map](language.html#pseudo-map) that exposes the
+# metadata about each path.
+#
+# Like the traditional Unix `stat` command an error processing a path name
+# does not immediately terminate processing the list of path names. This
+# command attempts to stat the remaining path names. This can result in a
+# "multiple error" exception that documents each path that could not stat'd
+# while still outputting information about some paths.
+#
+# If the `&follow-symlink` option is false and the path refers to a symbolic
+# link then metadata about the symlink is output. If `&follow-symlink` is
+# true then the metadata about the target of the symlink is output.
+#
+# The following keys are available in the pseudo-map. Whether the key has a
+# meaningful value depends on the platform.
+#
+# - `path`: The original path passed to the command. Available on all
+# platforms.
+#
+# - `abs-path`: The absolute path of the `path` value. Available on all
+# platforms.
+#
+# - `is-dir`: True if the path refers to a directory; otherwise, false.
+# Available on all platforms.
+#
+# - `size`: The size of the file in bytes. Available on all platforms.
+#
+# - `mode`: A numeric value describing the permissions and other attributes
+# of the file when interpreted as a bit pattern. The meaning of this value
+# depends on the platform. Available on all platforms.
+#
+# - `symbolic-mode`: A string representation of the `mode` value. Available on
+# all platforms.
+#
+# - `m-time`: The modification time of the file. Available on all platforms.
+#
+# - `a-time`: The access time of the file. Available on Unix and Windows.
+#
+# - `b-time`: The birth (i.e., creation) time of the file. Available on
+# Darwin (macOS) and Windows.
+#
+# - `c-time`: The status change time of the file. Status changes include
+# events such as changing the owner or permissions of the file. Available on
+# Unix.
+#
+# - `owner`: The user name for the `uid` that owns the file. Available on Unix.
+#
+# - `group`: The group name for the `gid` that owns the file. Available on Unix.
+#
+# - `uid`: The user ID that owns the file. Available on Unix.
+#
+# - `gid`: The group ID that owns the file. Available on Unix.
+#
+# - `num-links`: The number of hard links to the file. Available on Unix.
+#
+# - `inode`: The inode number of the file. Available on Unix.
+#
+# - `device`: The device ID of the filesystem containing file. Available on Unix.
+#
+# - `raw-device`: The raw device ID if the file is a device node (rather than
+# a directory, regular file, or symlink). Available on Unix.
+#
+# - `block-count`: The size of the file in blocks of `block-size`. Available on Unix.
+#
+# - `block-size`: The block size for I/O. Available on Unix.
+#
+# Example:
+#
+# ```elvish-transcript
+# ~> pwd
+# /tmp
+# ~> nop > f
+# ~> ls -l f
+# -rw-r----- 1 krader staff 0 Apr  1 19:53 f
+# ~> pprint (path:stat f)
+# [
+#  &path= f
+#  &abs-path=     /tmp/f
+#  &is-dir=       $false
+#  &size= (num 0)
+#  &mode= (num 416)
+#  &symbolic-mode=        -rw-r-----
+#  &m-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &a-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &b-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &c-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &owner=        krader
+#  &group=        staff
+#  &uid=  (num 501)
+#  &gid=  (num 20)
+#  &num-links=    (num 1)
+#  &inode=        (num 55886574)
+#  &device=       (num 16777229)
+#  &raw-device=   (num 0)
+#  &block-size=   (num 4096)
+#  &block-count=  (num 0)
+# ]
+# ```
+fn stat {|&follow-symlink=$false path...| }

--- a/pkg/mods/path/path_bsd.go
+++ b/pkg/mods/path/path_bsd.go
@@ -1,0 +1,55 @@
+//go:build freebsd || netbsd
+
+package path
+
+import (
+	_ "embed"
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os/user"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Stat_t)
+	var groupName, ownerName string
+	if user, err := user.LookupId(fmt.Sprintf("%d", extra.Uid)); err == nil {
+		ownerName = user.Username
+	} else {
+		ownerName = "<unknown>"
+	}
+	if group, err := user.LookupGroupId(fmt.Sprintf("%d", extra.Gid)); err == nil {
+		groupName = group.Name
+	} else {
+		groupName = "<unknown>"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return fileInfo{
+		Path:         path,
+		AbsPath:      absPath,
+		IsDir:        info.IsDir(),
+		Size:         big.NewInt(info.Size()),
+		Mode:         new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode: info.Mode().String(),
+		MTime:        info.ModTime(),
+		ATime:        time.Unix(extra.Atimespec.Sec, extra.Atimespec.Nsec),
+		BTime:        time.Unix(extra.Birthtimespec.Sec, extra.Birthtimespec.Nsec),
+		CTime:        time.Unix(extra.Ctimespec.Sec, extra.Ctimespec.Nsec),
+		Inode:        new(big.Int).SetUint64(extra.Ino),
+		Uid:          new(big.Int).SetUint64(uint64(extra.Uid)),
+		Gid:          new(big.Int).SetUint64(uint64(extra.Gid)),
+		NumLinks:     new(big.Int).SetUint64(uint64(extra.Nlink)),
+		Device:       new(big.Int).SetUint64(uint64(extra.Dev)),
+		RawDevice:    new(big.Int).SetUint64(uint64(extra.Rdev)),
+		BlockSize:    new(big.Int).SetUint64(uint64(extra.Blksize)),
+		BlockCount:   new(big.Int).SetUint64(uint64(extra.Blocks)),
+		Owner:        ownerName,
+		Group:        groupName,
+	}
+}

--- a/pkg/mods/path/path_darwin.go
+++ b/pkg/mods/path/path_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package path
+
+import (
+	_ "embed"
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os/user"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Stat_t)
+	var groupName, ownerName string
+	if user, err := user.LookupId(fmt.Sprintf("%d", extra.Uid)); err == nil {
+		ownerName = user.Username
+	} else {
+		ownerName = "<unknown>"
+	}
+	if group, err := user.LookupGroupId(fmt.Sprintf("%d", extra.Gid)); err == nil {
+		groupName = group.Name
+	} else {
+		groupName = "<unknown>"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return fileInfo{
+		Path:         path,
+		AbsPath:      absPath,
+		IsDir:        info.IsDir(),
+		Size:         big.NewInt(info.Size()),
+		Mode:         new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode: info.Mode().String(),
+		MTime:        info.ModTime(),
+		ATime:        time.Unix(extra.Atimespec.Sec, extra.Atimespec.Nsec),
+		BTime:        time.Unix(extra.Birthtimespec.Sec, extra.Birthtimespec.Nsec),
+		CTime:        time.Unix(extra.Ctimespec.Sec, extra.Ctimespec.Nsec),
+		Inode:        new(big.Int).SetUint64(extra.Ino),
+		Uid:          new(big.Int).SetUint64(uint64(extra.Uid)),
+		Gid:          new(big.Int).SetUint64(uint64(extra.Gid)),
+		NumLinks:     new(big.Int).SetUint64(uint64(extra.Nlink)),
+		Device:       new(big.Int).SetUint64(uint64(extra.Dev)),
+		RawDevice:    new(big.Int).SetUint64(uint64(extra.Rdev)),
+		BlockSize:    new(big.Int).SetUint64(uint64(extra.Blksize)),
+		BlockCount:   new(big.Int).SetUint64(uint64(extra.Blocks)),
+		Owner:        ownerName,
+		Group:        groupName,
+	}
+}

--- a/pkg/mods/path/path_linux.go
+++ b/pkg/mods/path/path_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package path
+
+import (
+	_ "embed"
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os/user"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Stat_t)
+	var groupName, ownerName string
+	if user, err := user.LookupId(fmt.Sprintf("%d", extra.Uid)); err == nil {
+		ownerName = user.Username
+	} else {
+		ownerName = "<unknown>"
+	}
+	if group, err := user.LookupGroupId(fmt.Sprintf("%d", extra.Gid)); err == nil {
+		groupName = group.Name
+	} else {
+		groupName = "<unknown>"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return fileInfo{
+		Path:         path,
+		AbsPath:      absPath,
+		IsDir:        info.IsDir(),
+		Size:         big.NewInt(info.Size()),
+		Mode:         new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode: info.Mode().String(),
+		MTime:        info.ModTime(),
+		// The coercion to int64 is so this works on 32-bit Linux platforms. On
+		// 64-bit Linux platforms the typecast is a no-op.
+		ATime:      time.Unix(int64(extra.Atim.Sec), int64(extra.Atim.Nsec)),
+		CTime:      time.Unix(int64(extra.Ctim.Sec), int64(extra.Ctim.Nsec)),
+		Inode:      new(big.Int).SetUint64(extra.Ino),
+		Uid:        new(big.Int).SetUint64(uint64(extra.Uid)),
+		Gid:        new(big.Int).SetUint64(uint64(extra.Gid)),
+		NumLinks:   new(big.Int).SetUint64(uint64(extra.Nlink)),
+		Device:     new(big.Int).SetUint64(uint64(extra.Dev)),
+		RawDevice:  new(big.Int).SetUint64(uint64(extra.Rdev)),
+		BlockSize:  new(big.Int).SetUint64(uint64(extra.Blksize)),
+		BlockCount: new(big.Int).SetUint64(uint64(extra.Blocks)),
+		Owner:      ownerName,
+		Group:      groupName,
+	}
+}

--- a/pkg/mods/path/path_openbsd.go
+++ b/pkg/mods/path/path_openbsd.go
@@ -1,0 +1,54 @@
+//go:build openbsd
+
+package path
+
+import (
+	_ "embed"
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os/user"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Stat_t)
+	var groupName, ownerName string
+	if user, err := user.LookupId(fmt.Sprintf("%d", extra.Uid)); err == nil {
+		ownerName = user.Username
+	} else {
+		ownerName = "<unknown>"
+	}
+	if group, err := user.LookupGroupId(fmt.Sprintf("%d", extra.Gid)); err == nil {
+		groupName = group.Name
+	} else {
+		groupName = "<unknown>"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return fileInfo{
+		Path:         path,
+		AbsPath:      absPath,
+		IsDir:        info.IsDir(),
+		Size:         big.NewInt(info.Size()),
+		Mode:         new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode: info.Mode().String(),
+		MTime:        info.ModTime(),
+		ATime:        time.Unix(extra.Atim.Unix()),
+		CTime:        time.Unix(extra.Ctim.Unix()),
+		Inode:        new(big.Int).SetUint64(extra.Ino),
+		Uid:          new(big.Int).SetUint64(uint64(extra.Uid)),
+		Gid:          new(big.Int).SetUint64(uint64(extra.Gid)),
+		NumLinks:     new(big.Int).SetUint64(uint64(extra.Nlink)),
+		Device:       new(big.Int).SetUint64(uint64(extra.Dev)),
+		RawDevice:    new(big.Int).SetUint64(uint64(extra.Rdev)),
+		BlockSize:    new(big.Int).SetUint64(uint64(extra.Blksize)),
+		BlockCount:   new(big.Int).SetUint64(uint64(extra.Blocks)),
+		Owner:        ownerName,
+		Group:        groupName,
+	}
+}

--- a/pkg/mods/path/path_test.go
+++ b/pkg/mods/path/path_test.go
@@ -61,6 +61,13 @@ func TestPath(t *testing.T) {
 		That("path:is-regular d/f").Puts(true),
 		That("path:is-regular bad").Puts(false),
 
+		That("put (path:stat d)[is-dir]").Puts(true),
+		That("put (path:stat d)[path]").Puts("d"),
+		That("put (path:stat d/f)[is-dir]").Puts(false),
+		That("put (path:stat d/f)[path]").Puts("d/f"),
+		That("put (path:stat d/f)[abs-path]").Puts(filepath.Join(tmpdir, "d", "f")),
+		That("put (path:stat d/f)[size]").Puts(0),
+
 		// Verify the commands for creating temporary filesystem objects work correctly.
 		That("var x = (path:temp-dir)", "rmdir $x", "put $x").Puts(
 			MatchingRegexp{Pattern: anyDir + `elvish-.*$`}),
@@ -136,6 +143,11 @@ func TestPath_Symlink(t *testing.T) {
 		That("path:is-regular s-bad &follow-symlink").Puts(false),
 		That("path:is-regular bad").Puts(false),
 		That("path:is-regular bad &follow-symlink").Puts(false),
+
+		That("put (path:stat s-d)[is-dir]").Puts(false),
+		That("put (path:stat &follow-symlink s-d)[is-dir]").Puts(true),
+		That("put (path:stat s-d-f)[is-dir]").Puts(false),
+		That("put (path:stat &follow-symlink s-d-f)[is-dir]").Puts(false),
 	)
 }
 

--- a/pkg/mods/path/path_windows.go
+++ b/pkg/mods/path/path_windows.go
@@ -1,3 +1,33 @@
+//go:build windows
+
 package path
 
+import (
+	_ "embed"
+	"io/fs"
+	"math/big"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
 const devTty = "CON"
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Win32FileAttributeData)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return fileInfo{
+		Path:         path,
+		AbsPath:      absPath,
+		IsDir:        info.IsDir(),
+		Size:         big.NewInt(info.Size()),
+		Mode:         new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode: info.Mode().String(),
+		MTime:        info.ModTime(),
+		ATime:        time.Unix(0, extra.LastAccessTime.Nanoseconds()),
+		BTime:        time.Unix(0, extra.CreationTime.Nanoseconds()),
+	}
+}


### PR DESCRIPTION
I originally started work on this to provide a mechanism to verify the behavior of other unit tests; e.g., a `path:chmod` command I'm working on. Primarily because the external `stat` command has different option names depending on whether you're on a BSD or Linux platform making it hard to use portably. However, since it seems like this could be generally useful I went ahead and implemented support for the metadata that is found on some, not all, platforms.

TBD is providing better support for interpretating the `mode` value.

Related: #1659