### PR TITLE
Pre exit hook

### DIFF
--- a/pkg/edit/repl.go
+++ b/pkg/edit/repl.go
@@ -21,6 +21,6 @@ func initRepl(ed *Editor, ev *eval.Evaler, nb eval.NsBuilder) {
 	ed.AfterCommand = append(ed.AfterCommand,
 		func(src parse.Source, duration float64, err error) {
 			m := vals.MakeMap("src", src, "duration", duration, "error", err)
-			callHooks(ev, "$<edit>:after-command", afterCommandHook.Get().(vals.List), m)
+			eval.CallHook(ev, nil, "$<edit>:after-command", afterCommandHook.Get().(vals.List), m)
 		})
 }

--- a/pkg/eval/builtin_fn_pred.d.elv
+++ b/pkg/eval/builtin_fn_pred.d.elv
@@ -1,6 +1,6 @@
-# Convert a value to boolean. In Elvish, only `$false` and errors are booleanly
-# false. Everything else, including 0, empty strings and empty lists, is booleanly
-# true:
+# Convert a value to boolean. In Elvish, only `$false`, `$nil`, and errors are
+# booleanly false. Everything else, including 0, empty strings and empty lists,
+# is booleanly true:
 #
 # ```elvish-transcript
 # ~> bool $true

--- a/pkg/eval/hook.go
+++ b/pkg/eval/hook.go
@@ -1,0 +1,40 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+
+	"src.elv.sh/pkg/diag"
+	"src.elv.sh/pkg/eval/vals"
+)
+
+// CallHook runs all the functions in the list "hook", with "args". If
+// "cfg" is not specified, current eval's ports will be used.
+func CallHook(ev *Evaler, cfg *EvalCfg, name string, hook vals.List, args ...any) {
+	if hook.Len() == 0 {
+		return
+	}
+
+	if cfg == nil {
+		ports, cleanup := PortsFromStdFiles(ev.ValuePrefix())
+		cfg = &EvalCfg{Ports: ports[:]}
+		defer cleanup()
+	}
+
+	callCfg := CallCfg{Args: args, From: "[hook " + name + "]"}
+
+	i := -1
+	for it := hook.Iterator(); it.HasElem(); it.Next() {
+		i++
+		fn, ok := it.Elem().(Callable)
+		if !ok {
+			diag.ShowError(os.Stderr, fmt.Errorf("hook %s[%d] must be callable", name, i))
+			continue
+		}
+
+		err := ev.Call(fn, callCfg, *cfg)
+		if err != nil {
+			diag.ShowError(os.Stderr, err)
+		}
+	}
+}

--- a/pkg/eval/hook_test.go
+++ b/pkg/eval/hook_test.go
@@ -1,0 +1,42 @@
+package eval_test
+
+import (
+	"testing"
+
+	"src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval/vals"
+	"src.elv.sh/pkg/eval/vars"
+	"src.elv.sh/pkg/parse"
+)
+
+func TestCallHook(t *testing.T) {
+	v := vals.EmptyList
+	hook := vars.FromPtr(&v)
+	ev := eval.NewEvaler()
+	ev.ExtendGlobal(eval.BuildNs().AddVar("test-hook", hook))
+
+	ports := eval.DummyPorts[:]
+	p, collect, err := eval.CapturePort()
+	if err != nil {
+		t.Error(err)
+	}
+	ports[1] = p
+
+	evalCfg := eval.EvalCfg{Ports: ports}
+
+	code := `set test-hook = [{|| put $true }]`
+	err = ev.Eval(parse.Source{Name: "[test]", Code: code}, evalCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	eval.CallHook(ev, &evalCfg, "test-hook", hook.Get().(vals.List))
+
+	vs, _ := collect()
+	if len(vs) != 1 {
+		t.Error(len(vs))
+	}
+
+	if v, ok := vs[0].(bool); !ok || !v {
+		t.Error(vs)
+	}
+}


### PR DESCRIPTION
allow user to customize pre-exit hook

It is useful when user wants to clean up things that associated with
shell session.

Provide a CallHook internal API for the common usage.