### PR TITLE
fix: epm domain config file can be a symlink

### DIFF
--- a/pkg/mods/epm/epm.elv
+++ b/pkg/mods/epm/epm.elv
@@ -185,7 +185,7 @@ fn -write-domain-config {|dom|
 fn -domain-config {|dom|
   var cfgfile = (-domain-config-file $dom)
   var cfg = $false
-  if (path:is-regular $cfgfile) {
+  if (path:is-regular &follow-symlink=$true $cfgfile) {
     # If the config file exists, read it...
     set cfg = (from-json < $cfgfile)
     -debug "Read domain config for "$dom": "(to-string $cfg)


### PR DESCRIPTION
With v0.21.0, if the custom package domain file is a symbolic link epm commands will fail with:

```text
=> No config file for domain 'my.custom.domain'
```

This may be the case if the file is managed by something like stow, nix, or home-manager.

Fix by following symbolic links.

issue: #1833