### PR TITLE
Fix typos

### DIFF
--- a/pkg/cli/modes/listing.go
+++ b/pkg/cli/modes/listing.go
@@ -24,7 +24,7 @@ type ListingSpec struct {
 	// the index of the Item to select. Required.
 	GetItems func(query string) (items []ListingItem, selected int)
 	// A function to call when the user has accepted the selected item. If the
-	// return value is true, the listing will not be closed after accpeting.
+	// return value is true, the listing will not be closed after accepting.
 	// If unspecified, the Accept function default to a function that does
 	// nothing other than returning false.
 	Accept func(string)

--- a/pkg/md/fmt.go
+++ b/pkg/md/fmt.go
@@ -22,7 +22,7 @@ import (
 //   - Thematic breaks use "***" where possible, falling back to "---" if using
 //     the former is problematic.
 //
-//   - Code blocks are always fenced, never idented.
+//   - Code blocks are always fenced, never indented.
 //
 //   - Code fences use backquotes (like "```") wherever possible, falling back
 //     to "~~~" if using the former is problematic.

--- a/pkg/mods/path/path_test.go
+++ b/pkg/mods/path/path_test.go
@@ -29,7 +29,7 @@ func TestPath(t *testing.T) {
 
 	TestWithEvalerSetup(t, Use("path", Ns, "file", file.Ns),
 		//  All the functions in path: are either simple wrappers of Go
-		//  functions or compatibility alises of their os: counterparts.
+		//  functions or compatibility aliases of their os: counterparts.
 		//
 		// As a result, the tests are just simple "smoke tests" to ensure that
 		// they exist and map to the correct function.
@@ -45,7 +45,7 @@ func TestPath(t *testing.T) {
 		That("path:is-abs a/b/s").Puts(false),
 		That("path:is-abs "+absPath).Puts(true),
 		That("path:join a b c").Puts(filepath.Join("a", "b", "c")),
-		// Compatibility alises.
+		// Compatibility aliases.
 		That("path:eval-symlinks d").Puts("d"),
 		That("path:is-dir d").Puts(true),
 		That("path:is-regular d/f").Puts(true),

--- a/website/learn/effective-elvish.md
+++ b/website/learn/effective-elvish.md
@@ -91,7 +91,7 @@ section documents how to make the most use of pipelines.
 Unlike functions in most other programming languages, Elvish commands do not
 have return values. Instead, they can write to *structured output*, which is
 similar to the traditional byte-based stdout, but preserves all internal
-structures of aribitrary Elvish values. The most fundamental command that does
+structures of arbitrary Elvish values. The most fundamental command that does
 this is `put`:
 
 ```elvish-transcript


### PR DESCRIPTION
I recently upgraded my `codespell` command to version 2.2.6 which caused creating a pull-request to catch the typos fixed by this change.