### PR TITLE
pkg/cli: disable termios `IXON` flag, which prevents `C-q` and `C-s` keymaps.

### DIFF
--- a/pkg/cli/term/setup_unix.go
+++ b/pkg/cli/term/setup_unix.go
@@ -26,6 +26,7 @@ func setup(in, out *os.File) (func() error, error) {
 	term.SetICanon(false)
 	term.SetIExten(false)
 	term.SetEcho(false)
+	term.SetIXON(false)
 	term.SetVMin(1)
 	term.SetVTime(0)
 

--- a/pkg/sys/eunix/termios.go
+++ b/pkg/sys/eunix/termios.go
@@ -63,6 +63,11 @@ func (term *Termios) SetICRNL(v bool) {
 	setFlag(&term.Iflag, unix.ICRNL, v)
 }
 
+// SetICRNL sets the IXON iflag bit
+func (term *Termios) SetIXON(v bool) {
+	setFlag(&term.Iflag, unix.IXON, v)
+}
+
 func setFlag(flag *termiosFlag, mask termiosFlag, v bool) {
 	if v {
 		*flag |= mask


### PR DESCRIPTION
`IXON` and the messages that it enables have no use in current terminals. According to wiki, it's been used to temporarily halt the process whenever slow hardware devices couldn't catch up with outputs. This is not a problem nowadays, so it should be safe to keep this flag disabled.