### PR TITLE
builtin_fn_styled.d.elv: disambiguate doc wording

### DIFF
--- a/pkg/eval/builtin_fn_styled.d.elv
+++ b/pkg/eval/builtin_fn_styled.d.elv
@@ -71,7 +71,7 @@ fn styled-segment {|object &fg-color=default &bg-color=default &bold=$false &dim
 # - A color name prefixed by `bg-` to set the background color.
 #
 # - A function that receives a styled segment as the only argument and outputs
-#   a single styled segment. This function will be applied to all the segments.
+#   a single styled segment: this function will be applied to all the segments.
 #
 # When a styled text is converted to a string the corresponding
 # [ANSI SGR code](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_.28Select_Graphic_Rendition.29_parameters)

--- a/pkg/eval/builtin_fn_styled.d.elv
+++ b/pkg/eval/builtin_fn_styled.d.elv
@@ -71,7 +71,7 @@ fn styled-segment {|object &fg-color=default &bg-color=default &bold=$false &dim
 # - A color name prefixed by `bg-` to set the background color.
 #
 # - A function that receives a styled segment as the only argument and outputs
-#   a single styled segment, which will be applied to all the segments.
+#   a single styled segment. This function will be applied to all the segments.
 #
 # When a styled text is converted to a string the corresponding
 # [ANSI SGR code](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_.28Select_Graphic_Rendition.29_parameters)


### PR DESCRIPTION
The prior wording could be interpreted as meaning that the single styled segment that the function returns, rather than the function itself, is then applied to all styled segments.