### PR TITLE
Improve error messages for failed plugin loads

### DIFF
--- a/pkg/eval/builtin_special.go
+++ b/pkg/eval/builtin_special.go
@@ -40,8 +40,12 @@ var IsBuiltinSpecial = map[string]bool{}
 
 // NoSuchModule encodes an error where a module spec cannot be resolved.
 type NoSuchModule struct{ spec string }
+
 // ModuleLoadError encapsulates an error message a failed module load operation.
-type ModuleLoadError struct{ spec string; errormsg string }
+type ModuleLoadError struct {
+	spec     string
+	errormsg string
+}
 
 // Error implements the error interface.
 func (err NoSuchModule) Error() string { return "no such module: " + err.spec }


### PR DESCRIPTION
This improves the error messages you get when elvish fails to load a go module.
Currently elvish almost always just fails with a NoSuchModule error, even when the error was actually a library mismatch or a missing Ns symbol in the .so file.