### PR TITLE
`pprint` and `repr` now sort map keys

### DIFF
--- a/0.20.0-release-notes.md
+++ b/0.20.0-release-notes.md
@@ -7,6 +7,14 @@ Draft release notes for Elvish 0.20.0.
 -   The language server now supports showing the documentation of builtin
     functions and variables on hover ([#1684](https://b.elv.sh/1684)).
 
+# Notable fixes and enhancements
+
+-   The `pprint` and `repr` commands now sort map keys
+    ([#1495](https://b.elv.sh/1495)).
+
+-   The `compare` and `order` commands have a new `&types` option to order
+    otherwise uncomparable types.
+
 # Breaking changes
 
 -   The `except` keyword in the `try` command was deprecated since 0.18.0 and is

--- a/pkg/eval/builtin_fn_io.d.elv
+++ b/pkg/eval/builtin_fn_io.d.elv
@@ -192,6 +192,9 @@ fn echo {|&sep=' ' @value| }
 # ]
 # ```
 #
+# Maps (both mutable and [pseudo](language.html#pseudo-map)) are output with
+# their keys sorted in the same order as `keys $map | order &types`.
+#
 # The output format is subject to change.
 #
 # See also [`repr`]().
@@ -204,6 +207,9 @@ fn pprint {|@value| }
 # ~> repr [foo 'lorem ipsum'] "aha\n"
 # [foo 'lorem ipsum'] "aha\n"
 # ```
+#
+# Maps (both mutable and [pseudo](language.html#pseudo-map)) are output with
+# their keys sorted in the same order as `keys $map | order &types`.
 #
 # See also [`pprint`]().
 #

--- a/pkg/eval/builtin_fn_io_test.go
+++ b/pkg/eval/builtin_fn_io_test.go
@@ -9,6 +9,8 @@ import (
 	"src.elv.sh/pkg/eval/errs"
 	. "src.elv.sh/pkg/eval/evaltest"
 	"src.elv.sh/pkg/eval/vals"
+	"src.elv.sh/pkg/mods/re"
+	"src.elv.sh/pkg/strutil"
 )
 
 func TestPut(t *testing.T) {
@@ -57,6 +59,7 @@ func TestPrint(t *testing.T) {
 		That(`print foo bar &sep=,`).Prints("foo,bar"),
 		thatOutputErrorIsBubbled("print foo"),
 	)
+
 }
 
 func TestEcho(t *testing.T) {
@@ -67,8 +70,61 @@ func TestEcho(t *testing.T) {
 }
 
 func TestPprint(t *testing.T) {
-	Test(t,
-		That(`pprint [foo bar]`).Prints("[\n foo\n bar\n]\n"),
+	setup := func(ev *eval.Evaler) {
+		ev.ExtendGlobal(eval.BuildNs().AddNs("re", re.Ns))
+	}
+
+	TestWithSetup(t, setup,
+		// Verify a simple list is pretty printed as expected.
+		That(`pprint [foo bar]`).Prints(strutil.Dedent(`
+			[
+			 foo
+			 bar
+			]
+		`)),
+		// Verify regular map keys are sorted.
+		That(`
+			var map = [&(num 4)=4 &(num 0)=0 &(num 2)=2 &def=z &abc=y
+				&$false=false &(num 1)=1 &$true=true &xyz=x]
+			pprint $map
+		`).Prints(strutil.Dedent(`
+			[
+			 &$false=	false
+			 &$true=	true
+			 &(num 0)=	0
+			 &(num 1)=	1
+			 &(num 2)=	2
+			 &(num 4)=	4
+			 &abc=	y
+			 &def=	z
+			 &xyz=	x
+			]
+		`)),
+		// Verify pseudo map keys are sorted. We use the pseudo map returned by
+		// `re:find` because it is moderately complex and prior to the change
+		// that sorts map keys produces output that is not sorted.
+		That(`
+			var map = (re:find '(.)+' abc)
+			pprint $map
+		`).Prints(strutil.Dedent(`
+			[
+			 &end=	(num 3)
+			 &groups=	[
+			   [
+			    &end=	(num 3)
+			    &start=	(num 0)
+			    &text=	abc
+			   ]
+			   [
+			    &end=	(num 3)
+			    &start=	(num 2)
+			    &text=	c
+			   ]
+			  ]
+			 &start=	(num 0)
+			 &text=	abc
+			]
+		`)),
 		thatOutputErrorIsBubbled("pprint foo"),
 	)
 }

--- a/pkg/eval/builtin_fn_pred.d.elv
+++ b/pkg/eval/builtin_fn_pred.d.elv
@@ -119,9 +119,14 @@ fn not-eq {|@values| }
 # - Lists are compared lexicographically by elements, if the elements at the
 #   same positions are comparable.
 #
-# If the ordering between two elements is not defined by the conditions above,
-# i.e. if the value of `$a` or `$b` is not covered by any of the cases above or
-# if they belong to different cases, a "bad value" exception is thrown.
+# If `&types` is `$false` (the default), and the ordering between two elements
+# is not defined by the conditions above, i.e. if the value of `$a` or `$b` is
+# not covered by any of the cases above or if they belong to different cases,
+# a "bad value" exception is thrown.
+#
+# If `&types` is `$true` and the values are not comparable then the type of
+# each value is compared. The value types have the following relationship:
+# bool < num < string < list < map.
 #
 # Examples:
 #
@@ -134,10 +139,20 @@ fn not-eq {|@values| }
 # ▶ (num 0)
 # ~> compare (num 10) (num 1)
 # ▶ (num 1)
+# ~> compare (num 1) $true
+# Exception: bad value: inputs to "compare" or "order" must be comparable values, but is uncomparable values
+# ~> compare &types (num 1) $true
+# ▶ (num 1)
+# ~> compare (num 1) string
+# Exception: bad value: inputs to "compare" or "order" must be comparable values, but is uncomparable values
+# ~> compare &types (num 1) string
+# ▶ (num -1)
 # ```
 #
 # Beware that strings that look like numbers are treated as strings, not
-# numbers.
+# numbers. Also, unlike the other comparison commands (e.g., [`==`](#num-cmp)
+# and [`<`](#num-cmp)) this command requires exactly two values. If not given
+# two values an "arity mismatch" exception is thrown.
 #
 # See also [`order`]().
-fn compare {|a b| }
+fn compare {|&types=$false a b| }

--- a/pkg/eval/builtin_fn_pred.go
+++ b/pkg/eval/builtin_fn_pred.go
@@ -1,9 +1,6 @@
 package eval
 
 import (
-	"math"
-	"math/big"
-
 	"src.elv.sh/pkg/eval/errs"
 	"src.elv.sh/pkg/eval/vals"
 )
@@ -53,125 +50,37 @@ func notEq(args ...any) bool {
 }
 
 // ErrUncomparable is raised by the compare and order commands when inputs contain
-// uncomparable values.
+// uncomparable values and the commands haven't been told to do a secondary
+// ordering of the types.
 var ErrUncomparable = errs.BadValue{
 	What:  `inputs to "compare" or "order"`,
 	Valid: "comparable values", Actual: "uncomparable values"}
 
-func compare(fm *Frame, a, b any) (int, error) {
-	switch cmp(a, b) {
-	case less:
+type cmpOptions struct {
+	Types bool
+}
+
+func (opt *cmpOptions) SetDefaultOptions() {}
+
+func compare(fm *Frame, opts cmpOptions, a, b any) (int, error) {
+	switch vals.Cmp(a, b) {
+	case vals.CmpLess:
 		return -1, nil
-	case equal:
+	case vals.CmpEqual:
 		return 0, nil
-	case more:
+	case vals.CmpMore:
 		return 1, nil
-	default:
+	}
+	if !opts.Types {
 		return 0, ErrUncomparable
 	}
-}
-
-type ordering uint8
-
-const (
-	less ordering = iota
-	equal
-	more
-	uncomparable
-)
-
-func cmp(a, b any) ordering {
-	switch a := a.(type) {
-	case int, *big.Int, *big.Rat, float64:
-		switch b.(type) {
-		case int, *big.Int, *big.Rat, float64:
-			a, b := vals.UnifyNums2(a, b, 0)
-			switch a := a.(type) {
-			case int:
-				return compareInt(a, b.(int))
-			case *big.Int:
-				return compareInt(a.Cmp(b.(*big.Int)), 0)
-			case *big.Rat:
-				return compareInt(a.Cmp(b.(*big.Rat)), 0)
-			case float64:
-				return compareFloat(a, b.(float64))
-			default:
-				panic("unreachable")
-			}
-		}
-	case string:
-		if b, ok := b.(string); ok {
-			switch {
-			case a == b:
-				return equal
-			case a < b:
-				return less
-			default: // a > b
-				return more
-			}
-		}
-	case vals.List:
-		if b, ok := b.(vals.List); ok {
-			aIt := a.Iterator()
-			bIt := b.Iterator()
-			for aIt.HasElem() && bIt.HasElem() {
-				o := cmp(aIt.Elem(), bIt.Elem())
-				if o != equal {
-					return o
-				}
-				aIt.Next()
-				bIt.Next()
-			}
-			switch {
-			case a.Len() == b.Len():
-				return equal
-			case a.Len() < b.Len():
-				return less
-			default: // a.Len() > b.Len()
-				return more
-			}
-		}
-	case bool:
-		if b, ok := b.(bool); ok {
-			switch {
-			case a == b:
-				return equal
-			//lint:ignore S1002 using booleans as values, not conditions
-			case a == false: // b == true is implicit
-				return less
-			default: // a == true && b == false
-				return more
-			}
-		}
+	switch vals.CmpTypes(a, b) {
+	case vals.CmpLess:
+		return -1, nil
+	case vals.CmpEqual:
+		return 0, nil
+	case vals.CmpMore:
+		return 1, nil
 	}
-	return uncomparable
-}
-
-func compareInt(a, b int) ordering {
-	if a < b {
-		return less
-	} else if a > b {
-		return more
-	}
-	return equal
-}
-
-func compareFloat(a, b float64) ordering {
-	// For the sake of ordering, NaN's are considered equal to each
-	// other and smaller than all numbers
-	switch {
-	case math.IsNaN(a):
-		if math.IsNaN(b) {
-			return equal
-		}
-		return less
-	case math.IsNaN(b):
-		return more
-	case a < b:
-		return less
-	case a > b:
-		return more
-	default: // a == b
-		return equal
-	}
+	panic("vals.CmpTypes returned unexpected value")
 }

--- a/pkg/eval/builtin_fn_pred_test.go
+++ b/pkg/eval/builtin_fn_pred_test.go
@@ -3,7 +3,7 @@ package eval_test
 import (
 	"testing"
 
-	. "src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval"
 	. "src.elv.sh/pkg/eval/evaltest"
 )
 
@@ -92,8 +92,22 @@ func TestCompare(t *testing.T) {
 		That("compare [x, y] [x, y]").Puts(0),
 
 		// Uncomparable values.
-		That("compare 1 (num 1)").Throws(ErrUncomparable),
-		That("compare x [x]").Throws(ErrUncomparable),
-		That("compare a [&a=x]").Throws(ErrUncomparable),
+		That("compare 1 (num 1)").Throws(eval.ErrUncomparable),
+		That("compare x [x]").Throws(eval.ErrUncomparable),
+		That("compare a [&a=x]").Throws(eval.ErrUncomparable),
+
+		// This validates that comparing otherwise uncomparable types imposes an
+		// ordering on those types. This is obviously not exhaustive but helps
+		// ensure such comparisons have reasonable behavior consistent with the
+		// behavior of the `order` command or the implicent ordering of map keys
+		// by `pprint` and `repr`.
+		That("compare &types 1 (num 1)").Puts(1),
+		That("compare &types (num 1) 1").Puts(-1),
+		That("compare &types x [x]").Puts(-1),
+		That("compare &types [x] x").Puts(1),
+		That("compare &types [x] [x]").Puts(0),
+		That("compare &types a [&a=x]").Puts(-1),
+		That("compare &types [&a=x] a").Puts(1),
+		That("compare &types [&a=x] (num 1)").Puts(1),
 	)
 }

--- a/pkg/eval/builtin_fn_stream.d.elv
+++ b/pkg/eval/builtin_fn_stream.d.elv
@@ -176,19 +176,22 @@ fn count {|input-list?| }
 # sorting process is guaranteed to be
 # [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
 #
-# The `&less-than` option, if given, establishes the ordering of the items. Its
-# value should be a function that takes two arguments and outputs a single
+# The `&less-than` option, if given, establishes the ordering of the items.
+# Its value should be a function that takes two arguments and outputs a single
 # boolean indicating whether the first argument is less than the second
-# argument. If the function throws an exception, `order` rethrows the exception
-# without outputting any value.
+# argument. If the function throws an exception, `order` rethrows the
+# exception without outputting any value. If `&less-than` is not `$nil` then
+# the `&types` option is ignored.
 #
 # If `&less-than` is `$nil` (the default), a builtin comparator equivalent to
-# `{|a b| == -1 (compare $a $b) }` is used.
+# `{|a b| == -1 (compare $a $b) }` is used. If `&types` is `$true` and the
+# values are not comparable then the type of each value is compared. The value
+# types have the following relationship: bool < num < string < list < map.
 #
-# The `&key` option, if given, is a function that gets called with each item to
-# be sorted. It must output a single value, which is used for comparison in
-# place of the original value. If the function throws an exception, `order`
-# rethrows the exception.
+# The `&key` option, if not `$nil`, is a function that gets called with each
+# item to be sorted. It must output a single value, which is used for
+# comparison in place of the original value. If the function throws an
+# exception, `order` rethrows the exception.
 #
 # Use of `&key` can usually be rewritten to use `&less-than` instead, but using
 # `&key` is usually faster because the callback is only called once for each
@@ -235,6 +238,21 @@ fn count {|input-list?| }
 # ▶ m
 # ```
 #
+# Ordering uncomparable types:
+#
+# ```elvish-transcript
+# ~> order [1 (num 1) $true [b] $false [&k1=v1] [a]]
+# Exception: bad value: inputs to "compare" or "order" must be comparable values, but is uncomparable values
+# ~> order &types [1 (num 1) $true [b] $false [&k1=v1] [a]]
+# ▶ $false
+# ▶ $true
+# ▶ (num 1)
+# ▶ 1
+# ▶ [a]
+# ▶ [b]
+# ▶ [&k1=v1]
+# ```
+#
 # Beware that strings that look like numbers are treated as strings, not
 # numbers. To sort strings as numbers, use an explicit `&key` or `&less-than`:
 #
@@ -256,4 +274,4 @@ fn count {|input-list?| }
 # (The `$"<~"` syntax is a reference to [the `<` function](#num-cmp).)
 #
 # See also [`compare`]().
-fn order {|&less-than=$nil &key=$nil &reverse=$false inputs?| }
+fn order {|&types=$false &less-than=$nil &key=$nil &reverse=$false inputs?| }

--- a/pkg/eval/builtin_fn_stream_test.go
+++ b/pkg/eval/builtin_fn_stream_test.go
@@ -109,7 +109,7 @@ func TestOrder(t *testing.T) {
 			Puts(vals.EmptyList, vals.MakeList("a"),
 				vals.MakeList("a", 1), vals.MakeList("a", 2)),
 
-		// Attempting to order uncomparable values
+		// Ordering uncomparable values.
 		That("put (num 1) 1 | order").
 			Throws(ErrUncomparable, "order"),
 		That("put 1 (num 1) | order").
@@ -120,6 +120,22 @@ func TestOrder(t *testing.T) {
 			Throws(ErrUncomparable, "order"),
 		That("put [a] [(num 1)] | order").
 			Throws(ErrUncomparable, "order"),
+
+		// Ordering otherwise uncomparable values while also taking into account
+		// the ordering of those value types.
+		That("put (num 1) 1 | order &types").
+			Puts(1, "1"),
+		That("put 1 (num 1) | order &types").
+			Puts(1, "1"),
+		That("put 1 (num 1) b | order &types").
+			Puts(1, "1", "b"),
+		That("put [a] a | order &types").
+			Puts("a", vals.MakeList("a")),
+		// Lists are equal if they have equal elements. In this case one list
+		// has a string and the other a number. Number types are less than
+		// string types so the second list should be ordered before the first.
+		That("put [a] [(num 1)] | order &types").
+			Puts(vals.MakeList(1), vals.MakeList("a")),
 
 		// &reverse
 		That("put foo bar ipsum | order &reverse").Puts("ipsum", "foo", "bar"),

--- a/pkg/eval/builtin_ns.d.elv
+++ b/pkg/eval/builtin_ns.d.elv
@@ -60,7 +60,7 @@ var pwd
 # The boolean true value.
 var true
 
-# A [psuedo-map](language.html#pseudo-map) that exposes information about the Elvish binary.
+# A [pseudo-map](language.html#pseudo-map) that exposes information about the Elvish binary.
 # Running `put $buildinfo | to-json` will produce the same output as `elvish -buildinfo -json`.
 #
 # See also [`$version`]().

--- a/pkg/eval/vals/compare.go
+++ b/pkg/eval/vals/compare.go
@@ -1,0 +1,197 @@
+package vals
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+)
+
+type ordering uint8
+
+const (
+	CmpLess ordering = iota
+	CmpEqual
+	CmpMore
+	CmpUncomparable
+)
+
+// Cmp compares two arbitrary Elvish types and returns a value that indicates
+// whether the values are not comparable or the first value is less, equal, or
+// greater than the second value.
+func Cmp(a, b any) ordering {
+	switch a := a.(type) {
+	case int, *big.Int, *big.Rat, float64:
+		switch b.(type) {
+		case int, *big.Int, *big.Rat, float64:
+			a, b := UnifyNums2(a, b, 0)
+			switch a := a.(type) {
+			case int:
+				return cmpInt(a, b.(int))
+			case *big.Int:
+				return cmpInt(a.Cmp(b.(*big.Int)), 0)
+			case *big.Rat:
+				return cmpInt(a.Cmp(b.(*big.Rat)), 0)
+			case float64:
+				return cmpFloat(a, b.(float64))
+			default:
+				panic("unreachable")
+			}
+		}
+	case string:
+		if b, ok := b.(string); ok {
+			switch {
+			case a == b:
+				return CmpEqual
+			case a < b:
+				return CmpLess
+			default: // a > b
+				return CmpMore
+			}
+		}
+	case List:
+		if b, ok := b.(List); ok {
+			aIt := a.Iterator()
+			bIt := b.Iterator()
+			for aIt.HasElem() && bIt.HasElem() {
+				o := Cmp(aIt.Elem(), bIt.Elem())
+				if o != CmpEqual {
+					return o
+				}
+				aIt.Next()
+				bIt.Next()
+			}
+			switch {
+			case a.Len() == b.Len():
+				return CmpEqual
+			case a.Len() < b.Len():
+				return CmpLess
+			default: // a.Len() > b.Len()
+				return CmpMore
+			}
+		}
+	// TODO: Figure out a sane solution for comparing maps.  Obviously the
+	// definition of "less than" is ill-defined for maps but it would be nice if
+	// we had a solution similar to that for the List case above. One solution
+	// is to treat each map as an ordered list of [key value] pairs (i.e.,
+	// sorted by their keys) and use the List comparison logic above. Yes, that
+	// behavior is hard to document but has the virtue of providing an
+	// unambiguous means of sorting maps.
+	//
+	// case Map:
+	//   if _, ok := b.(Map); ok {
+	//     // Fill in the blank.
+	//   }
+	case bool:
+		if b, ok := b.(bool); ok {
+			switch {
+			case a == b:
+				return CmpEqual
+			//lint:ignore S1002 using booleans as values, not conditions
+			case a == false: // b == true is implicit
+				return CmpLess
+			default: // a == true && b == false
+				return CmpMore
+			}
+		}
+	}
+
+	return CmpUncomparable
+}
+
+// CmpTypes compares two arbitrary Elvish types and returns a value that
+// indicates whether the type of the first value is less, equal, or greater than
+// the type of the second value. This allows creating a total ordering even when
+// dealing with heterogeneous types.
+//
+// The ordering is bool < num < string < list < map.
+func CmpTypes(a, b any) ordering {
+	switch a.(type) {
+	case bool:
+		return CmpLess // the bool type is always less than any other type
+	case int, *big.Int, *big.Rat, float64:
+		switch b.(type) {
+		case bool:
+			return CmpMore
+		default:
+			return CmpLess
+		}
+	case string:
+		switch b.(type) {
+		case bool:
+			return CmpMore
+		case int, *big.Int, *big.Rat, float64:
+			return CmpMore
+		default:
+			return CmpLess
+		}
+	case List:
+		switch b.(type) {
+		case bool:
+			return CmpMore
+		case int, *big.Int, *big.Rat, float64:
+			return CmpMore
+		case string:
+			return CmpMore
+		default:
+			return CmpLess
+		}
+	case Map:
+		return CmpMore
+	case StructMap:
+		return CmpMore
+	case PseudoStructMap:
+		return CmpMore
+	}
+
+	// This will only be executed if we have failed to properly handle all the
+	// types exposed by Elvish.
+	panic(fmt.Sprintf("uncomparable types %T and %T", a, b))
+}
+
+func cmpInt(a, b int) ordering {
+	if a < b {
+		return CmpLess
+	} else if a > b {
+		return CmpMore
+	}
+	return CmpEqual
+}
+
+func cmpFloat(a, b float64) ordering {
+	// For the sake of ordering, NaN's are considered equal to each
+	// other and smaller than all numbers
+	switch {
+	case math.IsNaN(a):
+		if math.IsNaN(b) {
+			return CmpEqual
+		}
+		return CmpLess
+	case math.IsNaN(b):
+		return CmpMore
+	case a < b:
+		return CmpLess
+	case a > b:
+		return CmpMore
+	default: // a == b
+		return CmpEqual
+	}
+}
+
+// CmpKVSlice is useful when we need to sort a set of key/value pairs on the
+// key. This supports hetergeneous key types by explicitly sorting uncomparable
+// key types to produce a total ordering.
+type CmpKVSlice [][2]any
+
+func (s CmpKVSlice) Len() int { return len(s) }
+
+func (s CmpKVSlice) Less(i, j int) bool {
+	o := Cmp(s[i][0], s[j][0]) // compare the "keys" (the first value of the slice)
+	if o == CmpUncomparable {
+		o = CmpTypes(s[i][0], s[j][0])
+	}
+	return o == CmpLess
+}
+
+func (s CmpKVSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/strutil/dedent.go
+++ b/pkg/strutil/dedent.go
@@ -1,0 +1,59 @@
+package strutil
+
+// This code is a fork of https://github.com/lithammer/dedent, but with a fix
+// for https://github.com/lithammer/dedent/issues/20 so that we can use raw
+// strings in a natural manner by placing the first indented line on a new line
+// following the opening backtick.
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	whitespaceOnly    = regexp.MustCompile("(?m)^[ \t]+$")
+	leadingWhitespace = regexp.MustCompile("(?m)(^[ \t]*)(?:[^ \t\n])")
+)
+
+// Dedent removes any common leading whitespace from every line in text. An
+// initial newline is removed.
+//
+// This can be used to make multiline (usually raw) strings to line up with the
+// left edge of the display, while still presenting them in the source code in
+// indented form.
+func Dedent(text string) string {
+	var margin string
+
+	if text[0] == '\n' {
+		text = whitespaceOnly.ReplaceAllString(text[1:], "")
+	} else {
+		text = whitespaceOnly.ReplaceAllString(text, "")
+	}
+	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
+
+	// Look for the longest leading string of spaces and tabs common to all
+	// lines.
+	for i, indent := range indents {
+		if i == 0 {
+			margin = indent[1]
+		} else if strings.HasPrefix(indent[1], margin) {
+			// Current line more deeply indented than previous winner:
+			// no change (previous winner is still on top).
+			continue
+		} else if strings.HasPrefix(margin, indent[1]) {
+			// Current line consistent with and no deeper than previous winner:
+			// it's the new winner.
+			margin = indent[1]
+		} else {
+			// Current line and previous winner have no common whitespace:
+			// there is no margin.
+			margin = ""
+			break
+		}
+	}
+
+	if margin != "" {
+		text = regexp.MustCompile("(?m)^"+margin).ReplaceAllString(text, "")
+	}
+	return text
+}


### PR DESCRIPTION
This change is more invasive than I expected because the existing Elvish value comparison code was in `pkg/eval`.  This moves the value comparison logic into `pkg/eval/vals` so it can be used by packges other than `eval`. For example, the vals package `repr` implementation as well as other Elvish modules which may want to compare Elvish values.

I also decided to introduce a `strutil.Dedent` function to make it easier to write multiline string literals in unit tests to improve readability of the expected value.

This also sorts the keys of pseudo (struct) maps for consistency with mutable maps. This arguably makes the output of pretty-printing pseudo maps less friendly since a struct map definition typically orders its members in a deliberate fashion (unlike a regular map). However, it is more important that the output of printing the output of regular and pseudo maps (via `repr` or `pprint`) be consistent with regard to the order of their keys.

Related: #1495