### PR TITLE
Exclude `_` from double argument checking

### DIFF
--- a/pkg/eval/compile_value.go
+++ b/pkg/eval/compile_value.go
@@ -398,10 +398,12 @@ func (cp *compiler) lambda(n *parse.Primary) valuesOp {
 				}
 				restArg = i
 			}
-			if seenName[name] {
-				cp.errorpf(arg, "duplicate argument name '%s'", name)
-			} else {
-				seenName[name] = true
+			if name != "_" {
+				if seenName[name] {
+					cp.errorpf(arg, "duplicate argument name '%s'", name)
+				} else {
+					seenName[name] = true
+				}
 			}
 			argNames[i] = name
 		}


### PR DESCRIPTION
Fix regression introduced by #1796