### PR TITLE
Replace `epm` dependency on `rm` with `os:remove-all`

### DIFF
--- a/pkg/mods/epm/epm.elv
+++ b/pkg/mods/epm/epm.elv
@@ -1,3 +1,4 @@
+use os
 use path
 use re
 use str
@@ -6,7 +7,6 @@ use platform
 pragma unknown-command = disallow
 var dirname~ = $e:dirname~
 var mkdir~ = $e:mkdir~
-var rm~ = $e:rm~
 var git~ = $e:git~
 var rsync~ = $e:rsync~
 
@@ -241,7 +241,7 @@ fn -uninstall-package {|pkg|
   }
   var dest = (dest $pkg)
   -info "Removing package "$pkg
-  rm -rf $dest
+  os:remove-all $dest
 }
 
 ######################################################################


### PR DESCRIPTION
Remove the `epm` dependency on `rm` with `os:remove-all` so it is slightly easier to use the `epm` command on Windows.

There aren't any unit tests for this but I verified it worked by running the following statements on my macOS and Windows systems:

    epm:install github.com/doubleagent/rivendell
    epm:uninstall github.com/doubleagent/rivendell

Related #1661