### PR TITLE
Add the installation instruction on ChromeOS using Chromebrew

### DIFF
--- a/website/get/package-manager.md
+++ b/website/get/package-manager.md
@@ -30,6 +30,8 @@ yay -S elvish-git
 
 Elvish is packaged by [Chromebrew](https://chromebrew.github.io/).
 
+![Chromebrew package](https://repology.org/badge/version-for-repo/crewbrew/elvish.svg)
+
 ```elvish
 crew install elvish
 ```

--- a/website/get/package-manager.md
+++ b/website/get/package-manager.md
@@ -26,6 +26,14 @@ your favorite AUR helper:
 yay -S elvish-git
 ```
 
+# ChromeOS
+
+Elvish is packaged by [Chromebrew](https://chromebrew.github.io/).
+
+```elvish
+crew install elvish
+```
+
 # Debian / Ubuntu
 
 ![Debian 13 package](https://repology.org/badge/version-for-repo/debian_13/elvish.svg)


### PR DESCRIPTION
Hi, there.

Thank you for creating such a wonderful shell.

I use ChromeOS from time to time.
The other day, I wanted to use the latest version of Elvish with the package manager, so I made it possible to install Elvish with Chromebrew, the ChromeOS package manager.

I've added the instructions to the installation documentation, so if there are no problems, would you be able to merge the PR?

Regards,
