### PR TITLE
pkg/edit: add support for OSC 133 semantic prompts

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -69,6 +69,7 @@ type app struct {
 	RPromptPersistent func() bool
 	BeforeReadline    []func()
 	AfterReadline     []func(string)
+	ShellIntegration  func() bool
 	Highlighter       Highlighter
 	Prompt            Prompt
 	RPrompt           Prompt
@@ -99,6 +100,7 @@ func NewApp(spec AppSpec) App {
 		RPromptPersistent: spec.RPromptPersistent,
 		BeforeReadline:    spec.BeforeReadline,
 		AfterReadline:     spec.AfterReadline,
+		ShellIntegration:  spec.ShellIntegration,
 		Highlighter:       spec.Highlighter,
 		Prompt:            spec.Prompt,
 		RPrompt:           spec.RPrompt,
@@ -113,6 +115,9 @@ func NewApp(spec AppSpec) App {
 	}
 	if a.RPromptPersistent == nil {
 		a.RPromptPersistent = func() bool { return false }
+	}
+	if a.ShellIntegration == nil {
+		a.ShellIntegration = func() bool { return true }
 	}
 	if a.Highlighter == nil {
 		a.Highlighter = dummyHighlighter{}
@@ -130,13 +135,14 @@ func NewApp(spec AppSpec) App {
 	lp.RedrawCb(a.redraw)
 
 	a.codeArea = tk.NewCodeArea(tk.CodeAreaSpec{
-		Bindings:    spec.CodeAreaBindings,
-		Highlighter: a.Highlighter.Get,
-		Prompt:      a.Prompt.Get,
-		RPrompt:     a.RPrompt.Get,
-		QuotePaste:  spec.QuotePaste,
-		OnSubmit:    a.CommitCode,
-		State:       spec.CodeAreaState,
+		Bindings:         spec.CodeAreaBindings,
+		Highlighter:      a.Highlighter.Get,
+		Prompt:           a.Prompt.Get,
+		RPrompt:          a.RPrompt.Get,
+		QuotePaste:       spec.QuotePaste,
+		OnSubmit:         a.CommitCode,
+		State:            spec.CodeAreaState,
+		ShellIntegration: a.ShellIntegration,
 
 		SimpleAbbreviations:    spec.SimpleAbbreviations,
 		CommandAbbreviations:   spec.CommandAbbreviations,

--- a/pkg/cli/app_spec.go
+++ b/pkg/cli/app_spec.go
@@ -12,6 +12,7 @@ type AppSpec struct {
 	RPromptPersistent func() bool
 	BeforeReadline    []func()
 	AfterReadline     []func(string)
+	ShellIntegration  func() bool
 
 	Highlighter Highlighter
 	Prompt      Prompt

--- a/pkg/cli/clitest/apptest.go
+++ b/pkg/cli/clitest/apptest.go
@@ -40,7 +40,10 @@ type Fixture struct {
 // been started asynchronously.
 func Setup(fns ...func(*cli.AppSpec, TTYCtrl)) *Fixture {
 	tty, ttyCtrl := NewFakeTTY()
-	spec := cli.AppSpec{TTY: tty}
+	spec := cli.AppSpec{
+		TTY:              tty,
+		ShellIntegration: func() bool { return false },
+	}
 	for _, fn := range fns {
 		fn(&spec, ttyCtrl)
 	}

--- a/pkg/cli/term/buffer.go
+++ b/pkg/cli/term/buffer.go
@@ -3,16 +3,13 @@ package term
 import (
 	"fmt"
 	"strings"
-
-	"src.elv.sh/pkg/wcwidth"
 )
 
-// Cell is an indivisible unit on the screen. It is not necessarily 1 column
-// wide.
+// Cell is an indivisible unit on the screen.
 type Cell struct {
-	Text      string
-	Style     string
-	ZeroWidth bool
+	Text  string
+	Style string
+	Width int
 }
 
 // Pos is a line/column position.
@@ -24,9 +21,7 @@ type Pos struct {
 func cellsWidth(cs []Cell) int {
 	w := 0
 	for _, c := range cs {
-		if !c.ZeroWidth {
-			w += wcwidth.Of(c.Text)
-		}
+		w += c.Width
 	}
 	return w
 }
@@ -161,7 +156,7 @@ func (b *Buffer) TTYString() string {
 				lastStyle = cell.Style
 			}
 			sb.WriteString(cell.Text)
-			usedWidth += wcwidth.Of(cell.Text)
+			usedWidth += cell.Width
 		}
 		if lastStyle != "" {
 			sb.WriteString("\033[m")

--- a/pkg/cli/term/buffer.go
+++ b/pkg/cli/term/buffer.go
@@ -10,8 +10,9 @@ import (
 // Cell is an indivisible unit on the screen. It is not necessarily 1 column
 // wide.
 type Cell struct {
-	Text  string
-	Style string
+	Text      string
+	Style     string
+	ZeroWidth bool
 }
 
 // Pos is a line/column position.
@@ -23,7 +24,9 @@ type Pos struct {
 func cellsWidth(cs []Cell) int {
 	w := 0
 	for _, c := range cs {
-		w += wcwidth.Of(c.Text)
+		if !c.ZeroWidth {
+			w += wcwidth.Of(c.Text)
+		}
 	}
 	return w
 }

--- a/pkg/cli/term/buffer_builder.go
+++ b/pkg/cli/term/buffer_builder.go
@@ -87,7 +87,7 @@ func (bb *BufferBuilder) WriteRuneSGR(r rune, style string) *BufferBuilder {
 		bb.Newline()
 		return bb
 	}
-	c := Cell{string(r), style}
+	c := Cell{Text: string(r), Style: style}
 	if r < 0x20 || r == 0x7f {
 		// Always show control characters in reverse video.
 		if style != "" {
@@ -95,7 +95,7 @@ func (bb *BufferBuilder) WriteRuneSGR(r rune, style string) *BufferBuilder {
 		} else {
 			style = "7"
 		}
-		c = Cell{"^" + string(r^0x40), style}
+		c = Cell{Text: "^" + string(r^0x40), Style: style}
 	}
 
 	if bb.Col+wcwidth.Of(c.Text) > bb.Width {
@@ -148,6 +148,15 @@ func (bb *BufferBuilder) WriteStyled(t ui.Text) *BufferBuilder {
 	for _, seg := range t {
 		bb.WriteStringSGR(seg.Text, seg.Style.SGR())
 	}
+	return bb
+}
+
+// WriteZeroWidth writes a zero-width sequence to the buffer. It writes the raw
+// sequence and does not process control characters or apply styling, and
+// because it is written with zero width, the cursor position is unchanged.
+func (bb *BufferBuilder) WriteZeroWidth(sequence string) *BufferBuilder {
+	c := Cell{Text: sequence, Style: "", ZeroWidth: true}
+	bb.Lines[len(bb.Lines)-1] = append(bb.Lines[len(bb.Lines)-1], c)
 	return bb
 }
 

--- a/pkg/cli/term/buffer_builder.go
+++ b/pkg/cli/term/buffer_builder.go
@@ -78,7 +78,7 @@ func (bb *BufferBuilder) Newline() *BufferBuilder {
 			bb.PreIndent()
 		}
 		for i := 0; i < bb.Indent; i++ {
-			bb.appendCell(Cell{Text: " "})
+			bb.appendCell(Cell{Text: " ", Width: 1})
 		}
 		if bb.PostIndent != nil {
 			bb.PostIndent()
@@ -97,7 +97,7 @@ func (bb *BufferBuilder) WriteRuneSGR(r rune, style string) *BufferBuilder {
 		bb.Newline()
 		return bb
 	}
-	c := Cell{Text: string(r), Style: style}
+	c := Cell{Text: string(r), Style: style, Width: wcwidth.OfRune(r)}
 	if r < 0x20 || r == 0x7f {
 		// Always show control characters in reverse video.
 		if style != "" {
@@ -105,7 +105,8 @@ func (bb *BufferBuilder) WriteRuneSGR(r rune, style string) *BufferBuilder {
 		} else {
 			style = "7"
 		}
-		c = Cell{Text: "^" + string(r^0x40), Style: style}
+		s := "^" + string(r^0x40)
+		c = Cell{Text: s, Style: style, Width: wcwidth.Of(s)}
 	}
 
 	if bb.Col+wcwidth.Of(c.Text) > bb.Width {
@@ -165,7 +166,7 @@ func (bb *BufferBuilder) WriteStyled(t ui.Text) *BufferBuilder {
 // sequence and does not process control characters or apply styling, and
 // because it is written with zero width, the cursor position is unchanged.
 func (bb *BufferBuilder) WriteZeroWidth(sequence string) *BufferBuilder {
-	c := Cell{Text: sequence, Style: "", ZeroWidth: true}
+	c := Cell{Text: sequence}
 	bb.Lines[len(bb.Lines)-1] = append(bb.Lines[len(bb.Lines)-1], c)
 	return bb
 }
@@ -174,6 +175,7 @@ func makeSpacing(n int) []Cell {
 	s := make([]Cell, n)
 	for i := 0; i < n; i++ {
 		s[i].Text = " "
+		s[i].Width = 1
 	}
 	return s
 }

--- a/pkg/cli/term/buffer_builder.go
+++ b/pkg/cli/term/buffer_builder.go
@@ -19,6 +19,10 @@ type BufferBuilder struct {
 	Lines [][]Cell
 	// Dot is what the user perceives as the cursor.
 	Dot Pos
+	// PreIndent is called before writing indent spaces on continuation lines.
+	PreIndent func()
+	// PostIndent is called after writing indent spaces on continuation lines.
+	PostIndent func()
 }
 
 // NewBufferBuilder makes a new BufferBuilder, initially with one empty line.
@@ -70,8 +74,14 @@ func (bb *BufferBuilder) Newline() *BufferBuilder {
 	bb.appendLine()
 
 	if bb.Indent > 0 {
+		if bb.PreIndent != nil {
+			bb.PreIndent()
+		}
 		for i := 0; i < bb.Indent; i++ {
 			bb.appendCell(Cell{Text: " "})
+		}
+		if bb.PostIndent != nil {
+			bb.PostIndent()
 		}
 	}
 

--- a/pkg/cli/term/buffer_builder_test.go
+++ b/pkg/cli/term/buffer_builder_test.go
@@ -17,41 +17,41 @@ var bufferBuilderWritesTests = []struct {
 	{NewBufferBuilder(10), "", "", &Buffer{Width: 10, Lines: [][]Cell{{}}}},
 	// Writing a single rune.
 	{NewBufferBuilder(10), "a", "1",
-		&Buffer{Width: 10, Lines: [][]Cell{{{"a", "1"}}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{{"a", "1", false}}}}},
 	// Writing control character.
 	{NewBufferBuilder(10), "\033", "",
-		&Buffer{Width: 10, Lines: [][]Cell{{{"^[", "7"}}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{{"^[", "7", false}}}}},
 	// Writing styled control character.
 	{NewBufferBuilder(10), "a\033b", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{{
-			{"a", "1"},
-			{"^[", "1;7"},
-			{"b", "1"}}}}},
+			{"a", "1", false},
+			{"^[", "1;7", false},
+			{"b", "1", false}}}}},
 	// Writing text containing a newline.
 	{NewBufferBuilder(10), "a\nb", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "1"}}, {{"b", "1"}}}}},
+			{{"a", "1", false}}, {{"b", "1", false}}}}},
 	// Writing text containing a newline when there is indent.
 	{NewBufferBuilder(10).SetIndent(2), "a\nb", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "1"}},
-			{{" ", ""}, {" ", ""}, {"b", "1"}},
+			{{"a", "1", false}},
+			{{" ", "", false}, {" ", "", false}, {"b", "1", false}},
 		}}},
 	// Writing long text that triggers wrapping.
 	{NewBufferBuilder(4), "aaaab", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1"}, {"a", "1"}, {"a", "1"}, {"a", "1"}},
-			{{"b", "1"}}}}},
+			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
+			{{"b", "1", false}}}}},
 	// Writing long text that triggers wrapping when there is indent.
 	{NewBufferBuilder(4).SetIndent(2), "aaaab", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1"}, {"a", "1"}, {"a", "1"}, {"a", "1"}},
-			{{" ", ""}, {" ", ""}, {"b", "1"}}}}},
+			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
+			{{" ", "", false}, {" ", "", false}, {"b", "1", false}}}}},
 	// Writing long text that triggers eager wrapping.
 	{NewBufferBuilder(4).SetIndent(2).SetEagerWrap(true), "aaaa", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1"}, {"a", "1"}, {"a", "1"}, {"a", "1"}},
-			{{" ", ""}, {" ", ""}}}}},
+			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
+			{{" ", "", false}, {" ", "", false}}}}},
 }
 
 // TestBufferBuilderWrites tests BufferBuilder.Writes by calling Writes on a
@@ -86,8 +86,8 @@ var bufferBuilderTests = []struct {
 			"bar",
 		),
 		&Buffer{Width: 10, Dot: Pos{0, 4}, Lines: [][]Cell{
-			{{"f", "4"}, {"o", "4"}, {"o", ""}, {" ", ""}},
-			{{"b", ""}, {"a", ""}, {"r", ""}},
+			{{"f", "4", false}, {"o", "4", false}, {"o", "", false}, {" ", "", false}},
+			{{"b", "", false}, {"a", "", false}, {"r", "", false}},
 		}},
 	},
 }
@@ -100,6 +100,36 @@ func TestBufferBuilder(t *testing.T) {
 				t.Errorf("Got buf %v, want %v", buf, test.wantBuf)
 			}
 		})
+	}
+}
+
+func TestWriteZeroWidth(t *testing.T) {
+	bb := NewBufferBuilder(10)
+	bb.Write("prompt").WriteZeroWidth("\033]133;A\007").Write("> ")
+	buf := bb.Buffer()
+
+	want := &Buffer{
+		Width: 10,
+		Lines: [][]Cell{{
+			{"p", "", false}, {"r", "", false}, {"o", "", false},
+			{"m", "", false}, {"p", "", false}, {"t", "", false},
+			{"\033]133;A\007", "", true}, // zero-width
+			{">", "", false}, {" ", "", false},
+		}},
+	}
+
+	if !reflect.DeepEqual(buf, want) {
+		t.Errorf("Got buf:\n%v\nWant:\n%v", buf, want)
+	}
+
+	// Verify width calculation excludes zero-width cells
+	if width := cellsWidth(buf.Lines[0]); width != 8 {
+		t.Errorf("cellsWidth = %d, want 8", width)
+	}
+
+	// Verify cursor position (zero-width doesn't affect it)
+	if bb.Col != 8 {
+		t.Errorf("bb.Col = %d, want 8", bb.Col)
 	}
 }
 

--- a/pkg/cli/term/buffer_builder_test.go
+++ b/pkg/cli/term/buffer_builder_test.go
@@ -92,6 +92,19 @@ var bufferBuilderTests = []struct {
 	},
 }
 
+func cloneBufferBuilder(bb *BufferBuilder) *BufferBuilder {
+	return &BufferBuilder{
+		Width:      bb.Width,
+		Col:        bb.Col,
+		Indent:     bb.Indent,
+		EagerWrap:  bb.EagerWrap,
+		Lines:      cloneLines(bb.Lines),
+		Dot:        bb.Dot,
+		PreIndent:  bb.PreIndent,
+		PostIndent: bb.PostIndent,
+	}
+}
+
 func TestBufferBuilder(t *testing.T) {
 	for _, test := range bufferBuilderTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -133,8 +146,46 @@ func TestWriteZeroWidth(t *testing.T) {
 	}
 }
 
-func cloneBufferBuilder(bb *BufferBuilder) *BufferBuilder {
-	return &BufferBuilder{
-		bb.Width, bb.Col, bb.Indent,
-		bb.EagerWrap, cloneLines(bb.Lines), bb.Dot}
+func TestIndentHooks(t *testing.T) {
+	tests := []struct {
+		name      string
+		indent    int
+		text      string
+		wantCalls []string
+	}{
+		{
+			name:      "multiline with indent",
+			indent:    2,
+			text:      "line1\nline2\nline3",
+			wantCalls: []string{"pre", "post", "pre", "post"},
+		},
+		{
+			name:      "single line with indent",
+			indent:    2,
+			text:      "single line",
+			wantCalls: nil,
+		},
+		{
+			name:      "multiline without indent",
+			indent:    0,
+			text:      "line1\nline2",
+			wantCalls: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bb := NewBufferBuilder(20).SetIndent(test.indent)
+
+			var calls []string
+			bb.PreIndent = func() { calls = append(calls, "pre") }
+			bb.PostIndent = func() { calls = append(calls, "post") }
+
+			bb.WriteStringSGR(test.text, "")
+
+			if !reflect.DeepEqual(calls, test.wantCalls) {
+				t.Errorf("hook calls = %v, want %v", calls, test.wantCalls)
+			}
+		})
+	}
 }

--- a/pkg/cli/term/buffer_builder_test.go
+++ b/pkg/cli/term/buffer_builder_test.go
@@ -17,41 +17,41 @@ var bufferBuilderWritesTests = []struct {
 	{NewBufferBuilder(10), "", "", &Buffer{Width: 10, Lines: [][]Cell{{}}}},
 	// Writing a single rune.
 	{NewBufferBuilder(10), "a", "1",
-		&Buffer{Width: 10, Lines: [][]Cell{{{"a", "1", false}}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{cell("a", "1")}}}},
 	// Writing control character.
 	{NewBufferBuilder(10), "\033", "",
-		&Buffer{Width: 10, Lines: [][]Cell{{{"^[", "7", false}}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{cell("^[", "7")}}}},
 	// Writing styled control character.
 	{NewBufferBuilder(10), "a\033b", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{{
-			{"a", "1", false},
-			{"^[", "1;7", false},
-			{"b", "1", false}}}}},
+			cell("a", "1"),
+			cell("^[", "1;7"),
+			cell("b", "1")}}}},
 	// Writing text containing a newline.
 	{NewBufferBuilder(10), "a\nb", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "1", false}}, {{"b", "1", false}}}}},
+			{cell("a", "1")}, {cell("b", "1")}}}},
 	// Writing text containing a newline when there is indent.
 	{NewBufferBuilder(10).SetIndent(2), "a\nb", "1",
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "1", false}},
-			{{" ", "", false}, {" ", "", false}, {"b", "1", false}},
+			{cell("a", "1")},
+			{cell(" ", ""), cell(" ", ""), cell("b", "1")},
 		}}},
 	// Writing long text that triggers wrapping.
 	{NewBufferBuilder(4), "aaaab", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
-			{{"b", "1", false}}}}},
+			{cell("a", "1"), cell("a", "1"), cell("a", "1"), cell("a", "1")},
+			{cell("b", "1")}}}},
 	// Writing long text that triggers wrapping when there is indent.
 	{NewBufferBuilder(4).SetIndent(2), "aaaab", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
-			{{" ", "", false}, {" ", "", false}, {"b", "1", false}}}}},
+			{cell("a", "1"), cell("a", "1"), cell("a", "1"), cell("a", "1")},
+			{cell(" ", ""), cell(" ", ""), cell("b", "1")}}}},
 	// Writing long text that triggers eager wrapping.
 	{NewBufferBuilder(4).SetIndent(2).SetEagerWrap(true), "aaaa", "1",
 		&Buffer{Width: 4, Lines: [][]Cell{
-			{{"a", "1", false}, {"a", "1", false}, {"a", "1", false}, {"a", "1", false}},
-			{{" ", "", false}, {" ", "", false}}}}},
+			{cell("a", "1"), cell("a", "1"), cell("a", "1"), cell("a", "1")},
+			{cell(" ", ""), cell(" ", "")}}}},
 }
 
 // TestBufferBuilderWrites tests BufferBuilder.Writes by calling Writes on a
@@ -86,8 +86,8 @@ var bufferBuilderTests = []struct {
 			"bar",
 		),
 		&Buffer{Width: 10, Dot: Pos{0, 4}, Lines: [][]Cell{
-			{{"f", "4", false}, {"o", "4", false}, {"o", "", false}, {" ", "", false}},
-			{{"b", "", false}, {"a", "", false}, {"r", "", false}},
+			{cell("f", "4"), cell("o", "4"), cell("o", ""), cell(" ", "")},
+			{cell("b", ""), cell("a", ""), cell("r", "")},
 		}},
 	},
 }
@@ -124,10 +124,10 @@ func TestWriteZeroWidth(t *testing.T) {
 	want := &Buffer{
 		Width: 10,
 		Lines: [][]Cell{{
-			{"p", "", false}, {"r", "", false}, {"o", "", false},
-			{"m", "", false}, {"p", "", false}, {"t", "", false},
-			{"\033]133;A\007", "", true}, // zero-width
-			{">", "", false}, {" ", "", false},
+			cell("p", ""), cell("r", ""), cell("o", ""),
+			cell("m", ""), cell("p", ""), cell("t", ""),
+			{"\033]133;A\007", "", 0}, // zero-width
+			cell(">", ""), cell(" ", ""),
 		}},
 	}
 

--- a/pkg/cli/term/buffer_test.go
+++ b/pkg/cli/term/buffer_test.go
@@ -3,16 +3,22 @@ package term
 import (
 	"reflect"
 	"testing"
+
+	"src.elv.sh/pkg/wcwidth"
 )
+
+func cell(text, style string) Cell {
+	return Cell{Text: text, Style: style, Width: wcwidth.Of(text)}
+}
 
 var cellsWidthTests = []struct {
 	cells     []Cell
 	wantWidth int
 }{
 	{[]Cell{}, 0},
-	{[]Cell{{"a", "", false}, {"好", "", false}}, 3},
-	{[]Cell{{"\033]133;A\007", "", true}}, 0},
-	{[]Cell{{"a", "", false}, {"\033]133;B\007", "", true}, {"b", "", false}}, 2},
+	{[]Cell{cell("a", ""), cell("好", "")}, 3},
+	{[]Cell{{"\033]133;A\007", "", 0}}, 0},
+	{[]Cell{cell("a", ""), {"\033]133;B\007", "", 0}, cell("b", "")}, 2},
 }
 
 func TestCellsWidth(t *testing.T) {
@@ -29,8 +35,8 @@ var makeSpacingTests = []struct {
 	want []Cell
 }{
 	{0, []Cell{}},
-	{1, []Cell{{" ", "", false}}},
-	{4, []Cell{{" ", "", false}, {" ", "", false}, {" ", "", false}, {" ", "", false}}},
+	{1, []Cell{cell(" ", "")}},
+	{4, []Cell{cell(" ", ""), cell(" ", ""), cell(" ", ""), cell(" ", "")}},
 }
 
 func TestMakeSpacing(t *testing.T) {
@@ -48,15 +54,15 @@ var compareCellsTests = []struct {
 	wantIndex int
 }{
 	{[]Cell{}, []Cell{}, true, 0},
-	{[]Cell{}, []Cell{{"a", "", false}}, false, 0},
+	{[]Cell{}, []Cell{cell("a", "")}, false, 0},
 	{
-		[]Cell{{"a", "", false}, {"好", "", false}, {"b", "", false}},
-		[]Cell{{"a", "", false}, {"好", "", false}, {"c", "", false}},
+		[]Cell{cell("a", ""), cell("好", ""), cell("b", "")},
+		[]Cell{cell("a", ""), cell("好", ""), cell("c", "")},
 		false, 2,
 	},
 	{
-		[]Cell{{"a", "", false}, {"好", "", false}, {"b", "", false}},
-		[]Cell{{"a", "", false}, {"好", "1", false}, {"c", "", false}},
+		[]Cell{cell("a", ""), cell("好", ""), cell("b", "")},
+		[]Cell{cell("a", ""), cell("好", "1"), cell("c", "")},
 		false, 1,
 	},
 }
@@ -81,7 +87,7 @@ var bufferCursorTests = []struct {
 		Pos{0, 0},
 	},
 	{
-		&Buffer{Width: 10, Lines: [][]Cell{{{"a", "", false}}, {{"好", "", false}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{cell("a", "")}, {cell("好", "")}}},
 		Pos{1, 2},
 	},
 }
@@ -102,42 +108,42 @@ var bufferTrimToLinesTests = []struct {
 }{
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
+			{cell("a", "")}, {cell("b", "")}, {cell("c", "")}, {cell("d", "")},
 		}},
 		0, 2,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}},
+			{cell("a", "")}, {cell("b", "")},
 		}},
 	},
 	// Negative low is treated as 0.
 
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
+			{cell("a", "")}, {cell("b", "")}, {cell("c", "")}, {cell("d", "")},
 		}},
 		-1, 2,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}},
+			{cell("a", "")}, {cell("b", "")},
 		}},
 	},
 	// With dot.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
+			{cell("a", "")}, {cell("b", "")}, {cell("c", "")}, {cell("d", "")},
 		}, Dot: Pos{1, 1}},
 		1, 3,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"b", "", false}}, {{"c", "", false}},
+			{cell("b", "")}, {cell("c", "")},
 		}, Dot: Pos{0, 1}},
 	},
 	// With dot that is going to be trimmed away.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
+			{cell("a", "")}, {cell("b", "")}, {cell("c", "")}, {cell("d", "")},
 		}, Dot: Pos{0, 1}},
 		1, 3,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"b", "", false}}, {{"c", "", false}},
+			{cell("b", "")}, {cell("c", "")},
 		}, Dot: Pos{0, 1}},
 	},
 }
@@ -161,29 +167,29 @@ var bufferExtendDownTests = []struct {
 }{
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}}},
+			{cell("a", "")}, {cell("b", "")}}},
 		&Buffer{Width: 11, Lines: [][]Cell{
-			{{"c", "", false}}, {{"d", "", false}}}},
+			{cell("c", "")}, {cell("d", "")}}},
 		false,
 		&Buffer{Width: 11, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}},
-			{{"c", "", false}}, {{"d", "", false}}}},
+			{cell("a", "")}, {cell("b", "")},
+			{cell("c", "")}, {cell("d", "")}}},
 	},
 	// Moving dot.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}}},
+			{cell("a", "")}, {cell("b", "")}}},
 		&Buffer{
 			Width: 11,
-			Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}},
+			Lines: [][]Cell{{cell("c", "")}, {cell("d", "")}},
 			Dot:   Pos{1, 1},
 		},
 		true,
 		&Buffer{
 			Width: 11,
 			Lines: [][]Cell{
-				{{"a", "", false}}, {{"b", "", false}},
-				{{"c", "", false}}, {{"d", "", false}}},
+				{cell("a", "")}, {cell("b", "")},
+				{cell("c", "")}, {cell("d", "")}},
 			Dot: Pos{3, 1},
 		},
 	},
@@ -208,55 +214,55 @@ var bufferExtendRightTests = []struct {
 }{
 	// No padding, equal height.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("a", "")}, {cell("b", "")}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("c", "")}, {cell("d", "")}}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", "", false}, {"c", "", false}},
-			{{"b", "", false}, {"d", "", false}}}},
+			{cell("a", ""), cell("c", "")},
+			{cell("b", ""), cell("d", "")}}},
 	},
 	// With padding, equal height.
 	{
-		&Buffer{Width: 2, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
+		&Buffer{Width: 2, Lines: [][]Cell{{cell("a", "")}, {cell("b", "")}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("c", "")}, {cell("d", "")}}},
 		false,
 		&Buffer{Width: 3, Lines: [][]Cell{
-			{{"a", "", false}, {" ", "", false}, {"c", "", false}},
-			{{"b", "", false}, {" ", "", false}, {"d", "", false}}}},
+			{cell("a", ""), cell(" ", ""), cell("c", "")},
+			{cell("b", ""), cell(" ", ""), cell("d", "")}}},
 	},
 	// buf is higher.
 	{
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"a", "", false}}, {{"b", "", false}}, {{"x", "", false}}}},
+			{cell("a", "")}, {cell("b", "")}, {cell("x", "")}}},
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"c", "", false}}, {{"d", "", false}},
+			{cell("c", "")}, {cell("d", "")},
 		}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", "", false}, {"c", "", false}},
-			{{"b", "", false}, {"d", "", false}},
-			{{"x", "", false}}}},
+			{cell("a", ""), cell("c", "")},
+			{cell("b", ""), cell("d", "")},
+			{cell("x", "")}}},
 	},
 	// buf2 is higher.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("a", "")}, {cell("b", "")}}},
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"c", "", false}}, {{"d", "", false}}, {{"e", "", false}},
+			{cell("c", "")}, {cell("d", "")}, {cell("e", "")},
 		}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", "", false}, {"c", "", false}},
-			{{"b", "", false}, {"d", "", false}},
-			{{" ", "", false}, {"e", "", false}}}},
+			{cell("a", ""), cell("c", "")},
+			{cell("b", ""), cell("d", "")},
+			{cell(" ", ""), cell("e", "")}}},
 	},
 	// Moving the dot.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("a", "")}, {cell("b", "")}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{cell("c", "")}, {cell("d", "")}}},
 		true,
 		&Buffer{Width: 2, Dot: Pos{0, 1}, Lines: [][]Cell{
-			{{"a", "", false}, {"c", "", false}},
-			{{"b", "", false}, {"d", "", false}}}},
+			{cell("a", ""), cell("c", "")},
+			{cell("b", ""), cell("d", "")}}},
 	},
 }
 

--- a/pkg/cli/term/buffer_test.go
+++ b/pkg/cli/term/buffer_test.go
@@ -10,7 +10,9 @@ var cellsWidthTests = []struct {
 	wantWidth int
 }{
 	{[]Cell{}, 0},
-	{[]Cell{{"a", ""}, {"好", ""}}, 3},
+	{[]Cell{{"a", "", false}, {"好", "", false}}, 3},
+	{[]Cell{{"\033]133;A\007", "", true}}, 0},
+	{[]Cell{{"a", "", false}, {"\033]133;B\007", "", true}, {"b", "", false}}, 2},
 }
 
 func TestCellsWidth(t *testing.T) {
@@ -27,8 +29,8 @@ var makeSpacingTests = []struct {
 	want []Cell
 }{
 	{0, []Cell{}},
-	{1, []Cell{{" ", ""}}},
-	{4, []Cell{{" ", ""}, {" ", ""}, {" ", ""}, {" ", ""}}},
+	{1, []Cell{{" ", "", false}}},
+	{4, []Cell{{" ", "", false}, {" ", "", false}, {" ", "", false}, {" ", "", false}}},
 }
 
 func TestMakeSpacing(t *testing.T) {
@@ -46,15 +48,15 @@ var compareCellsTests = []struct {
 	wantIndex int
 }{
 	{[]Cell{}, []Cell{}, true, 0},
-	{[]Cell{}, []Cell{{"a", ""}}, false, 0},
+	{[]Cell{}, []Cell{{"a", "", false}}, false, 0},
 	{
-		[]Cell{{"a", ""}, {"好", ""}, {"b", ""}},
-		[]Cell{{"a", ""}, {"好", ""}, {"c", ""}},
+		[]Cell{{"a", "", false}, {"好", "", false}, {"b", "", false}},
+		[]Cell{{"a", "", false}, {"好", "", false}, {"c", "", false}},
 		false, 2,
 	},
 	{
-		[]Cell{{"a", ""}, {"好", ""}, {"b", ""}},
-		[]Cell{{"a", ""}, {"好", "1"}, {"c", ""}},
+		[]Cell{{"a", "", false}, {"好", "", false}, {"b", "", false}},
+		[]Cell{{"a", "", false}, {"好", "1", false}, {"c", "", false}},
 		false, 1,
 	},
 }
@@ -79,7 +81,7 @@ var bufferCursorTests = []struct {
 		Pos{0, 0},
 	},
 	{
-		&Buffer{Width: 10, Lines: [][]Cell{{{"a", ""}}, {{"好", ""}}}},
+		&Buffer{Width: 10, Lines: [][]Cell{{{"a", "", false}}, {{"好", "", false}}}},
 		Pos{1, 2},
 	},
 }
@@ -100,42 +102,42 @@ var bufferTrimToLinesTests = []struct {
 }{
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}, {{"c", ""}}, {{"d", ""}},
+			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
 		}},
 		0, 2,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}},
+			{{"a", "", false}}, {{"b", "", false}},
 		}},
 	},
 	// Negative low is treated as 0.
 
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}, {{"c", ""}}, {{"d", ""}},
+			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
 		}},
 		-1, 2,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}},
+			{{"a", "", false}}, {{"b", "", false}},
 		}},
 	},
 	// With dot.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}, {{"c", ""}}, {{"d", ""}},
+			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
 		}, Dot: Pos{1, 1}},
 		1, 3,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"b", ""}}, {{"c", ""}},
+			{{"b", "", false}}, {{"c", "", false}},
 		}, Dot: Pos{0, 1}},
 	},
 	// With dot that is going to be trimmed away.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}, {{"c", ""}}, {{"d", ""}},
+			{{"a", "", false}}, {{"b", "", false}}, {{"c", "", false}}, {{"d", "", false}},
 		}, Dot: Pos{0, 1}},
 		1, 3,
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"b", ""}}, {{"c", ""}},
+			{{"b", "", false}}, {{"c", "", false}},
 		}, Dot: Pos{0, 1}},
 	},
 }
@@ -159,29 +161,29 @@ var bufferExtendDownTests = []struct {
 }{
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}}},
+			{{"a", "", false}}, {{"b", "", false}}}},
 		&Buffer{Width: 11, Lines: [][]Cell{
-			{{"c", ""}}, {{"d", ""}}}},
+			{{"c", "", false}}, {{"d", "", false}}}},
 		false,
 		&Buffer{Width: 11, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}},
-			{{"c", ""}}, {{"d", ""}}}},
+			{{"a", "", false}}, {{"b", "", false}},
+			{{"c", "", false}}, {{"d", "", false}}}},
 	},
 	// Moving dot.
 	{
 		&Buffer{Width: 10, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}}},
+			{{"a", "", false}}, {{"b", "", false}}}},
 		&Buffer{
 			Width: 11,
-			Lines: [][]Cell{{{"c", ""}}, {{"d", ""}}},
+			Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}},
 			Dot:   Pos{1, 1},
 		},
 		true,
 		&Buffer{
 			Width: 11,
 			Lines: [][]Cell{
-				{{"a", ""}}, {{"b", ""}},
-				{{"c", ""}}, {{"d", ""}}},
+				{{"a", "", false}}, {{"b", "", false}},
+				{{"c", "", false}}, {{"d", "", false}}},
 			Dot: Pos{3, 1},
 		},
 	},
@@ -206,55 +208,55 @@ var bufferExtendRightTests = []struct {
 }{
 	// No padding, equal height.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", ""}}, {{"b", ""}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", ""}}, {{"d", ""}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", ""}, {"c", ""}},
-			{{"b", ""}, {"d", ""}}}},
+			{{"a", "", false}, {"c", "", false}},
+			{{"b", "", false}, {"d", "", false}}}},
 	},
 	// With padding, equal height.
 	{
-		&Buffer{Width: 2, Lines: [][]Cell{{{"a", ""}}, {{"b", ""}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", ""}}, {{"d", ""}}}},
+		&Buffer{Width: 2, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
 		false,
 		&Buffer{Width: 3, Lines: [][]Cell{
-			{{"a", ""}, {" ", ""}, {"c", ""}},
-			{{"b", ""}, {" ", ""}, {"d", ""}}}},
+			{{"a", "", false}, {" ", "", false}, {"c", "", false}},
+			{{"b", "", false}, {" ", "", false}, {"d", "", false}}}},
 	},
 	// buf is higher.
 	{
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"a", ""}}, {{"b", ""}}, {{"x", ""}}}},
+			{{"a", "", false}}, {{"b", "", false}}, {{"x", "", false}}}},
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"c", ""}}, {{"d", ""}},
+			{{"c", "", false}}, {{"d", "", false}},
 		}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", ""}, {"c", ""}},
-			{{"b", ""}, {"d", ""}},
-			{{"x", ""}}}},
+			{{"a", "", false}, {"c", "", false}},
+			{{"b", "", false}, {"d", "", false}},
+			{{"x", "", false}}}},
 	},
 	// buf2 is higher.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", ""}}, {{"b", ""}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
 		&Buffer{Width: 1, Lines: [][]Cell{
-			{{"c", ""}}, {{"d", ""}}, {{"e", ""}},
+			{{"c", "", false}}, {{"d", "", false}}, {{"e", "", false}},
 		}},
 		false,
 		&Buffer{Width: 2, Lines: [][]Cell{
-			{{"a", ""}, {"c", ""}},
-			{{"b", ""}, {"d", ""}},
-			{{" ", ""}, {"e", ""}}}},
+			{{"a", "", false}, {"c", "", false}},
+			{{"b", "", false}, {"d", "", false}},
+			{{" ", "", false}, {"e", "", false}}}},
 	},
 	// Moving the dot.
 	{
-		&Buffer{Width: 1, Lines: [][]Cell{{{"a", ""}}, {{"b", ""}}}},
-		&Buffer{Width: 1, Lines: [][]Cell{{{"c", ""}}, {{"d", ""}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"a", "", false}}, {{"b", "", false}}}},
+		&Buffer{Width: 1, Lines: [][]Cell{{{"c", "", false}}, {{"d", "", false}}}},
 		true,
 		&Buffer{Width: 2, Dot: Pos{0, 1}, Lines: [][]Cell{
-			{{"a", ""}, {"c", ""}},
-			{{"b", ""}, {"d", ""}}}},
+			{{"a", "", false}, {"c", "", false}},
+			{{"b", "", false}, {"d", "", false}}}},
 	},
 }
 

--- a/pkg/cli/term/osc.go
+++ b/pkg/cli/term/osc.go
@@ -1,0 +1,31 @@
+package term
+
+import "fmt"
+
+// OSC 133 shell integration sequences enable terminals to understand shell
+// command structure for features like command navigation, intelligent text
+// selection, and command status indicators.
+//
+// Specification:
+// https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+const (
+	// OSC133A_I combines prompt start with initial prompt marker (preferred).
+	// This is more efficient than sending OSC133A and OSC133P_I separately.
+	OSC133A_I = "\033]133;A;k=i\007"
+
+	// OSC133P_R marks a right prompt. This is critical for terminals to
+	// correctly classify right prompts vs. user input.
+	OSC133P_R = "\033]133;P;k=r\007"
+
+	// OSC133B marks the start of user input. This separates prompts from
+	// command input, enabling proper command copying and selection.
+	OSC133B = "\033]133;B\007"
+
+	// OSC133C marks the start of command execution.
+	OSC133C = "\033]133;C\007"
+)
+
+// OSC133D returns the sequence marking command execution end with exit code.
+func OSC133D(exitCode int) string {
+	return fmt.Sprintf("\033]133;D;%d\007", exitCode)
+}

--- a/pkg/cli/term/osc.go
+++ b/pkg/cli/term/osc.go
@@ -9,10 +9,6 @@ import "fmt"
 // Specification:
 // https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
 const (
-	// OSC133A starts a new command and enters prompt mode. The following
-	// text is assumed to be the initial prompt.
-	OSC133A = "\033]133;A;cl=m\007"
-
 	// OSC133P_R marks a right prompt. This is critical for terminals to
 	// correctly classify right prompts vs. user input.
 	OSC133P_R = "\033]133;P;k=r\007"
@@ -28,7 +24,13 @@ const (
 	OSC133C = "\033]133;C\007"
 )
 
+// OSC133A returns the sequence that starts a new command and enters prompt
+// mode. The following text is assumed to be the initial prompt.
+func OSC133A(pid int) string {
+	return fmt.Sprintf("\033]133;A;cl=m;aid=%d\007", pid)
+}
+
 // OSC133D returns the sequence marking command execution end with exit code.
-func OSC133D(exitCode int) string {
-	return fmt.Sprintf("\033]133;D;%d\007", exitCode)
+func OSC133D(exitCode int, pid int) string {
+	return fmt.Sprintf("\033]133;D;%d;aid=%d\007", exitCode, pid)
 }

--- a/pkg/cli/term/osc.go
+++ b/pkg/cli/term/osc.go
@@ -17,6 +17,9 @@ const (
 	// correctly classify right prompts vs. user input.
 	OSC133P_R = "\033]133;P;k=r\007"
 
+	// OSC133P_S marks a secondary/continuation prompt for multiline input.
+	OSC133P_S = "\033]133;P;k=s\007"
+
 	// OSC133B marks the start of user input. This separates prompts from
 	// command input, enabling proper command copying and selection.
 	OSC133B = "\033]133;B\007"

--- a/pkg/cli/term/osc.go
+++ b/pkg/cli/term/osc.go
@@ -9,9 +9,9 @@ import "fmt"
 // Specification:
 // https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
 const (
-	// OSC133A_I combines prompt start with initial prompt marker (preferred).
-	// This is more efficient than sending OSC133A and OSC133P_I separately.
-	OSC133A_I = "\033]133;A;k=i\007"
+	// OSC133A starts a new command and enters prompt mode. The following
+	// text is assumed to be the initial prompt.
+	OSC133A = "\033]133;A;cl=m\007"
 
 	// OSC133P_R marks a right prompt. This is critical for terminals to
 	// correctly classify right prompts vs. user input.

--- a/pkg/cli/tk/codearea.go
+++ b/pkg/cli/tk/codearea.go
@@ -46,6 +46,9 @@ type CodeAreaSpec struct {
 	// should be quoted. If this function is not given, the Widget defaults to
 	// not quoting pasted texts.
 	QuotePaste func() bool
+	// A function that returns whether OSC 133 shell integration is enabled.
+	// If this function is not given, the Widget defaults to enabled.
+	ShellIntegration func() bool
 	// A function that is called on the submit event.
 	OnSubmit func()
 
@@ -138,6 +141,9 @@ func NewCodeArea(spec CodeAreaSpec) CodeArea {
 	if spec.QuotePaste == nil {
 		spec.QuotePaste = func() bool { return false }
 	}
+	if spec.ShellIntegration == nil {
+		spec.ShellIntegration = func() bool { return false }
+	}
 	if spec.OnSubmit == nil {
 		spec.OnSubmit = func() {}
 	}
@@ -164,7 +170,7 @@ func (w *codeArea) MaxHeight(width, height int) int {
 func (w *codeArea) render(width int) *term.Buffer {
 	view := getView(w)
 	bb := term.NewBufferBuilder(width)
-	renderView(view, bb)
+	renderView(view, bb, w.ShellIntegration())
 	return bb.Buffer()
 }
 

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -73,7 +73,7 @@ func renderView(v *view, buf *term.BufferBuilder, shellIntegration bool) {
 		}
 	}
 
-	writeOSC(term.OSC133A_I) // OSC 133;A;k=i - start of initial prompt
+	writeOSC(term.OSC133A) // OSC 133;A - start of initial prompt
 	buf.WriteStyled(v.prompt)
 	if len(buf.Lines) == 1 && buf.Col*2 < buf.Width {
 		buf.Indent = buf.Col

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -1,6 +1,8 @@
 package tk
 
 import (
+	"os"
+
 	"src.elv.sh/pkg/cli/term"
 	"src.elv.sh/pkg/ui"
 	"src.elv.sh/pkg/wcwidth"
@@ -73,7 +75,7 @@ func renderView(v *view, buf *term.BufferBuilder, shellIntegration bool) {
 		}
 	}
 
-	writeOSC(term.OSC133A) // OSC 133;A - start of initial prompt
+	writeOSC(term.OSC133A(os.Getpid())) // OSC 133;A - start of initial prompt
 	buf.WriteStyled(v.prompt)
 	if len(buf.Lines) == 1 && buf.Col*2 < buf.Width {
 		buf.Indent = buf.Col

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -78,6 +78,13 @@ func renderView(v *view, buf *term.BufferBuilder, shellIntegration bool) {
 	if len(buf.Lines) == 1 && buf.Col*2 < buf.Width {
 		buf.Indent = buf.Col
 	}
+	buf.PreIndent = func() {
+		writeOSC(term.OSC133P_S) // OSC 133;P;k=s - secondary prompt
+	}
+	buf.PostIndent = func() {
+		writeOSC(term.OSC133B) // OSC 133;B - return to input mode
+	}
+
 	writeOSC(term.OSC133B) // OSC 133;B - start of user input
 
 	parts := v.code.Partition(v.dot)
@@ -88,6 +95,8 @@ func renderView(v *view, buf *term.BufferBuilder, shellIntegration bool) {
 
 	buf.EagerWrap = false
 	buf.Indent = 0
+	buf.PreIndent = nil
+	buf.PostIndent = nil
 
 	// Handle rprompts with newlines.
 	if rpromptWidth := styledWcswidth(v.rprompt); rpromptWidth > 0 {

--- a/pkg/cli/tk/codearea_render.go
+++ b/pkg/cli/tk/codearea_render.go
@@ -64,13 +64,21 @@ func patchPending(c CodeBuffer, p PendingCode) (CodeBuffer, int, int) {
 	return CodeBuffer{Content: newContent, Dot: newDot}, p.From, p.From + len(p.Content)
 }
 
-func renderView(v *view, buf *term.BufferBuilder) {
+func renderView(v *view, buf *term.BufferBuilder, shellIntegration bool) {
 	buf.EagerWrap = true
 
+	writeOSC := func(seq string) {
+		if shellIntegration {
+			buf.WriteZeroWidth(seq)
+		}
+	}
+
+	writeOSC(term.OSC133A_I) // OSC 133;A;k=i - start of initial prompt
 	buf.WriteStyled(v.prompt)
 	if len(buf.Lines) == 1 && buf.Col*2 < buf.Width {
 		buf.Indent = buf.Col
 	}
+	writeOSC(term.OSC133B) // OSC 133;B - start of user input
 
 	parts := v.code.Partition(v.dot)
 	buf.
@@ -86,7 +94,12 @@ func renderView(v *view, buf *term.BufferBuilder) {
 		padding := buf.Width - buf.Col - rpromptWidth
 		if padding >= 1 {
 			buf.WriteSpaces(padding)
+			writeOSC(term.OSC133P_R) // OSC 133;P;k=r - right prompt
 			buf.WriteStyled(v.rprompt)
+			// OSC 133;B again - return to input mode after right prompt,
+			// preventing the right prompt marker from making subsequent
+			// input appear as part of the prompt
+			writeOSC(term.OSC133B)
 		}
 	}
 

--- a/pkg/edit/config_api.go
+++ b/pkg/edit/config_api.go
@@ -20,6 +20,13 @@ func initMaxHeight(appSpec *cli.AppSpec, nb eval.NsBuilder) {
 	nb.AddVar("max-height", maxHeight)
 }
 
+func initShellIntegration(appSpec *cli.AppSpec, ed *Editor, nb eval.NsBuilder) {
+	shellIntegration := newBoolVar(true)
+	ed.shellIntegration = func() bool { return shellIntegration.GetRaw().(bool) }
+	appSpec.ShellIntegration = ed.shellIntegration
+	nb.AddVar("shell-integration", shellIntegration)
+}
+
 func initReadlineHooks(appSpec *cli.AppSpec, ev *eval.Evaler, nb eval.NsBuilder) {
 	initBeforeReadline(appSpec, ev, nb)
 	initAfterReadline(appSpec, ev, nb)

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -34,6 +34,8 @@ type Editor struct {
 	// set in initHighlighter.
 	applyAutofix func()
 
+	shellIntegration func() bool
+
 	// Maybe move this to another type that represents the REPL cycle as a whole, not just the
 	// read/edit portion represented by the Editor type.
 	AfterCommand []func(src parse.Source, duration float64, err error)
@@ -64,6 +66,7 @@ func NewEditor(tty cli.TTY, ev *eval.Evaler, st storedefs.Store) *Editor {
 	}
 
 	initMaxHeight(&appSpec, nb)
+	initShellIntegration(&appSpec, ed, nb)
 	initReadlineHooks(&appSpec, ev, nb)
 	initAddCmdFilters(&appSpec, ev, nb, hs)
 	initGlobalBindings(&appSpec, ed, ev, nb)
@@ -133,6 +136,11 @@ func (ed *Editor) RunAfterCommandHooks(src parse.Source, duration float64, err e
 // See https://elv.sh/ref/edit.html for the Elvish API.
 func (ed *Editor) Ns() *eval.Ns {
 	return ed.ns
+}
+
+// ShellIntegration returns whether shell integration is enabled.
+func (ed *Editor) ShellIntegration() bool {
+	return ed.shellIntegration()
 }
 
 func (ed *Editor) notifyf(format string, args ...any) {

--- a/pkg/edit/testutils_test.go
+++ b/pkg/edit/testutils_test.go
@@ -71,7 +71,9 @@ func setup(c testutil.Cleanuper, fns ...func(*fixture)) *fixture {
 		// sure that the tests will work when run as root.
 		"set edit:prompt = { tilde-abbr $pwd; put '> ' }",
 		// This will simplify most tests against the terminal.
-		"set edit:rprompt = { }")
+		"set edit:rprompt = { }",
+		// Disable shell integration in tests to avoid OSC sequences in test output
+		"set edit:shell-integration = $false")
 	f := &fixture{Editor: ed, TTYCtrl: ttyCtrl, Evaler: ev, Store: st, Home: home}
 	for _, fn := range fns {
 		fn(f)

--- a/pkg/shell/interact.go
+++ b/pkg/shell/interact.go
@@ -146,7 +146,7 @@ func evalInteractive(fds [3]*os.File, ev *eval.Evaler, ed editor, src parse.Sour
 
 	if osc133 {
 		exitCode := errorExitCode(err)
-		_, _ = stdout.WriteString(term.OSC133D(exitCode))
+		_, _ = stdout.WriteString(term.OSC133D(exitCode, os.Getpid()))
 	}
 
 	return err

--- a/pkg/shell/interact.go
+++ b/pkg/shell/interact.go
@@ -41,6 +41,7 @@ type interactCfg struct {
 type editor interface {
 	ReadCode() (string, error)
 	RunAfterCommandHooks(src parse.Source, duration float64, err error)
+	ShellIntegration() bool
 }
 
 // Runs an interactive shell session.
@@ -124,12 +125,49 @@ func interact(ev *eval.Evaler, fds [3]*os.File, cfg *interactCfg) {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		err = evalInTTY(fds, ev, ed,
+		err = evalInteractive(fds, ev, ed,
 			parse.Source{Name: fmt.Sprintf("[tty %v]", cmdNum), Code: line})
 		if err != nil {
 			diag.ShowError(fds[2], err)
 		}
 	}
+}
+
+// Evaluates interactive commands with shell integration markers.
+func evalInteractive(fds [3]*os.File, ev *eval.Evaler, ed editor, src parse.Source) error {
+	stdout := fds[2]
+	osc133 := ed.ShellIntegration() && sys.IsATTY(stdout.Fd())
+
+	if osc133 {
+		_, _ = stdout.WriteString(term.OSC133C)
+	}
+
+	err := evalInTTY(fds, ev, ed, src)
+
+	if osc133 {
+		exitCode := errorExitCode(err)
+		_, _ = stdout.WriteString(term.OSC133D(exitCode))
+	}
+
+	return err
+}
+
+// Converts an evaluation error to a shell exit code.
+func errorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if exitErr, ok := err.(eval.ExternalCmdExit); ok {
+		ws := exitErr.WaitStatus
+		if ws.Exited() {
+			return ws.ExitStatus()
+		}
+		return 1
+	}
+
+	// All other error kinds (exceptions, etc.)
+	return 1
 }
 
 // Interactive mode panic handler.
@@ -171,6 +209,10 @@ func newMinEditor(in, out *os.File) *minEditor {
 
 func (ed *minEditor) RunAfterCommandHooks(src parse.Source, duration float64, err error) {
 	// no-op; minEditor doesn't support this hook.
+}
+
+func (ed *minEditor) ShellIntegration() bool {
+	return false
 }
 
 func (ed *minEditor) ReadCode() (string, error) {

--- a/website/ref/edit.md
+++ b/website/ref/edit.md
@@ -150,6 +150,23 @@ press Enter, it is erased. If you want to keep it, simply set
 set edit:rprompt-persistent = $true
 ```
 
+### Shell Integration
+
+Elvish supports
+[OSC 133 semantic prompt sequences](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md),
+which enable terminal emulators to understand shell command structure. This
+allows terminals with OSC 133 support to provide features like command
+navigation, intelligent output selection, and command status indicators.
+
+Shell integration is enabled by default. Terminal emulators that don't
+support these sequences will simply ignore them.
+
+To disable shell integration:
+
+```elvish
+set edit:shell-integration = $false
+```
+
 ## Keybindings
 
 Each mode has its own keybinding, accessible as the `binding` variable in its


### PR DESCRIPTION
OSC 133 semantic prompt sequences help terminals understand shell command structure for features like command navigation, intelligent text selection, and command status indicators.

https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md

This change adds support for OSC 133 A (prompt start), B (input start), C (command start), D (command exit), and P;k=r (right prompt). These sequences are only emitted to TTYs in interactive shell sessions.

I introduced the concept of "zero-width" buffer cells to prevent these "invisible" sequences from contributing to line width calculations. This adds a small (`int`) cost to each `Cell` instance. I explored some alternatives (interfaces, out-of-band tracking, a magic "style" value), but this ended up being the clearest and most efficient approach.

This feature is controlled via a new `edit:shell-integration` variable. It defaults to `$true` (enabled) but can be disabled at any time. It could be generalized to a map of shell integration features later while maintaining backwards compatibility (e.g. `$true` means all enabled):

    set edit:shell-integration = [ &osc133=$true &osc8=$true ]

I also explored ways to implement this support at the script level, but the existing `edit:` hooks don't cover enough cases, and the prompt's asynchronous, control-sequence-stripping output was too limiting.

Closes #1808