### PR TITLE
pkg/cli/tk/listbox_window.go: Fix divide by zero

### DIFF
--- a/pkg/cli/tk/listbox_window.go
+++ b/pkg/cli/tk/listbox_window.go
@@ -112,7 +112,9 @@ func getHorizontalWindow(state ListBoxState, padding, width, height int) (int, i
 	}
 	// Reduce the amount of available height by one because the last row will be
 	// reserved for the scrollbar.
-	height--
+	if height--; height < 1 {
+		return 0, 0
+	}
 	selected, lastFirst := state.Selected, state.First
 	// Start with the column containing the selected item, move left until
 	// either the width is exhausted, or lastFirst has been reached.


### PR DESCRIPTION
Fix `divide by zero` when resizing terminal.

Steps to reproduce:
1. invoke completion menu
2. reduce height of terminal window

related https://github.com/elves/elvish/issues/1282