### PR TITLE
Provide autosuggestions

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -141,6 +141,7 @@ func NewApp(spec AppSpec) App {
 		SimpleAbbreviations:    spec.SimpleAbbreviations,
 		CommandAbbreviations:   spec.CommandAbbreviations,
 		SmallWordAbbreviations: spec.SmallWordAbbreviations,
+		AutoSuggestionProvider: spec.AutoSuggestionProvider,
 	})
 
 	return &a
@@ -267,6 +268,10 @@ func (a *app) redraw(flag redrawFlag) {
 		a.codeArea.MutateState(func(s *tk.CodeAreaState) {
 			s.HideTips = true
 			s.HideRPrompt = hideRPrompt
+			// Clear autosuggestion on final redraw
+			if s.Pending.AutoSuggestion {
+				s.Pending = tk.PendingCode{}
+			}
 		})
 		bufMain := renderApp([]tk.Widget{a.codeArea /* no addon */}, width, height)
 		a.codeArea.MutateState(func(s *tk.CodeAreaState) {

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -142,6 +142,7 @@ func NewApp(spec AppSpec) App {
 		CommandAbbreviations:   spec.CommandAbbreviations,
 		SmallWordAbbreviations: spec.SmallWordAbbreviations,
 		AutoSuggestionProvider: spec.AutoSuggestionProvider,
+		OnAsyncSuggestion:      a.Redraw,
 	})
 
 	return &a

--- a/pkg/cli/app_spec.go
+++ b/pkg/cli/app_spec.go
@@ -25,6 +25,8 @@ type AppSpec struct {
 	CommandAbbreviations   func(f func(abbr, full string))
 	SmallWordAbbreviations func(f func(abbr, full string))
 
+	AutoSuggestionProvider func(code string) string
+
 	CodeAreaState tk.CodeAreaState
 	State         State
 }

--- a/pkg/cli/tk/codearea.go
+++ b/pkg/cli/tk/codearea.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"unicode"
 	"unicode/utf8"
 
@@ -50,6 +51,9 @@ type CodeAreaSpec struct {
 	OnSubmit func()
 	// A function that returns an autosuggestion for the given code.
 	AutoSuggestionProvider func(code string) string
+	// A callback that is called when an async autosuggestion is ready.
+	// The widget will call this to trigger a redraw.
+	OnAsyncSuggestion func()
 
 	// State. When used in New, this field specifies the initial state.
 	State CodeAreaState
@@ -114,6 +118,9 @@ type codeArea struct {
 	pasting bool
 	// Buffer for keeping Pasted text during bracketed pasting.
 	pasteBuffer bytes.Buffer
+
+	asyncSuggestionSeq  atomic.Int32
+	asyncSuggestionCode string // Code for which we have a pending/current suggestion
 }
 
 // NewCodeArea creates a new CodeArea from the given spec.
@@ -147,6 +154,9 @@ func NewCodeArea(spec CodeAreaSpec) CodeArea {
 	}
 	if spec.AutoSuggestionProvider == nil {
 		spec.AutoSuggestionProvider = func(s string) string { return "" }
+	}
+	if spec.OnAsyncSuggestion == nil {
+		spec.OnAsyncSuggestion = func() {}
 	}
 	return &codeArea{CodeAreaSpec: spec}
 }
@@ -222,21 +232,92 @@ func (w *codeArea) updateAutoSuggestion() {
 		return
 	}
 
-	suggestion := w.AutoSuggestionProvider(buf.Content)
-	if suggestion == "" {
-		// Clear autosuggestion if there's no suggestion
-		if w.State.Pending.AutoSuggestion {
-			w.State.Pending = PendingCode{}
+	code := buf.Content
+
+	// Check if the existing autosuggestion is still valid after typing.
+	// This prevents flickering when the user types characters that match the suggestion.
+	if w.State.Pending.AutoSuggestion && w.State.Pending.Content != "" {
+		// The suggestion was created at a certain point. We need to check if what
+		// the user has typed since then still matches the beginning of the suggestion.
+
+		// Check if From is within bounds (handles backspace case)
+		if w.State.Pending.From <= len(code) {
+			// Calculate what we've typed since the suggestion was made
+			typedSinceSuggestion := code[w.State.Pending.From:]
+
+			// If the suggestion still starts with what we've typed, adjust it
+			if strings.HasPrefix(w.State.Pending.Content, typedSinceSuggestion) {
+				// Keep the suggestion but adjust the content to show only the remaining part
+				// For example: originally "d --type f", typed "d", show " --type f"
+				remainingSuggestion := strings.TrimPrefix(w.State.Pending.Content, typedSinceSuggestion)
+
+				// Update the pending state
+				w.State.Pending = PendingCode{
+					From:           buf.Dot,
+					To:             buf.Dot,
+					Content:        remainingSuggestion,
+					AutoSuggestion: true,
+				}
+				// Don't launch a new async request - keep the existing suggestion
+				return
+			}
 		}
-		return
+		// Suggestion is no longer valid, clear it and get a new one
+		w.State.Pending = PendingCode{}
 	}
 
-	w.State.Pending = PendingCode{
-		From:           buf.Dot,
-		To:             buf.Dot,
-		Content:        suggestion,
-		AutoSuggestion: true,
-	}
+	// Launch async suggestion request
+	seq := w.asyncSuggestionSeq.Add(1)
+	w.asyncSuggestionCode = code
+
+	// Launch a goroutine to get the suggestion
+	// There may be multiple irrelevant goroutines running for autosuggestions.
+	go func() {
+		suggestion := w.AutoSuggestionProvider(code)
+
+		// Check if this suggestion is still relevant
+		stillRelevant := seq == w.asyncSuggestionSeq.Load() && code == w.asyncSuggestionCode
+
+		if !stillRelevant {
+			// User has typed more; discard this suggestion
+			return
+		}
+
+		// Apply the suggestion
+		w.StateMutex.Lock()
+		defer w.StateMutex.Unlock()
+
+		// Double-check conditions still hold
+		if w.State.Pending.Content != "" && !w.State.Pending.AutoSuggestion {
+			return
+		}
+		if w.State.Buffer.Content != code || w.State.Buffer.Dot != len(code) {
+			return
+		}
+
+		if suggestion == "" {
+			// Clear autosuggestion if there's no suggestion
+			if w.State.Pending.AutoSuggestion {
+				w.State.Pending = PendingCode{}
+			}
+		} else {
+			// Check if we already have this suggestion - if so, keep the existing one
+			// to avoid flickering and preserve the From position
+			if w.State.Pending.AutoSuggestion && w.State.Pending.Content == suggestion {
+				// Same suggestion, keep it as is
+				return
+			}
+			w.State.Pending = PendingCode{
+				From:           w.State.Buffer.Dot,
+				To:             w.State.Buffer.Dot,
+				Content:        suggestion,
+				AutoSuggestion: true,
+			}
+		}
+
+		// Trigger a redraw
+		w.OnAsyncSuggestion()
+	}()
 }
 
 func (w *codeArea) handlePasteSetting(start bool) bool {
@@ -427,6 +508,7 @@ func (w *codeArea) handleKeyEvent(key ui.Key) bool {
 		w.State.Buffer.InsertAtDot(s)
 		w.inserts += s
 		w.lastCodeBuffer = w.State.Buffer
+
 		if parse.IsWhitespace(key.Rune) {
 			w.expandCommandAbbr()
 		}

--- a/pkg/cli/tk/codearea.go
+++ b/pkg/cli/tk/codearea.go
@@ -48,6 +48,8 @@ type CodeAreaSpec struct {
 	QuotePaste func() bool
 	// A function that is called on the submit event.
 	OnSubmit func()
+	// A function that returns an autosuggestion for the given code.
+	AutoSuggestionProvider func(code string) string
 
 	// State. When used in New, this field specifies the initial state.
 	State CodeAreaState
@@ -80,6 +82,8 @@ type PendingCode struct {
 	To int
 	// The content of the pending code.
 	Content string
+	// Whether this pending code is an autosuggestion (affects styling).
+	AutoSuggestion bool
 }
 
 // ApplyPending applies pending code to the code buffer, and resets pending code.
@@ -141,6 +145,9 @@ func NewCodeArea(spec CodeAreaSpec) CodeArea {
 	if spec.OnSubmit == nil {
 		spec.OnSubmit = func() {}
 	}
+	if spec.AutoSuggestionProvider == nil {
+		spec.AutoSuggestionProvider = func(s string) string { return "" }
+	}
 	return &codeArea{CodeAreaSpec: spec}
 }
 
@@ -195,6 +202,41 @@ func (w *codeArea) CopyState() CodeAreaState {
 func (w *codeArea) resetInserts() {
 	w.inserts = ""
 	w.lastCodeBuffer = CodeBuffer{}
+}
+
+// updateAutoSuggestion updates the pending code with an autosuggestion.
+// This function assumes the state mutex is held.
+func (w *codeArea) updateAutoSuggestion() {
+	// Don't override non-autosuggestion pending code (e.g., from completion)
+	if w.State.Pending.Content != "" && !w.State.Pending.AutoSuggestion {
+		return
+	}
+
+	buf := &w.State.Buffer
+	// Only suggest when cursor is at the end
+	if buf.Dot != len(buf.Content) {
+		// Clear autosuggestion if cursor is not at the end
+		if w.State.Pending.AutoSuggestion {
+			w.State.Pending = PendingCode{}
+		}
+		return
+	}
+
+	suggestion := w.AutoSuggestionProvider(buf.Content)
+	if suggestion == "" {
+		// Clear autosuggestion if there's no suggestion
+		if w.State.Pending.AutoSuggestion {
+			w.State.Pending = PendingCode{}
+		}
+		return
+	}
+
+	w.State.Pending = PendingCode{
+		From:           buf.Dot,
+		To:             buf.Dot,
+		Content:        suggestion,
+		AutoSuggestion: true,
+	}
 }
 
 func (w *codeArea) handlePasteSetting(start bool) bool {
@@ -357,15 +399,17 @@ func (w *codeArea) handleKeyEvent(key ui.Key) bool {
 		return true
 	case ui.K(ui.Backspace), ui.K('H', ui.Ctrl):
 		w.resetInserts()
-		w.MutateState(func(s *CodeAreaState) {
-			c := &s.Buffer
-			// Remove the last rune.
-			_, chop := utf8.DecodeLastRuneInString(c.Content[:c.Dot])
-			*c = CodeBuffer{
-				Content: c.Content[:c.Dot-chop] + c.Content[c.Dot:],
-				Dot:     c.Dot - chop,
-			}
-		})
+		w.StateMutex.Lock()
+		defer w.StateMutex.Unlock()
+		c := &w.State.Buffer
+		// Remove the last rune.
+		_, chop := utf8.DecodeLastRuneInString(c.Content[:c.Dot])
+		*c = CodeBuffer{
+			Content: c.Content[:c.Dot-chop] + c.Content[c.Dot:],
+			Dot:     c.Dot - chop,
+		}
+		// Update autosuggestion after backspace
+		w.updateAutoSuggestion()
 		return true
 	default:
 		if isFuncKey || !unicode.IsGraphic(key.Rune) {
@@ -388,6 +432,7 @@ func (w *codeArea) handleKeyEvent(key ui.Key) bool {
 		}
 		w.expandSimpleAbbr()
 		w.expandSmallWordAbbr(key.Rune, CategorizeSmallWord)
+		w.updateAutoSuggestion()
 		return true
 	}
 }

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -16,6 +16,8 @@ type view struct {
 }
 
 var stylingForPending = ui.Underlined
+var stylingForAutoSuggestion = ui.FgBrightBlack
+// var stylingForAutoSuggestion = ui
 
 func getView(w *codeArea) *view {
 	s := w.CopyState()
@@ -26,8 +28,13 @@ func getView(w *codeArea) *view {
 	}
 	if pFrom < pTo {
 		// Apply stylingForPending to [pFrom, pTo)
+		styling := stylingForPending
+		if s.Pending.AutoSuggestion {
+			styling = stylingForAutoSuggestion
+		}
+		// Apply styling to [pFrom, pTo)
 		parts := styledCode.Partition(pFrom, pTo)
-		pending := ui.StyleText(parts[1], stylingForPending)
+		pending := ui.StyleText(parts[1], styling)
 		styledCode = ui.Concat(parts[0], pending, parts[2])
 	}
 

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -16,8 +16,7 @@ type view struct {
 }
 
 var stylingForPending = ui.Underlined
-var stylingForAutoSuggestion = ui.FgBrightBlack
-// var stylingForAutoSuggestion = ui
+var stylingForAutoSuggestion = ui.Dim
 
 func getView(w *codeArea) *view {
 	s := w.CopyState()
@@ -43,7 +42,16 @@ func getView(w *codeArea) *view {
 		rprompt = w.RPrompt()
 	}
 
-	return &view{w.Prompt(), rprompt, styledCode, code.Dot, errors}
+	// For autosuggestions, override the dot position to stay at the original cursor
+	// position (before the suggestion) for rendering purposes only
+	dot := code.Dot
+	if s.Pending.AutoSuggestion && s.Pending.Content != "" && pFrom < pTo {
+		// Only use pFrom if patchPending returned a valid pending range
+		// (pFrom < pTo means it wasn't rejected as invalid)
+		dot = pFrom
+	}
+
+	return &view{w.Prompt(), rprompt, styledCode, dot, errors}
 }
 
 func patchPending(c CodeBuffer, p PendingCode) (CodeBuffer, int, int) {

--- a/pkg/cli/tk/codearea_test.go
+++ b/pkg/cli/tk/codearea_test.go
@@ -507,9 +507,9 @@ func TestCodeAreaState_ApplyPending(t *testing.T) {
 		return s
 	}
 	tt.Test(t, applyPending,
-		Args(CodeAreaState{Buffer: CodeBuffer{}, Pending: PendingCode{0, 0, "ls"}}).
+		Args(CodeAreaState{Buffer: CodeBuffer{}, Pending: PendingCode{0, 0, "ls", false}}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "ls", Dot: 2}, Pending: PendingCode{}}),
-		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, Pending: PendingCode{0, 0, "ls"}}).
+		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}, Pending: PendingCode{0, 0, "ls", false}}).
 			Rets(CodeAreaState{Buffer: CodeBuffer{Content: "lsx", Dot: 3}, Pending: PendingCode{}}),
 		// No-op when Pending is empty.
 		Args(CodeAreaState{Buffer: CodeBuffer{"x", 1}}).

--- a/pkg/edit/autosuggest.go
+++ b/pkg/edit/autosuggest.go
@@ -32,10 +32,11 @@ func defaultHistoryProvider(hs *histStore, code string) string {
 		text := cmds[i].Text
 		// Match commands that start with current input
 		// Also handle multiline commands - only match against the first line
-		if strings.HasPrefix(text, code) && len(text) > len(code) {
+		if strings.HasPrefix(text, code) {
 			text = TrimSpaceRight(text)
-			// Return the remaining part after the current input
-			return text[len(code):]
+			if len(text) > len(code) {
+				return text[len(code):]
+			}
 		}
 	}
 

--- a/pkg/edit/autosuggest.go
+++ b/pkg/edit/autosuggest.go
@@ -1,0 +1,123 @@
+package edit
+
+import (
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"src.elv.sh/pkg/cli"
+	"src.elv.sh/pkg/cli/tk"
+	"src.elv.sh/pkg/eval"
+	"src.elv.sh/pkg/eval/vars"
+)
+
+func defaultHistoryProvider(hs *histStore, code string) string {
+	if hs == nil {
+		return ""
+	}
+	if code == "" {
+		return ""
+	}
+
+	// Get commands from history that start with the current input
+	// TODO: Optimize this to avoid fetching all commands
+	cmds, err := hs.AllCmds()
+	if err != nil {
+		return ""
+	}
+
+	// Search backwards through history for the most recent match
+	for i := len(cmds) - 1; i >= 0; i-- {
+		text := cmds[i].Text
+		// Match commands that start with current input
+		// Also handle multiline commands - only match against the first line
+		if strings.HasPrefix(text, code) && len(text) > len(code) {
+			text = TrimSpaceRight(text)
+			// Return the remaining part after the current input
+			return text[len(code):]
+		}
+	}
+
+	return ""
+}
+
+var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+
+func TrimSpaceRight(s string) string {
+	start := 0
+	stop := len(s)
+	for ; stop > start; stop-- {
+		c := s[stop-1]
+		if c >= utf8.RuneSelf {
+			// start has been already trimmed above, should trim end only
+			return strings.TrimRightFunc(s[start:stop], unicode.IsSpace)
+		}
+		if asciiSpace[c] == 0 {
+			break
+		}
+	}
+
+	return s[start:stop]
+}
+
+func initAutoSuggestionSpec(appSpec *cli.AppSpec, hs *histStore, enabled vars.PtrVar, provider vars.PtrVar, ev *eval.Evaler) {
+	appSpec.AutoSuggestionProvider = func(code string) string {
+		if !enabled.GetRaw().(bool) {
+			return ""
+		}
+
+		// Check if user has set a custom provider function
+		providerFn := provider.GetRaw()
+		if fn, ok := providerFn.(eval.Callable); ok {
+			// Call user-defined provider function
+			var result string
+			valuesCb := func(ch <-chan any) {
+				for v := range ch {
+					if s, ok := v.(string); ok && result == "" {
+						result = s
+						return
+					}
+				}
+			}
+			bytesCb := func(_ *os.File) {}
+
+			port, done, err := eval.PipePort(valuesCb, bytesCb)
+			if err != nil {
+				return ""
+			}
+			err = ev.Call(fn,
+				eval.CallCfg{Args: []any{code}, From: "[auto-suggestion provider]"},
+				eval.EvalCfg{Ports: []*eval.Port{nil, port, nil}})
+			done()
+			if err == nil && result != "" {
+				return result
+			}
+			return ""
+		}
+
+		// Fall back to default history-based provider
+		return defaultHistoryProvider(hs, code)
+	}
+}
+
+func initAutoSuggestionAPI(app cli.App, enabled vars.PtrVar, provider vars.PtrVar, nb eval.NsBuilder) {
+	acceptFn := func() {
+		codeArea, ok := focusedCodeArea(app)
+		if !ok {
+			return
+		}
+		codeArea.MutateState(func(s *tk.CodeAreaState) {
+			// Only accept if there's an autosuggestion pending
+			if s.Pending.Content != "" && s.Pending.AutoSuggestion {
+				s.ApplyPending()
+			}
+		})
+	}
+
+	nb.AddNs("auto-suggestion",
+		eval.BuildNsNamed("edit:auto-suggestion").
+			AddVar("enabled", enabled).
+			AddVar("provider", provider).
+			AddGoFn("accept", acceptFn))
+}

--- a/pkg/edit/buffer_builtins.go
+++ b/pkg/edit/buffer_builtins.go
@@ -24,6 +24,10 @@ func initBufferBuiltins(app cli.App, nb eval.NsBuilder) {
 			}
 			codeArea.MutateState(func(s *tk.CodeAreaState) {
 				fn(&s.Buffer)
+				// Clear autosuggestion when cursor is not at the end
+				if s.Pending.AutoSuggestion && s.Buffer.Dot != len(s.Buffer.Content) {
+					s.Pending = tk.PendingCode{}
+				}
 			})
 		}
 	}

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -63,6 +63,9 @@ func NewEditor(tty cli.TTY, ev *eval.Evaler, st storedefs.Store) *Editor {
 		_ = err // TODO(xiaq): Report the error.
 	}
 
+	autoSuggestEnabled := newBoolVar(true)
+	var autoSuggestProviderFn eval.Callable
+	autoSuggestProvider := newFnVar(autoSuggestProviderFn)
 	initMaxHeight(&appSpec, nb)
 	initReadlineHooks(&appSpec, ev, nb)
 	initAddCmdFilters(&appSpec, ev, nb, hs)
@@ -70,7 +73,9 @@ func NewEditor(tty cli.TTY, ev *eval.Evaler, st storedefs.Store) *Editor {
 	initInsertAPI(&appSpec, ed, ev, nb)
 	initHighlighter(&appSpec, ed, ev, nb)
 	initPrompts(&appSpec, ed, ev, nb)
+	initAutoSuggestionSpec(&appSpec, hs, autoSuggestEnabled, autoSuggestProvider, ev)
 	ed.app = cli.NewApp(appSpec)
+	initAutoSuggestionAPI(ed.app, autoSuggestEnabled, autoSuggestProvider, nb)
 
 	initExceptionsAPI(ed, nb)
 	initVarsAPI(nb)

--- a/pkg/edit/init.elv
+++ b/pkg/edit/init.elv
@@ -41,6 +41,8 @@ set insert:binding = (binding-table [
   &Ctrl-U=    $kill-line-left~
   &Ctrl-K=    $kill-line-right~
 
+  &Ctrl-F=    $auto-suggestion:accept~
+
   &Ctrl-V= $insert-raw~
   &Ctrl-Alt-V= $-insert-key-name~
 


### PR DESCRIPTION
Provide fish like autosuggestion. By default it suggest from history. But can be customized (maybe use it to provide AI suggestions?)

```
# enabled by default
set edit:auto-suggestion:enabled = $true

# optional
set edit:auto-suggestion:provider = {|code|
  if (str:has-prefix $code "hello ") {
    put "world"
  }
}

# default keymap
set edit:insert:binding[Ctrl-F] = $edit:auto-suggestion:accept~
```


fixes #322 