### PR TITLE
Update documentation for kind-of

### DIFF
--- a/pkg/eval/builtin_fn_misc.d.elv
+++ b/pkg/eval/builtin_fn_misc.d.elv
@@ -12,7 +12,7 @@
 # [assembly languages](https://en.wikipedia.org/wiki/NOP).
 fn nop {|&any-opt= @value| }
 
-# Output the kinds of `$value`s. Example:
+# Output the kinds of `$value`s (also known as the _type_). Example:
 #
 # ```elvish-transcript
 # ~> kind-of lorem [] [&]


### PR DESCRIPTION
This commit updates the documentation of the builtin kind-of function to include the word "type", so it's easier to find for people that are looking for it under that name.