### PR TITLE
Update readline-binding.elv with Alt-d (kill-word)

### DIFF
--- a/pkg/mods/readline-binding/readline-binding.elv
+++ b/pkg/mods/readline-binding/readline-binding.elv
@@ -20,7 +20,8 @@ set edit:global-binding[Ctrl-G] = $edit:close-mode~
     $b Ctrl-P $edit:history:start~
     # TODO: ^S ^T ^X family ^Y ^_
     $b Alt-b  $edit:move-dot-left-word~
-    # TODO Alt-c Alt-d
+    # TODO Alt-c
+    $b Alt-d  $edit:kill-word-right~
     $b Alt-f  $edit:move-dot-right-word~
     # TODO Alt-l Alt-r Alt-u
 


### PR DESCRIPTION
Add the previously TODO `Alt-d` keybinding to mirror readline's `kill-word`.