### PR TITLE
`pprint` (and `repr`) now sorts map keys

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -7,6 +7,11 @@ Draft release notes for Elvish 0.20.0.
 -   The language server now supports showing the documentation of builtin
     functions and variables on hover ([#1684](https://b.elv.sh/1684)).
 
+# Notable fixes and enhancements
+
+-   The `pprint` and `repr` commands now sort map keys
+    ([#1495](https://b.elv.sh/1495)).
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -9,6 +9,7 @@ import (
 	"src.elv.sh/pkg/eval/errs"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
+	"src.elv.sh/pkg/strutil"
 )
 
 func TestPut(t *testing.T) {
@@ -68,7 +69,29 @@ func TestEcho(t *testing.T) {
 
 func TestPprint(t *testing.T) {
 	Test(t,
-		That(`pprint [foo bar]`).Prints("[\n foo\n bar\n]\n"),
+		That(`pprint [foo bar]`).Prints(strutil.Dedent(`
+			[
+			 foo
+			 bar
+			]
+		`)),
+		That(`
+			var map = [&(num 4)=4 &(num 0)=0 &(num 2)=2 &def=z &abc=y
+				&$false=false &(num 1)=1 &$true=true &xyz=x]
+			pprint $map
+		`).Prints(strutil.Dedent(`
+			[
+			 &abc=	y
+			 &def=	z
+			 &xyz=	x
+			 &$false=	false
+			 &$true=	true
+			 &(num 0)=	0
+			 &(num 1)=	1
+			 &(num 2)=	2
+			 &(num 4)=	4
+			]
+		`)),
 		thatOutputErrorIsBubbled("pprint foo"),
 	)
 }

--- a/pkg/eval/builtin_fn_pred.go
+++ b/pkg/eval/builtin_fn_pred.go
@@ -1,9 +1,6 @@
 package eval
 
 import (
-	"math"
-	"math/big"
-
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vals"
 )
@@ -59,119 +56,14 @@ var ErrUncomparable = errs.BadValue{
 	Valid: "comparable values", Actual: "uncomparable values"}
 
 func compare(fm *Frame, a, b any) (int, error) {
-	switch cmp(a, b) {
-	case less:
+	switch vals.Cmp(a, b) {
+	case vals.CmpLess:
 		return -1, nil
-	case equal:
+	case vals.CmpEqual:
 		return 0, nil
-	case more:
+	case vals.CmpMore:
 		return 1, nil
 	default:
 		return 0, ErrUncomparable
-	}
-}
-
-type ordering uint8
-
-const (
-	less ordering = iota
-	equal
-	more
-	uncomparable
-)
-
-func cmp(a, b any) ordering {
-	switch a := a.(type) {
-	case int, *big.Int, *big.Rat, float64:
-		switch b.(type) {
-		case int, *big.Int, *big.Rat, float64:
-			a, b := vals.UnifyNums2(a, b, 0)
-			switch a := a.(type) {
-			case int:
-				return compareInt(a, b.(int))
-			case *big.Int:
-				return compareInt(a.Cmp(b.(*big.Int)), 0)
-			case *big.Rat:
-				return compareInt(a.Cmp(b.(*big.Rat)), 0)
-			case float64:
-				return compareFloat(a, b.(float64))
-			default:
-				panic("unreachable")
-			}
-		}
-	case string:
-		if b, ok := b.(string); ok {
-			switch {
-			case a == b:
-				return equal
-			case a < b:
-				return less
-			default: // a > b
-				return more
-			}
-		}
-	case vals.List:
-		if b, ok := b.(vals.List); ok {
-			aIt := a.Iterator()
-			bIt := b.Iterator()
-			for aIt.HasElem() && bIt.HasElem() {
-				o := cmp(aIt.Elem(), bIt.Elem())
-				if o != equal {
-					return o
-				}
-				aIt.Next()
-				bIt.Next()
-			}
-			switch {
-			case a.Len() == b.Len():
-				return equal
-			case a.Len() < b.Len():
-				return less
-			default: // a.Len() > b.Len()
-				return more
-			}
-		}
-	case bool:
-		if b, ok := b.(bool); ok {
-			switch {
-			case a == b:
-				return equal
-			//lint:ignore S1002 using booleans as values, not conditions
-			case a == false: // b == true is implicit
-				return less
-			default: // a == true && b == false
-				return more
-			}
-		}
-	}
-	return uncomparable
-}
-
-func compareInt(a, b int) ordering {
-	if a < b {
-		return less
-	} else if a > b {
-		return more
-	}
-	return equal
-}
-
-func compareFloat(a, b float64) ordering {
-	// For the sake of ordering, NaN's are considered equal to each
-	// other and smaller than all numbers
-	switch {
-	case math.IsNaN(a):
-		if math.IsNaN(b) {
-			return equal
-		}
-		return less
-	case math.IsNaN(b):
-		return more
-	case a < b:
-		return less
-	case a > b:
-		return more
-	default: // a == b
-		return equal
 	}
 }

--- a/pkg/eval/builtin_fn_stream.go
+++ b/pkg/eval/builtin_fn_stream.go
@@ -208,12 +208,12 @@ func (s *slice) Less(i, j int) bool {
 
 	if s.lessThan == nil {
 		// Use the builtin comparator.
-		o := cmp(a, b)
-		if o == uncomparable {
+		o := vals.Cmp(a, b)
+		if o == vals.Uncomparable {
 			s.err = ErrUncomparable
 			return true
 		}
-		return o == less
+		return o == vals.CmpLess
 	}
 
 	// Use the &less-than callback.

--- a/pkg/eval/vals/compare.go
+++ b/pkg/eval/vals/compare.go
@@ -1,0 +1,131 @@
+package vals
+
+import (
+	"math"
+	"math/big"
+)
+
+type ordering uint8
+
+const (
+	CmpLess ordering = iota
+	CmpEqual
+	CmpMore
+	Uncomparable
+)
+
+// Cmp compares two arbitrary Elvish types and returns a value that indicates
+// whether the values are not comparable or the first value is less, equal, or
+// greater than the second value.
+func Cmp(a, b any) ordering {
+	switch a := a.(type) {
+	case int, *big.Int, *big.Rat, float64:
+		switch b.(type) {
+		case int, *big.Int, *big.Rat, float64:
+			a, b := UnifyNums2(a, b, 0)
+			switch a := a.(type) {
+			case int:
+				return cmpInt(a, b.(int))
+			case *big.Int:
+				return cmpInt(a.Cmp(b.(*big.Int)), 0)
+			case *big.Rat:
+				return cmpInt(a.Cmp(b.(*big.Rat)), 0)
+			case float64:
+				return cmpFloat(a, b.(float64))
+			default:
+				panic("unreachable")
+			}
+		}
+	case string:
+		if b, ok := b.(string); ok {
+			switch {
+			case a == b:
+				return CmpEqual
+			case a < b:
+				return CmpLess
+			default: // a > b
+				return CmpMore
+			}
+		}
+	case List:
+		if b, ok := b.(List); ok {
+			aIt := a.Iterator()
+			bIt := b.Iterator()
+			for aIt.HasElem() && bIt.HasElem() {
+				o := Cmp(aIt.Elem(), bIt.Elem())
+				if o != CmpEqual {
+					return o
+				}
+				aIt.Next()
+				bIt.Next()
+			}
+			switch {
+			case a.Len() == b.Len():
+				return CmpEqual
+			case a.Len() < b.Len():
+				return CmpLess
+			default: // a.Len() > b.Len()
+				return CmpMore
+			}
+		}
+	case bool:
+		if b, ok := b.(bool); ok {
+			switch {
+			case a == b:
+				return CmpEqual
+			//lint:ignore S1002 using booleans as values, not conditions
+			case a == false: // b == true is implicit
+				return CmpLess
+			default: // a == true && b == false
+				return CmpMore
+			}
+		}
+	}
+	return Uncomparable
+}
+
+func cmpInt(a, b int) ordering {
+	if a < b {
+		return CmpLess
+	} else if a > b {
+		return CmpMore
+	}
+	return CmpEqual
+}
+
+func cmpFloat(a, b float64) ordering {
+	// For the sake of ordering, NaN's are considered equal to each
+	// other and smaller than all numbers
+	switch {
+	case math.IsNaN(a):
+		if math.IsNaN(b) {
+			return CmpEqual
+		}
+		return CmpLess
+	case math.IsNaN(b):
+		return CmpMore
+	case a < b:
+		return CmpLess
+	case a > b:
+		return CmpMore
+	default: // a == b
+		return CmpEqual
+	}
+}
+
+// CmpSlice is useful when you need to sort a set of values; e.g., map keys.
+type CmpSlice []any
+
+func (s CmpSlice) Len() int { return len(s) }
+
+func (s CmpSlice) Less(i, j int) bool {
+	o := Cmp(s[i], s[j])
+	if o == Uncomparable {
+		return true
+	}
+	return o == CmpLess
+}
+
+func (s CmpSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/eval/vals/repr.go
+++ b/pkg/eval/vals/repr.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"sort"
 	"strconv"
 
 	"src.elv.sh/pkg/parse"
@@ -60,18 +61,9 @@ func Repr(v any, indent int) string {
 	case File:
 		return fmt.Sprintf("<file{%s %d}>", parse.Quote(v.Name()), v.Fd())
 	case List:
-		b := NewListReprBuilder(indent)
-		for it := v.Iterator(); it.HasElem(); it.Next() {
-			b.WriteElem(Repr(it.Elem(), indent+1))
-		}
-		return b.String()
+		return reprList(v, indent)
 	case Map:
-		builder := NewMapReprBuilder(indent)
-		for it := v.Iterator(); it.HasElem(); it.Next() {
-			k, v := it.Elem()
-			builder.WritePair(Repr(k, indent+1), indent+2, Repr(v, indent+2))
-		}
-		return builder.String()
+		return reprMap(v, indent)
 	case StructMap:
 		return reprStructMap(v, indent)
 	case PseudoStructMap:
@@ -79,6 +71,32 @@ func Repr(v any, indent int) string {
 	default:
 		return fmt.Sprintf("<unknown %v>", v)
 	}
+}
+
+func reprList(v List, indent int) string {
+	b := NewListReprBuilder(indent)
+	for it := v.Iterator(); it.HasElem(); it.Next() {
+		b.WriteElem(Repr(it.Elem(), indent+1))
+	}
+	return b.String()
+}
+
+func reprMap(v Map, indent int) string {
+	builder := NewMapReprBuilder(indent)
+	var keys CmpSlice
+	for it := v.Iterator(); it.HasElem(); it.Next() {
+		k, _ := it.Elem()
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+	for _, key := range keys {
+		val, ok := v.Index(key)
+		if !ok { // this is a "can't happen" situation but we are paranoid
+			panic(fmt.Sprintf("hashmap.Index() failed for key: %v", key))
+		}
+		builder.WritePair(Repr(key, indent+1), indent+2, Repr(val, indent+2))
+	}
+	return builder.String()
 }
 
 func reprStructMap(v StructMap, indent int) string {

--- a/pkg/strutil/dedent.go
+++ b/pkg/strutil/dedent.go
@@ -1,0 +1,59 @@
+package strutil
+
+// This code is a fork of https://github.com/lithammer/dedent, but with a fix
+// for https://github.com/lithammer/dedent/issues/20 so that we can use raw
+// strings in a natural manner by placing the first indented line on a new line
+// following the opening backtick.
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	whitespaceOnly    = regexp.MustCompile("(?m)^[ \t]+$")
+	leadingWhitespace = regexp.MustCompile("(?m)(^[ \t]*)(?:[^ \t\n])")
+)
+
+// Dedent removes any common leading whitespace from every line in text. An
+// initial newline is removed.
+//
+// This can be used to make multiline (usually raw) strings to line up with the
+// left edge of the display, while still presenting them in the source code in
+// indented form.
+func Dedent(text string) string {
+	var margin string
+
+	if text[0] == '\n' {
+		text = whitespaceOnly.ReplaceAllString(text[1:], "")
+	} else {
+		text = whitespaceOnly.ReplaceAllString(text, "")
+	}
+	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
+
+	// Look for the longest leading string of spaces and tabs common to all
+	// lines.
+	for i, indent := range indents {
+		if i == 0 {
+			margin = indent[1]
+		} else if strings.HasPrefix(indent[1], margin) {
+			// Current line more deeply indented than previous winner:
+			// no change (previous winner is still on top).
+			continue
+		} else if strings.HasPrefix(margin, indent[1]) {
+			// Current line consistent with and no deeper than previous winner:
+			// it's the new winner.
+			margin = indent[1]
+		} else {
+			// Current line and previous winner have no common whitespace:
+			// there is no margin.
+			margin = ""
+			break
+		}
+	}
+
+	if margin != "" {
+		text = regexp.MustCompile("(?m)^"+margin).ReplaceAllString(text, "")
+	}
+	return text
+}


### PR DESCRIPTION
This change is more invasive than I expected because the existing Elvish value comparison code was in `pkg/eval` rather than `pkg/eval/vals`. This moves the value comparison logic into the `vals` package so it can be used by packges other than `eval`. For example, the vals package `repr` implementation. Not to mention other Elvish modules which may want to compare Elvish values.

I also decided to introduce a `strutil.Dedent` function to make it easier to write multiline string literals in unit tests while retaining readability.

Related: 1495