### PR TITLE
Implement a well defined ordering among types

### DIFF
--- a/pkg/eval/builtin_fn_stream_test.go
+++ b/pkg/eval/builtin_fn_stream_test.go
@@ -131,18 +131,17 @@ func TestOrder(t *testing.T) {
 		That("put 10 1 5 2 | order &reverse &key={|v| num $v }").
 			Puts("10", "5", "2", "1"),
 
-		// &total orders the values into groups of different types, and sorts
-		// the groups themselves. Test that without assuming the relative order
-		// between numbers and strings.
-		That(
-			"put (num 3/2) (num 1) c (num 2) a | order &total | var li = [(all)]",
-			"put $li",
-			"has-value [[a c (num 1) (num 3/2) (num 2)] [(num 1) (num 3/2) (num 2) a c]] $li").
-			Puts(Anything, true),
-		// &total keeps the order of unordered values as is.
+		// &total orders the values into groups of different types, and orders
+		// the items in the groups or keeps the original order if the items do
+		// not  have a defined ordering (such as for maps).
+		That(`put (num 3/2) $nil [x y] [&c=d] (num 1) [a b] $true z [&a=b] (num 2) ^
+			$false y | order &total`).
+			Puts(nil, false, true, 1, big.NewRat(3, 2), 2, "y", "z",
+				vals.MakeList("a", "b"), vals.MakeList("x", "y"),
+				vals.MakeMap("c", "d"), vals.MakeMap("a", "b")),
+		// &total keeps the order of unordered values (as is true for maps) as is.
 		That("put [&foo=bar] [&a=b] [&x=y] | order &total").
 			Puts(vals.MakeMap("foo", "bar"), vals.MakeMap("a", "b"), vals.MakeMap("x", "y")),
-
 		// &less-than
 		That("put 1 10 2 5 | order &less-than={|a b| < $a $b }").
 			Puts("1", "2", "5", "10"),

--- a/pkg/eval/vals/cmp.go
+++ b/pkg/eval/vals/cmp.go
@@ -3,7 +3,8 @@ package vals
 import (
 	"math"
 	"math/big"
-	"unsafe"
+	"reflect"
+	"sync"
 )
 
 // Ordering relationship between two Elvish values.
@@ -61,14 +62,7 @@ func cmpInner(a, b any, recurse func(a, b any) Ordering) Ordering {
 		}
 	case string:
 		if b, ok := b.(string); ok {
-			switch {
-			case a == b:
-				return CmpEqual
-			case a < b:
-				return CmpLess
-			default: // a > b
-				return CmpMore
-			}
+			return compareBuiltin(a, b)
 		}
 	case List:
 		if b, ok := b.(List); ok {
@@ -99,13 +93,15 @@ func cmpInner(a, b any, recurse func(a, b any) Ordering) Ordering {
 	return CmpUncomparable
 }
 
-func compareBuiltin[T interface{ int | uintptr | string }](a, b T) Ordering {
-	if a < b {
+func compareBuiltin[T interface{ int | string }](a, b T) Ordering {
+	switch {
+	case a < b:
 		return CmpLess
-	} else if a > b {
+	case a > b:
 		return CmpMore
+	default:
+		return CmpEqual
 	}
-	return CmpEqual
 }
 
 func compareFloat(a, b float64) Ordering {
@@ -154,15 +150,84 @@ func CmpTotal(a, b any) Ordering {
 	return CmpEqual
 }
 
-var typeOfInt uintptr
+const (
+	// Define an order among the types most likely to appear in lists and maps.
+	typeOfNil = iota
+	typeOfBool
+	typeOfNum
+	typeOfString
+	typeOfList
+	typeOfMap
+	// Now order the types less likely to appear in lists and maps so we have a
+	// consistent ordering of the known types.
+	typeOfGlob
+	typeOfPipe
+	typeOfFn
+	typeOfExc
+	typeOfNs
+	typeOfUiText
+	typeOfUiTextSegment
+	typeOfEditKey
+	typeOfSentinal // insert any new types before this line
+)
 
-func typeOf(x any) uintptr {
-	switch x.(type) {
-	case *big.Int, *big.Rat, float64:
-		return typeOfInt
+var maxType int = typeOfSentinal - 1
+var unknownTypes = map[string]int{}
+var utMutex sync.Mutex
+
+// typeOf returns an integer that defines an ordering between different Elvish
+// value types.
+func typeOf(x any) int {
+	switch x := x.(type) {
+	case Kinder:
+		switch x.Kind() {
+		case "exception":
+			return typeOfExc
+		case "fn":
+			return typeOfFn
+		case "glob-pattern":
+			return typeOfGlob
+		case "ns":
+			return typeOfNs
+		case "pipe":
+			return typeOfPipe
+		case "edit:key":
+			return typeOfEditKey
+		case "ui:text":
+			return typeOfUiText
+		case "ui:text-segment":
+			return typeOfUiTextSegment
+		}
+	case nil:
+		return typeOfNil
+	case bool:
+		return typeOfBool
+	case int, *big.Int, *big.Rat, float64:
+		return typeOfNum
+	case string:
+		return typeOfString
+	case List:
+		return typeOfList
+	case Map, PseudoStructMap, StructMap:
+		return typeOfMap
 	}
-	// The first word of an empty interface is a pointer to the type descriptor.
-	return *(*uintptr)(unsafe.Pointer(&x))
-}
 
-func init() { typeOfInt = typeOf(0) }
+	// We don't recognize the value type. Assign it the next ordering value so
+	// it appears after the known types and any unknown type we've already seen.
+	// Ideally this code will never be executed. It exists to ensure that if the
+	// code above doesn't handle a type we still get predictable behavior when
+	// ordering heterogeneous values.
+	//
+	// TODO: Figure out how to discover when this code is executed so the logic
+	// above can be augmented to explicitly handle the type.
+	utMutex.Lock()
+	defer utMutex.Unlock()
+	t := reflect.TypeOf(x)
+	tName := t.Name()
+	if i, ok := unknownTypes[tName]; ok {
+		return i
+	}
+	maxType += 1
+	unknownTypes[tName] = maxType
+	return maxType
+}


### PR DESCRIPTION
This builds on the previous changes to implement a total ordering by replacing the dependency on the address at which various types are defined (which is effectively random) with an explicit ordering. For types without an explicit ordering it uses an ordering based on the order in which each unknown type is compared. This makes the ordering predictable based on the execution of Elvish code without regard to unpredictable factors such as the layout of data structures in the Elvish binary.

Note that the use of mechanisms like the `peach` command can introduce unpredictable ordering of unknown value types since this change handles unknown types at run time and thus, in theory, produce different results when Elvish code that invokes `compare &total` or `order &total` is run concurrently.  Whereas the prior logic is not affected by the parallelism of Elvish code.  Nonetheless, I maintain that the predictability of ordering heterogenous values introduced by this change is a net positive since the new behavior will be predictable and reproducible (as a practical matter) while the prior logic (based on the random layout of data structures in the Elvish binary) is neither.

Related #1495