### PR TITLE
Fix broken readline binding link

### DIFF
--- a/website/learn/fundamentals.md
+++ b/website/learn/fundamentals.md
@@ -51,7 +51,13 @@ switches, which usually do not contain spaces or special characters.
 
 ## Editing the command line
 
-TODO
+TODO: This requires a lot more detail.
+
+A starting point is to run `pprint $edit:insert:binding` to show the bindings
+for the normal insert mode. There are many more modes with their own bindings.
+See the [`edit`](../ref/edit.html) module documentation for more details. See
+also the [`readline-binding`](../ref/readline-binding.html) module that provides
+key bindings similar to the default bindings provided by Bash.
 
 ## Builtin and external commands
 

--- a/website/ref/readline-binding.md
+++ b/website/ref/readline-binding.md
@@ -4,9 +4,11 @@
 
 # Introduction
 
-The `readline-binding` module provides readline-like key bindings, such as
-binding <kbd>Ctrl-A</kbd> to move the cursor to the start of the line. To use,
-put the following in your [`rc.elv`](command.html#rc-file):
+The `readline-binding` module provides GNU readline-like key bindings, such as
+binding <kbd>Ctrl-A</kbd> to move the cursor to the start of the line. GNU
+readline bindings are the default for shells such as Bash. So if you are
+migrating from Bash to Elvish you probably want to add the following to your
+[`rc.elv`](command.html#rc-file):
 
 ```elvish
 use readline-binding
@@ -17,5 +19,5 @@ Note that this will override some of the standard bindings. For example,
 rather than start location mode.
 
 See the
-[source code](https://src.elv.sh/pkg/mods/readlinebinding/readline-binding.elv)
+[source code](https://src.elv.sh/pkg/mods/readline-binding/readline-binding.elv)
 for details.


### PR DESCRIPTION
The primary purpose of this change is to fix a broken link to the readline binding source. A secondary purpose is a baby step to addressing issue #1719.

Related #1719