### PR TITLE
Provide more info for an invalid doc link

### DIFF
--- a/website/tools/check-rellinks.py
+++ b/website/tools/check-rellinks.py
@@ -47,6 +47,13 @@ def main(args):
                 path = filename
             else:
                 if os.path.splitext(path)[1] == '':
+                    # Tell people who inadvertently append a trailing slash to
+                    # a URL not meant to refer to a index.html file they have
+                    # made a mistake.
+                    # See https://github.com/elves/elvish/issues/1749.
+                    if path.endswith(".html/"):
+                        print(f'WARNING: A trailing slash implies you are referring to {path}index.html.')
+                        print(f'WARNING: This is not what you want and the trailing slash should be removed.')
                     path += '/index.html'
                 if path.startswith('/'):
                     path = path.lstrip('/')


### PR DESCRIPTION
Make it more obvious why a documentation reference link is invalid when the URL path incorrectly includes a trailing slash. This would have saved me an hour of debugging when I was working on a change that included a reference like this one:

    [`edit:histlist:start`](../ref/edit.html/#edit:histlist:start)

Fixes #1749