### PR TITLE
pkg: Simplify tests with testutil.Setenv

### DIFF
--- a/pkg/eval/vars/env_test.go
+++ b/pkg/eval/vars/env_test.go
@@ -31,7 +31,7 @@ func TestEnvVariable(t *testing.T) {
 		t.Errorf("envVariable.Set to a non-string value didn't return an error")
 	}
 
-	os.Setenv(name, "bar")
+	testutil.Setenv(t, name, "bar")
 	if v.Get() != "bar" {
 		t.Errorf("EnvVariable.Get doesn't return value set elsewhere")
 	}

--- a/pkg/fsutil/getwd_test.go
+++ b/pkg/fsutil/getwd_test.go
@@ -30,11 +30,9 @@ func TestGetwd(t *testing.T) {
 		{"wd not abbreviated when HOME is slash", "/", tmpdir, tmpdir},
 	}
 
-	testutil.SaveEnv(t, env.HOME)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv(env.HOME, test.home)
+			testutil.Setenv(t, env.HOME, test.home)
 			must.Chdir(test.chdir)
 			if gotWd := Getwd(); gotWd != test.wantWd {
 				t.Errorf("Getwd() -> %v, want %v", gotWd, test.wantWd)

--- a/pkg/testutil/scaled_test.go
+++ b/pkg/testutil/scaled_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -27,12 +26,9 @@ var scaledMsTests = []struct {
 }
 
 func TestScaled(t *testing.T) {
-	envSave := os.Getenv(env.ELVISH_TEST_TIME_SCALE)
-	defer os.Setenv(env.ELVISH_TEST_TIME_SCALE, envSave)
-
 	for _, test := range scaledMsTests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv(env.ELVISH_TEST_TIME_SCALE, test.env)
+			Setenv(t, env.ELVISH_TEST_TIME_SCALE, test.env)
 			got := Scaled(test.d)
 			if got != test.want {
 				t.Errorf("got %v, want %v", got, test.want)


### PR DESCRIPTION
The PR refactors tests to use https://pkg.go.dev/src.elv.sh/pkg/testutil#Setenv