### PR TITLE
completion: fix expansion

### DIFF
--- a/pkg/edit/completion.go
+++ b/pkg/edit/completion.go
@@ -80,7 +80,13 @@ func completionStart(ed *Editor, bindings tk.Bindings, ev *eval.Evaler, cfg comp
 			insertedPrefix := false
 			codeArea.MutateState(func(s *tk.CodeAreaState) {
 				rep := s.Buffer.Content[result.Replace.From:result.Replace.To]
-				if len(prefix) > len(rep) && strings.HasPrefix(prefix, rep) {
+				if strings.HasPrefix(rep, "~/") {
+					if dir, err := os.UserHomeDir(); err == nil {
+						rep = strings.Replace(rep, "~", dir, 1)
+					}
+				}
+
+				if len(prefix) > len(rep) && strings.HasPrefix(strings.ToLower(prefix), strings.ToLower(rep)) {
 					s.Pending = tk.PendingCode{
 						Content: prefix,
 						From:    result.Replace.From, To: result.Replace.To}

--- a/pkg/edit/completion_test.go
+++ b/pkg/edit/completion_test.go
@@ -3,6 +3,7 @@ package edit
 import (
 	"testing"
 
+	"src.elv.sh/pkg/cli/lscolors"
 	"src.elv.sh/pkg/cli/term"
 	"src.elv.sh/pkg/eval"
 	"src.elv.sh/pkg/eval/vals"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestCompletionAddon(t *testing.T) {
+	lscolors.SetTestLsColors(t)
 	f := setup(t)
 
 	testutil.ApplyDir(testutil.Dir{"a": "", "b": ""})
@@ -27,6 +29,7 @@ func TestCompletionAddon(t *testing.T) {
 }
 
 func TestCompletionAddon_CompletesLongestCommonPrefix(t *testing.T) {
+	lscolors.SetTestLsColors(t)
 	f := setup(t)
 
 	testutil.ApplyDir(testutil.Dir{"foo1": "", "foo2": "", "foo": "", "fox": ""})
@@ -73,6 +76,7 @@ func TestCompletionAddon_AppliesAutofix(t *testing.T) {
 }
 
 func TestCompleteFilename(t *testing.T) {
+	lscolors.SetTestLsColors(t)
 	f := setup(t)
 
 	testutil.ApplyDir(testutil.Dir{"d": testutil.Dir{"a": "", "b": ""}})
@@ -156,6 +160,7 @@ func TestCompleteSudo(t *testing.T) {
 }
 
 func TestCompletionMatcher(t *testing.T) {
+	lscolors.SetTestLsColors(t)
 	f := setup(t)
 
 	testutil.ApplyDir(testutil.Dir{"foo": "", "oof": ""})


### PR DESCRIPTION
Expands `~` before prefix check so that menu won't be show for single candidate. Lowercase prefix check to support case-insensitive `edit:completion:matcher`.

Does NOT fix quotation change.

e.g. completing a single candidate that contains space:

```elv
set edit:completion:arg-completer[bug] = {|@args|
    put "with space"
}
```

```
bug w[TAB]
```

fix https://github.com/elves/elvish/issues/1826