### PR TITLE
website/ref/language: add hints for list operations

### DIFF
--- a/website/ref/language.md
+++ b/website/ref/language.md
@@ -383,6 +383,24 @@ Examples:
 ▶ [lorem ipsum]
 ```
 
+Common operations with lists can be achieved using the patterns below:
+
+```elvish-transcript
+~> var li = [lorem ipsum]
+~> var new-li = (conj $li foo bar)  # This emulates concatenating or appending.
+~> put $new-li
+▶ [lorem ipsum foo bar]
+~> var newer-li = [foo bar $@li]    # This emulates prepending.
+~> put $newer-li
+▶ [foo bar lorem ipsum]
+```
+
+See also:
+
+-   [`conj`](builtin.html#conj) builtin
+
+-   [`$@`](#variable-use) for variable exploding
+
 ## Map
 
 A map is a value containing unordered key-value pairs.


### PR DESCRIPTION
This commit modifies the language reference section on lists and provides hints how a user can emulate concatenating or prepending to a list.  The goal is to surface what is to be answers to common usage needs, especially for users coming to Elvish from other language ecosystems.