### PR TITLE
Make eawk accept a custom separator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM golang:1.18-alpine as builder
-RUN apk update && \
-    apk add --virtual build-deps make git
+FROM golang:1.20-alpine as builder
+RUN apk add --no-cache --virtual build-deps make git
 # Build Elvish
 COPY . /go/src/src.elv.sh
 RUN make -C /go/src/src.elv.sh get
 
-FROM alpine:3.13
-COPY --from=builder /go/bin/elvish /bin/elvish
+FROM alpine:3.18
 RUN adduser -D elf
-RUN apk update && apk add tmux mandoc man-pages vim curl git
+RUN apk update && apk add tmux mandoc man-pages vim curl sqlite git
+COPY --from=builder /go/bin/elvish /bin/elvish
 USER elf
 WORKDIR /home/elf
 CMD ["/bin/elvish"]

--- a/pkg/eval/builtin_fn_str.go
+++ b/pkg/eval/builtin_fn_str.go
@@ -67,11 +67,29 @@ func base(fm *Frame, b int, nums ...int) error {
 	return nil
 }
 
-var eawkWordSep = regexp.MustCompile("[ \t]+")
+type eawkOpt struct {
+	Sep   string
+	Posix bool
+}
 
-func eawk(fm *Frame, f Callable, inputs Inputs) error {
+func (o *eawkOpt) SetDefaultOptions() {
+	o.Posix = false
+	o.Sep = "[ \t]+"
+}
+
+func eawk(fm *Frame, opts eawkOpt, f Callable, inputs Inputs) error {
 	broken := false
+	var eawkWordSep *regexp.Regexp
 	var err error
+	if opts.Posix {
+		eawkWordSep, err = regexp.CompilePOSIX(opts.Sep)
+	} else {
+		eawkWordSep, err = regexp.Compile(opts.Sep)
+	}
+	if err != nil {
+		return err
+	}
+
 	inputs(func(v any) {
 		if broken {
 			return

--- a/pkg/eval/builtin_fn_str_test.go
+++ b/pkg/eval/builtin_fn_str_test.go
@@ -87,5 +87,17 @@ func TestEawk(t *testing.T) {
 				}
 			}
 		`).Puts("a", "c", "e"),
+		// Parsing docker image ps output with custom separator:
+		That(`
+	to-lines [
+		'REPOSITORY                TAG          IMAGE ID      CREATED         SIZE'
+		'<none>                    <none>       265c2d25a944  16 minutes ago  67.5 MB'
+		'<none>                    <none>       26408a88b236  16 minutes ago  389 MB'
+		'localhost/elvish_eawk     latest       0570db4e3eaa  32 hours ago    67.5 MB'
+		'localhost/elvish          latest       59b1eec93ab7  33 hours ago    67.5 MB'
+		'docker.io/library/golang  latest       015e6b7f599b  46 hours ago    838 MB'
+		'docker.io/library/golang  1.20-alpine  93db368a0a9e  3 days ago      266 MB'
+	] | eawk &sep=" [ ]+" {|0 1 2 3 4 5| put $5 }
+		`).Puts("SIZE", "67.5 MB", "389 MB", "67.5 MB", "67.5 MB", "838 MB", "266 MB"),
 	)
 }

--- a/pkg/eval/builtin_fn_str_test.go
+++ b/pkg/eval/builtin_fn_str_test.go
@@ -87,7 +87,7 @@ func TestEawk(t *testing.T) {
 				}
 			}
 		`).Puts("a", "c", "e"),
-		// Parsing docker image ps output with custom separator:
+		// Parsing docker image ls output with custom separator:
 		That(`
 	to-lines [
 		'REPOSITORY                TAG          IMAGE ID      CREATED         SIZE'


### PR DESCRIPTION
One of the biggest pain points of using elvish as a shell in practice  for
me has been parsing output from shell commands that return text.

Many CLIs are parseable by AWK. Elvish provides eawk to provide
some of the key tasks that AWK does without introducing a
separate DSL, relying solely on the expressiveness of lambdas.

In practice, most of the power of AWK is being able to change
the separator to parse the particular output of the command
you pipe into it (commas, pipe, spacing strictly longer than two spaces, etc etc). 
So this commit adds an optional `sep` argument that takes a regex pattern.

(I also updated the dockerfile.)