### PR TITLE
add a check to prevent setting edit:-dot to a out of boundary value

### DIFF
--- a/pkg/edit/state_api.go
+++ b/pkg/edit/state_api.go
@@ -1,12 +1,16 @@
 package edit
 
 import (
+	"errors"
+
 	"src.elv.sh/pkg/cli"
 	"src.elv.sh/pkg/cli/tk"
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/vals"
 	"src.elv.sh/pkg/eval/vars"
 )
+
+var errDotOutOfBoundary = errors.New("dot out of command boundary")
 
 func insertAtDot(app cli.App, text string) {
 	codeArea, ok := focusedCodeArea(app)
@@ -42,6 +46,10 @@ func initStateAPI(app cli.App, nb eval.NsBuilder) {
 		err := vals.ScanToGo(v, &dot)
 		if err != nil {
 			return err
+		}
+		state := codeArea.CopyState()
+		if dot < 0 || dot > len(state.Buffer.Content) {
+			return errDotOutOfBoundary
 		}
 		codeArea.MutateState(func(s *tk.CodeAreaState) {
 			s.Buffer.Dot = dot

--- a/pkg/edit/state_api_test.go
+++ b/pkg/edit/state_api_test.go
@@ -33,6 +33,13 @@ func TestDot(t *testing.T) {
 	testCodeBuffer(t, f.Editor, tk.CodeBuffer{Content: "code", Dot: 0})
 }
 
+func TestDotOutOfBoundary(t *testing.T) {
+	f := setup(t)
+
+	f.SetCodeBuffer(tk.CodeBuffer{Content: "", Dot: 0})
+	testThatOutputErrorIsBubbled(t, f, `set edit:-dot = 10`)
+}
+
 func TestCurrentCommand(t *testing.T) {
 	f := setup(t)
 


### PR DESCRIPTION
It will throw an error when attempting to set such a value to the dot.

The process would crash otherwise when set the dot to an invalid value then try to insert something for example:
```
~>  set edit:-dot = 10
~> [try to insert something]

goroutine 1 [running]:
src.elv.sh/pkg/sys.DumpStack()
        src.elv.sh/pkg/sys/dumpstack.go:10 +0x65
src.elv.sh/pkg/shell.handlePanic()
        src.elv.sh/pkg/shell/interact.go:137 +0x4f
panic({0x982460?, 0xc000482000?})
        runtime/panic.go:914 +0x21f
src.elv.sh/pkg/cli/tk.(*CodeBuffer).InsertAtDot(...)
        src.elv.sh/pkg/cli/tk/codearea.go:93
src.elv.sh/pkg/cli/tk.(*codeArea).handleKeyEvent(0xc000150100, {0x71f650?, 0xc0?})
        src.elv.sh/pkg/cli/tk/codearea.go:383 +0x54c
src.elv.sh/pkg/cli/tk.(*codeArea).Handle(0xc000150000?, {0xa43e80?, 0xc000230150?})
        src.elv.sh/pkg/cli/tk/codearea.go:178 +0x52
src.elv.sh/pkg/cli.(*app).handle(0xc000150000, {0x964020?, 0xc000230150})
        src.elv.sh/pkg/cli/app.go:227 +0x1c6
src.elv.sh/pkg/cli.(*loop).Run(0xc00011c4c0)
        src.elv.sh/pkg/cli/loop.go:129 +0x18c
src.elv.sh/pkg/cli.(*app).ReadCode(0xc000150000)
        src.elv.sh/pkg/cli/app.go:485 +0x485
src.elv.sh/pkg/edit.(*Editor).ReadCode(0xc000080020?)
        src.elv.sh/pkg/edit/editor.go:116 +0x1b
src.elv.sh/pkg/shell.interact(0xc000208000, {0xc000080020, 0xc000080028, 0xc000080030}, 0xc0001d1ca8)
        src.elv.sh/pkg/shell/interact.go:96 +0x845
src.elv.sh/pkg/shell.(*Program).Run(0xc0001e4000, {0xc000080020, 0xc000080028, 0xc000080030}, {0xc0000240a0, 0x0, 0x0})
        src.elv.sh/pkg/shell/shell.go:88 +0x27a
src.elv.sh/pkg/prog.composite.Run({0xc0000a7800?, 0x4, 0x6da70a?}, {0xc000080020, 0xc000080028, 0xc000080030}, {0xc0000240a0, 0x0, 0x0})
        src.elv.sh/pkg/prog/prog.go:117 +0x12d
src.elv.sh/pkg/prog.Run({0xc000080020, 0xc000080028, 0xc000080030}, {0xc0000240a0, 0x1, 0x1}, {0xa44780, 0xc0000123d8})
        src.elv.sh/pkg/prog/prog.go:84 +0x4b4
main.main()
        src.elv.sh/cmd/elvish/main.go:18 +0x177
```