### PR TITLE
Fixes multihardlink directory styling on unix

### DIFF
--- a/pkg/cli/lscolors/stat_unix.go
+++ b/pkg/cli/lscolors/stat_unix.go
@@ -8,5 +8,8 @@ import (
 )
 
 func isMultiHardlink(info os.FileInfo) bool {
+	if info.IsDir() {
+		return false
+	}
 	return info.Sys().(*syscall.Stat_t).Nlink > 1
 }


### PR DESCRIPTION
Hello.

Encountered strange behaviour of lscolors package regarding multihardlink formatting on unix systems.

It's perfectly normal for a directory to have more than one reference -- that's how Unix filesystem works (as far as I know), e.g. execution of `/usr/bin/ls -hn --color /` yields:

```console
lrwxrwxrwx   1 0 0    7  1 Jul  2021 bin -> usr/bin
drwxr-xr-x   4 0 0 4.0K 29 Jun 06:36 boot
drwxrwxr-x   2 0 0 4.0K  1 Jul  2021 cdrom
drwxr-xr-x   3 0 0 4.0K 16 Mar 19:47 data
drwxr-xr-x  20 0 0 4.8K 14 Jul 13:12 dev
...
```

where 2nd column is reference count for each directory. 

I've created a real multihardlink file and default `ls` displays it in red and yellow color (as configured in `LS_COLORS` env. var):

``` console
$ LS_COLORS="mh=1;33;48;5;52:" /usr/bin/ls -l --color
```

![image](https://github.com/elves/elvish/assets/50381946/9185c559-8794-4e44-b107-5ddfc781744b)


However, invoking `pkg/cli/lscolors` on the same directory results in:

![image](https://github.com/elves/elvish/assets/50381946/7c827085-d3b4-4b60-a3eb-8fd68b3f5ced)

That's why I propose to add extra logic into `isMultiHardlink()` function. 

-----

Further investigation showed up that the result also depends on current working directory. Excessive coloring happens when working directory is the same as listing directory, and vanishes when listing directory is different.

![image](https://github.com/elves/elvish/assets/50381946/df5c1784-8762-4689-9671-4ad1043e85a9)

![image](https://github.com/elves/elvish/assets/50381946/54540373-3b1c-46b4-89f1-f5512826ab68)

Apparently, that's because `GetStyle()` expects absolute paths, not relative ones.