### PR TITLE
pkg/mods/epm: Add sourcehut to default domain list

### DIFF
--- a/pkg/mods/epm/epm.elv
+++ b/pkg/mods/epm/epm.elv
@@ -30,6 +30,11 @@ var -default-domain-config = [
     &protocol= https
     &levels= 2
   ]
+  &"git.sr.ht"= [
+    &method= git
+    &protocol= https
+    &levels= 2
+  ]
 ]
 
 # The path of the `epm`-managed directory.


### PR DESCRIPTION
This adds [sourcehut](https://git.sr.ht/) as a source for epm.  I feel it has become a popular enough open source hosting to warrant adding it to the default list. I'm currently in the process of moving my personal projects there.