### PR TITLE
Implement `path:stat`

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -2,6 +2,8 @@ Draft release notes for Elvish 0.20.0.
 
 # Notable new features
 
+-   A new `path:stat` command ([#1659](https://b.elv.sh/1659)).
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/mods/path/path.d.elv
+++ b/pkg/mods/path/path.d.elv
@@ -116,7 +116,7 @@ fn join {|@path-component| }
 # ▶ true
 # ```
 #
-# See also [`path:is-regular`]().
+# See also [`path:is-regular`](), [`path:stat`]().
 fn is-dir {|&follow-symlink=$false path| }
 
 # Outputs `$true` if the path resolves to a regular file. If the final element of the path is a
@@ -135,7 +135,7 @@ fn is-dir {|&follow-symlink=$false path| }
 # ▶ false
 # ```
 #
-# See also [`path:is-dir`]().
+# See also [`path:is-dir`](), [`path:stat`]().
 fn is-regular {|&follow-symlink=$false path| }
 
 # Creates a new directory and outputs its name.
@@ -197,3 +197,129 @@ fn temp-dir {|&dir='' pattern?| }
 # ▶ /some/dir/elvish-RANDOMSTR
 # ```
 fn temp-file {|&dir='' pattern?| }
+
+# Output a [pseudo-map](language.html#pseudo-map) containing metadata for each
+# path.
+#
+# If passed zero path names it does nothing; otherwise, it iterates over the
+# list of path names and attempts to determine the characteristics of each
+# path. Like the traditional Unix `stat` command an error processing a path
+# name does not immediately terminate processing the list of path names. This
+# command attempts to stat the remaining path names. This can result in a
+# "multiple error" exception that documents each path that it could not stat
+# while still outputting information about the other paths.
+#
+# If the `&follow-symlink` option is false, and the path refers to a symbolic
+# link, then metadata about the symlink is output. If `&follow-symlink` is
+# true then the metadata about the target of the symlink is output.
+#
+# Some keys may have a constant value depending on the platform. For example,
+# Windows will always report `$false` for the `is-named-pipe` key since
+# windows does not support named pipes. The following keys are populated on
+# all platforms:
+#
+# - `abs-path`: The absolute path of the `path` value.
+#
+# - `is-char-device`: True if the path refers to a character device file.
+#
+# - `is-device`: True if the path refers to a device file.
+#
+# - `is-dir`: True if the path refers to a directory.
+#
+# - `is-named-pipe`: True if the path refers to a named pipe file.
+#
+# - `is-regular`: True if the path refers to a regular file.
+#
+# - `is-socket`: True if the path refers to a Unix domain socket file.
+#
+# - `is-symlink`: True if the path refers to a symbolic link file.
+#
+# - `m-time`: The modification time of the file.
+#
+# - `mode`: A number describing the "mode" of the file. This includes file
+# permissions and other attributes that describe various aspects of the file
+# (such as whether it is a regular file, directory, etc.). The value is
+# defined by the [Go fs API](https://pkg.go.dev/io/fs#FileMode).
+#
+# - `path`: The original path passed to the command.
+#
+# - `perms`: A number describing the permissions and set-uid, set-gid, and
+# sticky attributes of the file when interpreted as a bit pattern. The meaning
+# of this value depends on the platform. Note that on Windows only the user
+# write permission bit (0o200) is meangingful.
+#
+# - `size`: The size of the file in bytes.
+#
+# - `symbolic-mode`: A string representation of the `mode` value.
+#
+# - `symbolic-perms`: A string representation of the `perms` value.
+#
+# These keys are always present in the pseudo-map but might not be initialized
+# (thus having the "zero value") depending on the platform:
+#
+# - `a-time`: The access time of the file. Meaningful on Unix and Windows.
+#
+# - `b-time`: The birth (i.e., creation) time of the file. Meaningful on
+# FreeBSD, NetBSD, Darwin (macOS), and Windows.
+#
+# - `block-count`: The size of the file in blocks of `block-size`. Meaningful
+# on Unix.
+#
+# - `block-size`: The block size for I/O. Meaningful on Unix.
+#
+# - `c-time`: The status change time of the file. Status changes include
+# events such as changing the owner or permissions of the file. Meaningful on
+# Unix.
+#
+# - `device`: The device ID of the filesystem containing file. Meaningful on Unix.
+#
+# - `gid`: The group ID that owns the file. Meaningful on Unix.
+#
+# - `group`: The group name for the `gid` that owns the file. Meaningful on Unix.
+#
+# - `inode`: The inode number of the file. Meaningful on Unix.
+#
+# - `num-links`: The number of hard links to the file. Meaningful on Unix.
+#
+# - `owner`: The user name for the `uid` that owns the file. Meaningful on Unix.
+#
+# - `raw-device`: The raw device ID if the file is a device node (rather than
+# a directory, regular file, or symlink). Meaningful on Unix.
+#
+# - `uid`: The user ID that owns the file. Meaningful on Unix.
+#
+# Example:
+#
+# ```elvish-transcript
+# ~> pwd
+# /tmp
+# ~> nop > f
+# ~> ls -l f
+# -rw-r----- 1 krader staff 0 Apr  1 19:53 f
+# ~> pprint (path:stat f)
+# [
+#  &path= f
+#  &abs-path=     /tmp/f
+#  &is-dir=       $false
+#  &size= (num 0)
+#  &mode= (num 416)
+#  &symbolic-mode=        -rw-r-----
+#  &m-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &a-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &b-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &c-time=       <unknown 2023-04-04 13:48:33.672098599 -0700 PDT>
+#  &owner=        krader
+#  &group=        staff
+#  &uid=  (num 501)
+#  &gid=  (num 20)
+#  &num-links=    (num 1)
+#  &inode=        (num 55886574)
+#  &device=       (num 16777229)
+#  &raw-device=   (num 0)
+#  &block-size=   (num 4096)
+#  &block-count=  (num 0)
+# ]
+# ```
+#
+# See also [`path:is-dir`](), [`path:is-regular`]().
+fn stat {|&follow-symlink=$false path...| }

--- a/pkg/mods/path/path.go
+++ b/pkg/mods/path/path.go
@@ -3,13 +3,58 @@ package path
 
 import (
 	_ "embed"
+	"io/fs"
+	"math/big"
 	"os"
 	"path/filepath"
+	"time"
 
+	"src.elv.sh/pkg/errutil"
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vars"
 )
+
+// fileInfo exposes metadata from the os.Stat/os.Lstat functions.
+//
+// We ignore a few fs.FileMode bits, such as fs.ModeAppend, because they aren't
+// found on platforms currently supported by Elvish; e.g., Plan9.
+type fileInfo struct {
+	// These fields are populated on every platform. However, they might only be
+	// meaningful on some platforms. For example, on Windows the IsNamedPipe
+	// member will always be false.
+	Path          string
+	AbsPath       string
+	IsDir         bool
+	IsRegular     bool
+	IsSymlink     bool
+	IsDevice      bool
+	IsCharDevice  bool
+	IsNamedPipe   bool
+	IsSocket      bool
+	Size          *big.Int
+	Mode          *big.Int
+	SymbolicMode  string
+	Perms         *big.Int
+	SymbolicPerms string
+	MTime         time.Time
+	// These fields are only populated on some platforms.
+	ATime      time.Time
+	BTime      time.Time
+	CTime      time.Time
+	Owner      string
+	Group      string
+	Uid        *big.Int
+	Gid        *big.Int
+	NumLinks   *big.Int
+	Inode      *big.Int
+	Device     *big.Int
+	RawDevice  *big.Int
+	BlockSize  *big.Int
+	BlockCount *big.Int
+}
+
+func (fileInfo) IsStructMap() {}
 
 // Ns is the namespace for the path: module.
 var Ns = eval.BuildNsNamed("path").
@@ -30,6 +75,7 @@ var Ns = eval.BuildNsNamed("path").
 		"is-dir":        isDir,
 		"is-regular":    isRegular,
 		"join":          filepath.Join,
+		"stat":          stat,
 		"temp-dir":      tempDir,
 		"temp-file":     tempFile,
 	}).Ns()
@@ -97,4 +143,59 @@ func tempFile(opts mktempOpt, args ...string) (*os.File, error) {
 	}
 
 	return os.CreateTemp(opts.Dir, pattern)
+}
+
+const (
+	// These are the publicly visible auxiliary permission file mode bits. We
+	// map these to/from the Go fs package equivalents.
+	publicStickyBit = uint64(0o1000)
+	publicSetgidBit = uint64(0o2000)
+	publicSetuidBit = uint64(0o4000)
+)
+
+type statOpts struct{ FollowSymlink bool }
+
+func (opts *statOpts) SetDefaultOptions() {}
+
+// stat outputs a psuedo-map containing metadata about each path.
+func stat(fm *eval.Frame, opts statOpts, paths ...string) error {
+	var returnErr error
+	out := fm.ValueOutput()
+	for _, path := range paths {
+		var err error
+		var info os.FileInfo
+		if opts.FollowSymlink {
+			info, err = os.Stat(path)
+		} else {
+			info, err = os.Lstat(path)
+		}
+		if err != nil {
+			returnErr = errutil.Multi(returnErr, err)
+		} else {
+			out.Put(pathMetadata(path, info))
+		}
+	}
+	return returnErr
+}
+
+// publicPerms exposes only the public permission bits of the file mode to make
+// it easier for users to deal with the file permissions (which is a subset of
+// the file mode bits). This maps three Go internal permission bits (setuid,
+// setgid, sticky) to well known, legacy Unix, public bits to make is easier for
+// users to deal with the file permissions and to use the permissions in Elvish
+// commands such as `path:chmod`.
+func publicPerms(info fs.FileInfo) (uint64, string) {
+	perms := info.Mode() & (fs.ModePerm | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
+	symbolicPerms := perms.String()
+	numPerms := uint64(perms & fs.ModePerm)
+	if perms&fs.ModeSetuid == fs.ModeSetuid {
+		numPerms = numPerms | publicSetuidBit
+	}
+	if perms&fs.ModeSetgid == fs.ModeSetgid {
+		numPerms = numPerms | publicSetgidBit
+	}
+	if perms&fs.ModeSticky == fs.ModeSticky {
+		numPerms = numPerms | publicStickyBit
+	}
+	return numPerms, symbolicPerms
 }

--- a/pkg/mods/path/path_bsd.go
+++ b/pkg/mods/path/path_bsd.go
@@ -1,0 +1,14 @@
+//go:build freebsd || netbsd
+
+package path
+
+import (
+	"syscall"
+	"time"
+)
+
+func pathPlatformMetadata(fi *fileInfo, extra *syscall.Stat_t) {
+	fi.ATime = time.Unix(extra.Atimespec.Sec, extra.Atimespec.Nsec)
+	fi.BTime = time.Unix(extra.Birthtimespec.Sec, extra.Birthtimespec.Nsec)
+	fi.CTime = time.Unix(extra.Ctimespec.Sec, extra.Ctimespec.Nsec)
+}

--- a/pkg/mods/path/path_darwin.go
+++ b/pkg/mods/path/path_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package path
+
+import (
+	"syscall"
+	"time"
+)
+
+func pathPlatformMetadata(fi *fileInfo, extra *syscall.Stat_t) {
+	fi.ATime = time.Unix(extra.Atimespec.Sec, extra.Atimespec.Nsec)
+	fi.BTime = time.Unix(extra.Birthtimespec.Sec, extra.Birthtimespec.Nsec)
+	fi.CTime = time.Unix(extra.Ctimespec.Sec, extra.Ctimespec.Nsec)
+}

--- a/pkg/mods/path/path_linux.go
+++ b/pkg/mods/path/path_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package path
+
+import (
+	"syscall"
+	"time"
+)
+
+func pathPlatformMetadata(fi *fileInfo, extra *syscall.Stat_t) {
+	fi.ATime = time.Unix(int64(extra.Atim.Sec), int64(extra.Atim.Nsec))
+	fi.CTime = time.Unix(int64(extra.Ctim.Sec), int64(extra.Ctim.Nsec))
+}

--- a/pkg/mods/path/path_openbsd.go
+++ b/pkg/mods/path/path_openbsd.go
@@ -1,0 +1,13 @@
+//go:build openbsd
+
+package path
+
+import (
+	"syscall"
+	"time"
+)
+
+func pathPlatformMetadata(fi *fileInfo, extra *syscall.Stat_t) {
+	fi.ATime = time.Unix(extra.Atim.Unix())
+	fi.CTime = time.Unix(extra.Ctim.Unix())
+}

--- a/pkg/mods/path/path_test.go
+++ b/pkg/mods/path/path_test.go
@@ -61,6 +61,11 @@ func TestPath(t *testing.T) {
 		That("path:is-regular d/f").Puts(true),
 		That("path:is-regular bad").Puts(false),
 
+		That("put (path:stat d)[path]").Puts("d"),
+		That("put (path:stat d/f)[path]").Puts("d/f"),
+		That("put (path:stat d/f)[abs-path]").Puts(filepath.Join(tmpdir, "d", "f")),
+		That("put (path:stat d/f)[size]").Puts(0),
+
 		// Verify the commands for creating temporary filesystem objects work correctly.
 		That("var x = (path:temp-dir)", "rmdir $x", "put $x").Puts(
 			MatchingRegexp{Pattern: anyDir + `elvish-.*$`}),
@@ -136,6 +141,15 @@ func TestPath_Symlink(t *testing.T) {
 		That("path:is-regular s-bad &follow-symlink").Puts(false),
 		That("path:is-regular bad").Puts(false),
 		That("path:is-regular bad &follow-symlink").Puts(false),
+
+		That("put (path:stat s-d)[is-dir]").Puts(false),
+		That("put (path:stat s-d)[is-regular]").Puts(false),
+		That("put (path:stat &follow-symlink s-d)[is-dir]").Puts(true),
+		That("put (path:stat s-d-f)[is-dir]").Puts(false),
+		That("put (path:stat s-d-f)[is-regular]").Puts(false),
+		That("put (path:stat &follow-symlink s-d-f)[is-regular]").Puts(true),
+		That("put (path:stat s-d-f)[is-symlink]").Puts(true),
+		That("put (path:stat &follow-symlink s-d-f)[is-symlink]").Puts(false),
 	)
 }
 

--- a/pkg/mods/path/path_unix.go
+++ b/pkg/mods/path/path_unix.go
@@ -2,4 +2,67 @@
 
 package path
 
+import (
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os/user"
+	"path/filepath"
+	"syscall"
+)
+
 const devTty = "/dev/tty"
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Stat_t)
+	var groupName, ownerName string
+	if user, err := user.LookupId(fmt.Sprintf("%d", extra.Uid)); err == nil {
+		ownerName = user.Username
+	} else {
+		ownerName = "<unknown>"
+	}
+	if group, err := user.LookupGroupId(fmt.Sprintf("%d", extra.Gid)); err == nil {
+		groupName = group.Name
+	} else {
+		groupName = "<unknown>"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	perms, symbolicPerms := publicPerms(info)
+
+	// The coercion to uint64 below is so this works on 32-bit platforms where
+	// values like extra.Uid are 32-bit.
+	fi := fileInfo{
+		Path:        path,
+		AbsPath:     absPath,
+		IsDir:       info.IsDir(),
+		IsRegular:   info.Mode().IsRegular(),
+		IsNamedPipe: info.Mode()&fs.ModeNamedPipe == fs.ModeNamedPipe,
+		IsSymlink:   info.Mode()&fs.ModeSymlink == fs.ModeSymlink,
+		IsDevice:    info.Mode()&fs.ModeDevice == fs.ModeDevice,
+		IsCharDevice: info.Mode()&fs.ModeDevice == fs.ModeDevice &&
+			info.Mode()&fs.ModeCharDevice == fs.ModeCharDevice,
+		Mode:          new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode:  info.Mode().String(),
+		Perms:         new(big.Int).SetUint64(perms),
+		SymbolicPerms: symbolicPerms,
+		MTime:         info.ModTime(),
+		Size:          big.NewInt(info.Size()),
+		Inode:         new(big.Int).SetUint64(extra.Ino),
+		Uid:           new(big.Int).SetUint64(uint64(extra.Uid)),
+		Gid:           new(big.Int).SetUint64(uint64(extra.Gid)),
+		NumLinks:      new(big.Int).SetUint64(uint64(extra.Nlink)),
+		Device:        new(big.Int).SetUint64(uint64(extra.Dev)),
+		RawDevice:     new(big.Int).SetUint64(uint64(extra.Rdev)),
+		BlockSize:     new(big.Int).SetUint64(uint64(extra.Blksize)),
+		BlockCount:    new(big.Int).SetUint64(uint64(extra.Blocks)),
+		Owner:         ownerName,
+		Group:         groupName,
+	}
+	// Apply any Unix Unix OS specific modifications of the structure. This is
+	// just the auxiliary timestamps at this time.
+	pathPlatformMetadata(&fi, extra)
+	return fi
+}

--- a/pkg/mods/path/path_windows.go
+++ b/pkg/mods/path/path_windows.go
@@ -1,3 +1,46 @@
+//go:build windows
+
 package path
 
+import (
+	"io/fs"
+	"math/big"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
 const devTty = "CON"
+
+func pathMetadata(path string, info fs.FileInfo) fileInfo {
+	extra := info.Sys().(*syscall.Win32FileAttributeData)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	perms, symbolicPerms := publicPerms(info)
+
+	// Some of the mode translations (such as setting the IsNamedPipe struct
+	// member) are probably never true on Windows. Nonetheless, we include them
+	// for symmetry with Unix and because I might be mistaken in about whether
+	// they are, or are not, applicable on Windows.
+	return fileInfo{
+		Path:        path,
+		AbsPath:     absPath,
+		IsDir:       info.IsDir(),
+		IsRegular:   info.Mode().IsRegular(),
+		IsNamedPipe: info.Mode()&fs.ModeNamedPipe == fs.ModeNamedPipe,
+		IsSymlink:   info.Mode()&fs.ModeSymlink == fs.ModeSymlink,
+		IsDevice:    info.Mode()&fs.ModeDevice == fs.ModeDevice,
+		IsCharDevice: info.Mode()&fs.ModeDevice == fs.ModeDevice &&
+			info.Mode()&fs.ModeCharDevice == fs.ModeCharDevice,
+		Size:          big.NewInt(info.Size()),
+		Mode:          new(big.Int).SetUint64(uint64(info.Mode())),
+		SymbolicMode:  info.Mode().String(),
+		Perms:         new(big.Int).SetUint64(perms),
+		SymbolicPerms: symbolicPerms,
+		MTime:         info.ModTime(),
+		ATime:         time.Unix(0, extra.LastAccessTime.Nanoseconds()),
+		BTime:         time.Unix(0, extra.CreationTime.Nanoseconds()),
+	}
+}


### PR DESCRIPTION
In theory the `path:stat` command introduced by this change allows an Elvish implementation of something like the Unix `ls`, or Windows `dir`, command. More importantly, it provides a more general API than builtins like `path:is-dir` and `path:is-regular`. Making it possible to test many other path attributes. I didn't deprecate those related commands because they are probably used often enough it doesn't make sense to deprecate them.

Related: #1659