### PR TITLE
website: Fix typos

### DIFF
--- a/website/blog/0.11-release-notes.md
+++ b/website/blog/0.11-release-notes.md
@@ -76,7 +76,7 @@ As usual, prebuilt binaries can be found in [get](../get/).
     assignments ([#486](https://github.com/elves/elvish/issues/486)).
 
 -   A primitive for running functions in parallel,
-    [`run-parellel`](../ref/builtin.html#run-parallel), has been added
+    [`run-parallel`](../ref/builtin.html#run-parallel), has been added
     ([#485](https://github.com/elves/elvish/issues/485)).
 
 -   The [`splits`](../ref/builtin.html#splits) builtin now supports a `&max`

--- a/website/cmd/gensite/model.go
+++ b/website/cmd/gensite/model.go
@@ -25,7 +25,7 @@ type siteConf struct {
 	BaseCSS    []string
 }
 
-// categoryMeta represents the metadata of a cateogory, found in the global
+// categoryMeta represents the metadata of a category, found in the global
 // site configuration.
 type categoryMeta struct {
 	Name    string

--- a/website/learn/tour.md
+++ b/website/learn/tour.md
@@ -487,7 +487,7 @@ the following command shows details of the `elvish` binary:
 ```
 
 **Note**: the same feature is usually known as *command substitution* in
-traditonal shells.
+traditional shells.
 
 Unlike traditional shells, Elvish only splits the output on newlines, not any
 other whitespace characters.

--- a/website/slides/2024-08-rc-design.md
+++ b/website/slides/2024-08-rc-design.md
@@ -69,7 +69,7 @@ Qi Xiao (xiaq)
     ```
 
 -   ```elvish
-    # update-servers-in-parellel.elv
+    # update-servers-in-parallel.elv
     var hosts = [[&name=a &cmd='apt update']
                  [&name=b &cmd='pacman -Syu']]
     # peach = "parallel each"


### PR DESCRIPTION
The PR corrects grammar mistakes in the `website` directory.