### PR TITLE
Fix a typo detected by spellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         go install golang.org/x/tools/cmd/stringer@latest
         go install golang.org/x/tools/cmd/goimports@latest
         go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
-        pip install --user codespell==2.2.1
+        pip install --user codespell==2.2.5
     - name: Run checks
       run: make all-checks
 

--- a/website/ref/command.md
+++ b/website/ref/command.md
@@ -45,7 +45,7 @@ history. Its path is determined as follows:
 2.  If the `XDG_STATE_HOME` environment variable is defined and non-empty,
     `$XDG_STATE_HOME/elvish/db.bolt` is used.
 
-3.  Othersie, `~/.local/state/elvish/db.bolt` (non-Windows OSes) or
+3.  Otherwise, `~/.local/state/elvish/db.bolt` (non-Windows OSes) or
     `%LocalAppData%\elvish\db.bolt` is used.
 
 # Running a script


### PR DESCRIPTION
While working on an unrelated change I noticed that `make all-checks` found a typo. I was using codespell 2.2.5 so this also upodates the .github/workflows/ci.yml file to depend on that release since doing so does not introduce any false positives.