### PR TITLE
pkg/cli: Add histlist option to reverse listing

### DIFF
--- a/pkg/edit/listing.go
+++ b/pkg/edit/listing.go
@@ -54,8 +54,10 @@ func initHistlist(ed *Editor, ev *eval.Evaler, histStore histutil.Store, commonB
 	bindingVar := newBindingVar(emptyBindingsMap)
 	bindings := newMapBindings(ed, ev, bindingVar, commonBindingVar)
 	dedup := newBoolVar(true)
+	reverse := newBoolVar(false)
 	ns := eval.BuildNsNamed("edit:histlist").
 		AddVar("binding", bindingVar).
+		AddVar("reverse", reverse).
 		AddGoFns(map[string]any{
 			"start": func() {
 				w, err := modes.NewHistlist(ed.app, modes.HistlistSpec{
@@ -63,6 +65,9 @@ func initHistlist(ed *Editor, ev *eval.Evaler, histStore histutil.Store, commonB
 					AllCmds:  histStore.AllCmds,
 					Dedup: func() bool {
 						return dedup.Get().(bool)
+					},
+					Reverse: func() bool {
+						return reverse.Get().(bool)
 					},
 					Filter: filterSpec,
 					CodeAreaRPrompt: func() ui.Text {


### PR DESCRIPTION
This provides a variable (`edit:histlist:reverse`) to reverse the listing, with more recent commands at the top, but leaves the default order as more recent at the bottom.

```
set edit:histlist:reverse = $true
```

Reversing (most to least recent commands) the histlist makes it easier to see more recent commands quickly without having to look near the bottom of the screen.