### PR TITLE
Make Concat return a new globPattern.

### DIFF
--- a/pkg/eval/glob.go
+++ b/pkg/eval/glob.go
@@ -136,8 +136,11 @@ func (gp globPattern) Index(k any) (any, error) {
 func (gp globPattern) Concat(v any) (any, error) {
 	switch rhs := v.(type) {
 	case string:
-		gp.append(stringToSegments(rhs)...)
-		return gp, nil
+		var segs []glob.Segment
+		segs = append(segs, gp.Segments...)
+		segs = append(segs, stringToSegments(rhs)...)
+		return globPattern{Pattern: glob.Pattern{Segments: segs}, Flags: gp.Flags,
+			Buts: gp.Buts, TypeCb: gp.TypeCb}, nil
 	case globPattern:
 		// We know rhs contains exactly one segment.
 		gp.append(rhs.Segments[0])

--- a/pkg/eval/glob_test.go
+++ b/pkg/eval/glob_test.go
@@ -22,6 +22,15 @@ func TestGlob_Simple(t *testing.T) {
 	)
 }
 
+func TestGlob_BraceConcat(t *testing.T) {
+	testutil.InTempDir(t)
+	must.CreateEmpty("xy.u", "xy.v", "xy.w", "xz.w")
+
+	Test(t,
+		That("put x*.{u v w}").Puts("xy.u", "xy.v", "xy.w", "xz.w"),
+	)
+}
+
 func TestGlob_Recursive(t *testing.T) {
 	testutil.InTempDir(t)
 	must.MkdirAll("1/2/3")


### PR DESCRIPTION
I don't know if this is fully sufficient, but it seems to fix the specific test case mentioned.

Fixes #1245