### PR TITLE
Implement `os:remove`

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -2,6 +2,8 @@ Draft release notes for Elvish 0.20.0.
 
 # Notable new features
 
+-   A new `os:remove` command ([#1659](https://b.elv.sh/1659)).
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/mods/doc/doc.go
+++ b/pkg/mods/doc/doc.go
@@ -17,6 +17,7 @@ import (
 	"src.elv.sh/pkg/mods/file"
 	"src.elv.sh/pkg/mods/flag"
 	"src.elv.sh/pkg/mods/math"
+	"src.elv.sh/pkg/mods/os"
 	"src.elv.sh/pkg/mods/path"
 	"src.elv.sh/pkg/mods/platform"
 	"src.elv.sh/pkg/mods/re"
@@ -161,6 +162,7 @@ var modToCode = map[string]io.Reader{
 	"file:":            read(file.DElvCode),
 	"flag:":            read(flag.DElvCode),
 	"math:":            read(math.DElvCode),
+	"os:":              read(os.DElvCode),
 	"path:":            read(path.DElvCode),
 	"platform:":        read(platform.DElvCode),
 	"re:":              read(re.DElvCode),

--- a/pkg/mods/os/os.d.elv
+++ b/pkg/mods/os/os.d.elv
@@ -1,0 +1,32 @@
+# Removes one or more path names.
+#
+# If passed zero path names it does nothing; otherwise, it iterates over the
+# list of path names and attempts to remove each one. If a path name does not
+# exist or cannot be removed (perhaps because it is a non-empty directory or
+# permissions do not allow the operation) an exception is raised.
+#
+# Like the traditional Unix `rm` command an error processing a path name does
+# not immediately terminate processing the list of path names. This command
+# attempts to remove the remaining path names. This can result in a "multiple
+# error" exception that documents each path that could not be removed.
+#
+# If the `&missing-ok` option is set to true a path name that does not
+# exist is silently ignored.
+#
+# If the `&recursive` option is true a path name that refers to a directory is
+# removed recursively. If this option is false then attempting to remove a
+# directory that is not empty will fail.
+#
+# ```elvish-transcript
+# ~> mkdir elv
+# ~> mkdir elv/d
+# ~> touch elv/a
+# ~> touch elv/d/a
+# ~> os:remove elv/x
+# Exception: path does not exist: elv/x
+# ~> os:remove &missing-okay elv/x
+# ~> os:remove elv
+# Exception: remove elv/d: directory not empty
+# ~> os:remove &recursive elv
+# ```
+fn remove {|&missing-ok=$false &recursive=$false path...| }

--- a/pkg/mods/os/os.go
+++ b/pkg/mods/os/os.go
@@ -1,0 +1,78 @@
+// Package path provides functions for manipulating filesystem path names.
+package os
+
+import (
+	_ "embed"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"src.elv.sh/pkg/errutil"
+	"src.elv.sh/pkg/eval"
+)
+
+// Ns is the namespace for the path: module.
+var Ns = eval.BuildNsNamed("path").
+	AddGoFns(map[string]any{
+		"remove": remove,
+	}).Ns()
+
+// DElvCode contains the content of the .d.elv file for this module.
+//
+//go:embed *.d.elv
+var DElvCode string
+
+type rmOpts struct {
+	MissingOk bool
+	Recursive bool
+}
+
+func (opts *rmOpts) SetDefaultOptions() {}
+
+// remove deletes filesystem paths.
+func remove(opts rmOpts, args ...string) error {
+	var returnErr error
+	for _, path := range args {
+		err := recursiveRemove(path, opts.Recursive, opts.MissingOk)
+		returnErr = errutil.Multi(returnErr, err)
+	}
+	return returnErr
+}
+
+// recursiveRemove deletes a filesystem path. It optimistically assumes that any
+// path refers to a non-directory or an empty directory. If a directory is not
+// empty, and the `recursive` option is true, it will attempt to do a
+// depth-first removal of the path. This does not use the Go os.RemoveAll
+// function because we want to include all paths that could not be removed in
+// the error this can return. We also want to distinguish between a path not
+// existing versus other errors and os.RemoveAll makes that harder. The logic is
+// simpler if we only rely on os.Remove to disambiguate these cases.
+func recursiveRemove(path string, recursive bool, MissingOk bool) error {
+	err := os.Remove(path)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		if MissingOk {
+			return nil
+		}
+	} else if isDirNotEmpty(err.(*fs.PathError).Unwrap()) {
+		if !recursive {
+			return err
+		}
+		dirEntries, suberr := os.ReadDir(path)
+		if suberr != nil {
+			return errutil.Multi(err, suberr)
+		}
+		err = nil
+		for _, f := range dirEntries {
+			path := filepath.Join(path, f.Name())
+			suberr := recursiveRemove(path, recursive, MissingOk)
+			err = errutil.Multi(err, suberr)
+		}
+		suberr = os.Remove(path)
+		return errutil.Multi(err, suberr)
+	}
+	return err
+}

--- a/pkg/mods/os/os_test.go
+++ b/pkg/mods/os/os_test.go
@@ -1,0 +1,61 @@
+package os
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"src.elv.sh/pkg/eval"
+	. "src.elv.sh/pkg/eval/evaltest"
+	"src.elv.sh/pkg/testutil"
+)
+
+var removePaths = testutil.Dir{
+	"a": "",
+	"d": testutil.Dir{
+		"b": "",
+		"e": testutil.Dir{
+			"f": "",
+		},
+		"c": "",
+	},
+}
+
+var removeSymlinks = []struct {
+	path   string
+	target string
+}{
+	{"s-bad", "/argle/bargle"},
+	{"d/s-f", "b"},
+}
+
+func TestPathRemove(t *testing.T) {
+	tmpdir := testutil.InTempDir(t)
+	testutil.ApplyDir(removePaths)
+	for _, link := range removeSymlinks {
+		err := os.Symlink(link.target, link.path)
+		if err != nil {
+			// Creating symlinks requires a special permission on Windows. If
+			// the user doesn't have that permission, just skip the whole test.
+			t.Skip(err)
+		}
+	}
+
+	// Note that the order of these tests is important as subsequent tests rely
+	// on prior tests having removed specific files.
+	TestWithSetup(t, importModules,
+		That("os:remove").DoesNothing(),
+		That("os:remove does-not-exist").Throws(ErrorWithType(&os.PathError{})),
+		That("os:remove &missing-ok does-not-exist").DoesNothing(),
+		That("os:remove "+filepath.Join(tmpdir, "d", "e")).Throws(ErrorWithType(&os.PathError{})),
+		That("put d/**").Puts("d/e/f", "d/b", "d/c", "d/e", "d/s-f"),
+		That("os:remove &recursive "+filepath.Join(tmpdir, "d", "e")).DoesNothing(),
+		That("put d/**").Puts("d/b", "d/c", "d/s-f"),
+		That("os:remove &recursive *").DoesNothing(),
+		That("put **").Throws(eval.ErrWildcardNoMatch),
+	)
+}
+
+func importModules(ev *eval.Evaler) {
+	ev.ExtendGlobal(eval.BuildNs().AddNs("os", Ns))
+}

--- a/pkg/mods/os/os_unix.go
+++ b/pkg/mods/os/os_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package os
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// isDirNotEmpty returns a bool that indicates whether the error corresponds to a
+// platform specific syscall error that indicates a directory is not empty.
+func isDirNotEmpty(err error) bool {
+	return errors.Is(err, unix.ENOTEMPTY)
+}

--- a/pkg/mods/os/os_windows.go
+++ b/pkg/mods/os/os_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package os
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isDirNotEmpty returns a bool that indicates whether the error corresponds to a
+// platform specific syscall error that indicates a directory is not empty.
+func isDirNotEmpty(err error) bool {
+	return errors.Is(err, windows.ERROR_DIR_NOT_EMPTY)
+}

--- a/website/ref/index.toml
+++ b/website/ref/index.toml
@@ -45,6 +45,10 @@ name = "math"
 title = "math: Math Utilities"
 
 [[articles]]
+name = "os"
+title = "os: Operating System Utilities"
+
+[[articles]]
 name = "path"
 title = "path: Filesystem Path Utilities"
 

--- a/website/ref/os.md
+++ b/website/ref/os.md
@@ -1,0 +1,15 @@
+<!-- toc -->
+
+@module os
+
+# Introduction
+
+The `os:` module provides commands for performing operating system specific
+functions such as creating directories and removing files. The commands in this
+module are, for the most part, OS agnostic. That is, commands such as
+`os:remove` can be expected to behave more or less the same regardless of the
+the platform Elvish is running on. Where that is not true it will be noted in
+the documentation of the command.
+
+Function usages are given in the same format as in the reference doc for the
+[builtin module](builtin.html).


### PR DESCRIPTION
I considered adhering more closely to the traditional Unix `rm` and `rmdir` commands. For example, by implementing each independently and supporting the `--force` option. However, I concluded there are insufficient reasons to do so. In particular, the POSIX `--force` (or `-f`) option is most often used solely for its side-effect of making elimination of a non-existent path a non-error. I also don't like that `-f` also fixes permission errors to allow allow removing files. If we decide that feature is needed it should be added under a distinct option (e.g. `&fix-perms`).

Related: #1659