### PR TITLE
pkg/glob: Simplify test with filepath.ToSlash

### DIFF
--- a/pkg/glob/glob_test.go
+++ b/pkg/glob/glob_test.go
@@ -2,10 +2,10 @@ package glob
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"src.elv.sh/pkg/testutil"
@@ -75,7 +75,7 @@ func TestGlob_Absolute(t *testing.T) {
 
 func testGlob(t *testing.T, abs bool) {
 	dir := testutil.InTempDir(t)
-	dir = strings.ReplaceAll(dir, string(os.PathSeparator), "/")
+	dir = filepath.ToSlash(dir)
 
 	for _, dir := range append(mkdirs, mkdirDots...) {
 		err := os.Mkdir(dir, 0755)


### PR DESCRIPTION
`filepath.ToSlash(dir)` is the same as `strings.ReplaceAll(dir, string(os.PathSeparator), "/")`