### PR TITLE
language: mention that the tilde can also be a variable suffix

### DIFF
--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -72,8 +72,10 @@ constructs:
 
 The following characters are parsed as metacharacters under certain conditions:
 
--   `~`: introduces [tilde expansion](#tilde-expansion) if appearing at the
-    beginning of a compound expression
+-   `~`: if appearing at the beginning of a compound expression, it introduces
+    [tilde expansion](#tilde-expansion); if appearing at the end of a variable,
+    it refers to a function with the same name (see
+    [variable suffix](#variable-suffix))
 
 -   `=`: terminates [map keys](#map), option keys, or the variable name in
     [temporary assignments](#temporary-assignment)


### PR DESCRIPTION
When somebody is learning Elvish, he/she will soon stumble on a variable with a tilde suffix, e.g.: `$foo~`.

If he then goes to the [Language specification](https://elv.sh/ref/language.html), and searches for the `~` character, he will find 290 matches, so impractical to follow all of them.

If he searches for the name `tilde`, he will find section https://elv.sh/ref/language.html#metacharacters, but that section mentions tilde only for the tilde-expansion case.

This PR adds the mention also for https://elv.sh/ref/language.html#variable-suffix, so that finally one can more easily find out that a variable ending with `~` refers to function (or callable).

Thanks for Elvish!