### PR TITLE
Implement a well defined ordering among types

### DIFF
--- a/pkg/eval/builtin_fn_pred.d.elv
+++ b/pkg/eval/builtin_fn_pred.d.elv
@@ -121,7 +121,8 @@ fn not-eq {|@values| }
 #     equivalent to comparing by codepoints.
 #
 #     Beware that strings that look like numbers are compared as strings, not
-#     numbers.
+#     numbers. For example, `compare 2 10` is not the same as `compare (num 2)
+#     (num 10)`. The former outputs 1, the latter -1.
 #
 # -   Lists: Compared lexicographically by elements, with elements compared
 #     recursively.
@@ -141,13 +142,14 @@ fn not-eq {|@values| }
 #
 #     -   If they don't, `compare` compares their types and outputs -1 or 1.
 #
-#         The ordering between Elvish types is unspecified, but it is guaranteed
-#         to be consistent during the same Elvish session. For example, if
-#         `compare &total $a $b` outputs -1 when `$a` is a number and `$b` is a
-#         string, it will always output -1 for such pairs.
+#     The ordering between Elvish types is partially specified and guaranteed
+#     to be consistent across all platforms. The partial order is nil < bool <
+#     num < string < list < map < file. Other types, such as exceptions, are
+#     guaranteed to appear after those types in a consistent order on all
+#     platforms, but is otherwise unspecified.
 #
-#     This artificial total order is mainly useful when sorting values of mixed
-#     types.
+#     This artificial total order is mainly useful when sorting values of
+#     mixed types.
 #
 # Examples:
 #

--- a/pkg/eval/builtin_fn_stream_test.go
+++ b/pkg/eval/builtin_fn_stream_test.go
@@ -131,18 +131,17 @@ func TestOrder(t *testing.T) {
 		That("put 10 1 5 2 | order &reverse &key={|v| num $v }").
 			Puts("10", "5", "2", "1"),
 
-		// &total orders the values into groups of different types, and sorts
-		// the groups themselves. Test that without assuming the relative order
-		// between numbers and strings.
-		That(
-			"put (num 3/2) (num 1) c (num 2) a | order &total | var li = [(all)]",
-			"put $li",
-			"has-value [[a c (num 1) (num 3/2) (num 2)] [(num 1) (num 3/2) (num 2) a c]] $li").
-			Puts(Anything, true),
-		// &total keeps the order of unordered values as is.
+		// &total orders the values into groups of different types, and orders
+		// the items in the groups or keeps the original order if the items do
+		// not  have a defined ordering (such as for maps).
+		That(`put (num 3/2) $nil [x y] [&c=d] (num 1) [a b] $true z [&a=b] (num 2) ^
+			$false y | order &total`).
+			Puts(nil, false, true, 1, big.NewRat(3, 2), 2, "y", "z",
+				vals.MakeList("a", "b"), vals.MakeList("x", "y"),
+				vals.MakeMap("c", "d"), vals.MakeMap("a", "b")),
+		// &total keeps the order of unordered values (as is true for maps) as is.
 		That("put [&foo=bar] [&a=b] [&x=y] | order &total").
 			Puts(vals.MakeMap("foo", "bar"), vals.MakeMap("a", "b"), vals.MakeMap("x", "y")),
-
 		// &less-than
 		That("put 1 10 2 5 | order &less-than={|a b| < $a $b }").
 			Puts("1", "2", "5", "10"),

--- a/pkg/eval/vals/kind.go
+++ b/pkg/eval/vals/kind.go
@@ -20,6 +20,9 @@ type Kinder interface {
 // and document the rationale for the choice in the doc string for `func
 // (ExternalCmd) Kind()` as well as user facing documentation. It's not
 // obvious why this returns "fn" rather than "external" for that case.
+//
+// See also vals.typeOf(). If this changes there is a good chance vals.typeOf()
+// will also need to change.
 func Kind(v any) string {
 	switch v := v.(type) {
 	case nil:


### PR DESCRIPTION
Replace the current total ordering of types defined by the address at which each type is defined (which is effectively random) with an explicit ordering. This makes writing unit tests easier and provides predictable run time behavior for users regardless of which platform they run Elvish on.

Related #1495