### PR TITLE
Add an error handling when duplicated function arguments found 

### DIFF
--- a/pkg/eval/compile_value.go
+++ b/pkg/eval/compile_value.go
@@ -377,10 +377,12 @@ func (cp *compiler) lambda(n *parse.Primary) valuesOp {
 		restArg       int = -1
 		optNames      []string
 		optDefaultOps []valuesOp
+		seenNames     map[string]bool
 	)
 	if len(n.Elements) > 0 {
 		// Argument list.
 		argNames = make([]string, len(n.Elements))
+		seenNames = make(map[string]bool)
 		for i, arg := range n.Elements {
 			ref := stringLiteralOrError(cp, arg, "argument name")
 			sigil, qname := SplitSigil(ref)
@@ -396,6 +398,11 @@ func (cp *compiler) lambda(n *parse.Primary) valuesOp {
 					cp.errorpf(arg, "only one argument may have @ prefix")
 				}
 				restArg = i
+			}
+			if seenNames[name] {
+				cp.errorpf(arg, "duplicate argument name '%s'", name)
+			} else {
+				seenNames[name] = true
 			}
 			argNames[i] = name
 		}

--- a/pkg/eval/compile_value_test.elvts
+++ b/pkg/eval/compile_value_test.elvts
@@ -365,6 +365,11 @@ Compilation error: argument name must not be empty
 Compilation error: argument name must not be empty
   [tty]:1:3-3: {|@| }
 
+## argument name must not be duplicated ##
+~> {|a a| }
+Compilation error: duplicate argument name 'a'
+  [tty]:1:5-5: {|a a| }
+
 ## option name must be unqualified ##
 ~> {|&a:b=1| }
 Compilation error: option name must be unqualified


### PR DESCRIPTION
Avoid duplicated arguments in the lambda.

_Before_ we allowed the following `fn` definition including duplicated args
```
> fn foo {|x x| puts $x} 
```
_Now_ we catch duplicated argument 'x' error and display an error message at the compile time in the console. e.g.
```
> compilation error: [interactive]:1:12-12: duplicate argument name 'x'
```



Related to https://github.com/elves/elvish/issues/1142