### PR TITLE
pkg/cli/modes: Filter by tags.

### DIFF
--- a/pkg/edit/complete/raw_item.go
+++ b/pkg/edit/complete/raw_item.go
@@ -33,6 +33,7 @@ type ComplexItem struct {
 	Stem       string  // Used in the code and the menu.
 	CodeSuffix string  // Appended to the code.
 	Display    ui.Text // How the item is displayed. If empty, defaults to ui.T(Stem).
+	Tag        string  // TODO
 }
 
 func (c ComplexItem) String() string { return c.Stem }
@@ -46,5 +47,6 @@ func (c ComplexItem) Cook(q parse.PrimaryType) modes.CompletionItem {
 	return modes.CompletionItem{
 		ToInsert: quoted + c.CodeSuffix,
 		ToShow:   display,
+		Tag:      c.Tag,
 	}
 }

--- a/pkg/edit/completion.go
+++ b/pkg/edit/completion.go
@@ -25,6 +25,7 @@ import (
 type complexCandidateOpts struct {
 	CodeSuffix string
 	Display    any
+	Tag        string
 }
 
 func (*complexCandidateOpts) SetDefaultOptions() {}
@@ -46,6 +47,7 @@ func complexCandidate(fm *eval.Frame, opts complexCandidateOpts, stem string) (c
 		Stem:       stem,
 		CodeSuffix: opts.CodeSuffix,
 		Display:    display,
+		Tag:        opts.Tag,
 	}, nil
 }
 
@@ -162,6 +164,8 @@ func (c complexItem) Index(k any) (any, bool) {
 		return c.CodeSuffix, true
 	case "display":
 		return c.Display, true
+	case "tag":
+		return c.Tag, true
 	}
 	return nil, false
 }
@@ -188,8 +192,8 @@ func (c complexItem) Hash() uint32 {
 
 func (c complexItem) Repr(indent int) string {
 	// TODO(xiaq): Pretty-print when indent >= 0
-	return fmt.Sprintf("(edit:complex-candidate %s &code-suffix=%s &display=%s)",
-		parse.Quote(c.Stem), parse.Quote(c.CodeSuffix), vals.Repr(c.Display, indent+1))
+	return fmt.Sprintf("(edit:complex-candidate %s &code-suffix=%s &display=%s &tag=%s)",
+		parse.Quote(c.Stem), parse.Quote(c.CodeSuffix), vals.Repr(c.Display, indent+1), parse.Quote(c.Tag))
 }
 
 type wrappedArgGenerator func(*eval.Frame, ...string) error

--- a/pkg/edit/completion_test.go
+++ b/pkg/edit/completion_test.go
@@ -96,9 +96,9 @@ func TestComplexCandidate(t *testing.T) {
 		That("cc a/b").Puts(complexItem{Stem: "a/b"}),
 		That("cc a/b &code-suffix=' '").Puts(complexItem{Stem: "a/b", CodeSuffix: " "}),
 		That("cc a/b &code-suffix=' ' &display=A/B").Puts(
-			complexItem{"a/b", " ", ui.T("A/B")}),
+			complexItem{"a/b", " ", ui.T("A/B"), ""}),
 		That("cc a/b &code-suffix=' ' &display=(styled A/B red)").Puts(
-			complexItem{"a/b", " ", ui.T("A/B", ui.FgRed)}),
+			complexItem{"a/b", " ", ui.T("A/B", ui.FgRed), ""}),
 		That("cc a/b &code-suffix=' ' &display=[]").Throws(
 			errs.BadValue{What: "&display", Valid: "string or styled", Actual: "[]"}),
 


### PR DESCRIPTION
Added tag support for completion menu.
Can be tested with https://github.com/rsteube/carapace-bin/pull/2147

> This is to keep track on it and for discussions.
> Ultimately this feature is best to be implemented by @xiaq . 

![image](https://github.com/elves/elvish/assets/9090290/6547a668-9533-4f78-af3c-405cc2b037ab)

Switch between tags with `ALT+n` / `ALT+p`:

![image](https://github.com/elves/elvish/assets/9090290/58350273-0b84-49f2-ba3f-b69c246a1cfe)

related #914 