### PR TITLE
Fix edit:insert:binding regression

### DIFF
--- a/pkg/edit/init.elv
+++ b/pkg/edit/init.elv
@@ -49,6 +49,7 @@ set insert:binding = (binding-table [
   &Ctrl-N= $navigation:start~
   &Tab=    $completion:smart-start~
   &Up=     $history:start~
+  &Down=   $end-of-history~
 
   &Alt-Enter={ insert-at-dot "\n" }
 


### PR DESCRIPTION
Add an insert mode binding that was accidently lost by an earlier refactoring that moved default bindings from Go code to embedded Elvish code.

Fixes #1738