### PR TITLE
Support combobox when getting focused code area

### DIFF
--- a/pkg/cli/modes/mode.go
+++ b/pkg/cli/modes/mode.go
@@ -17,8 +17,12 @@ var ErrFocusedWidgetNotCodeArea = errors.New("focused widget is not a code area"
 // FocusedCodeArea returns a CodeArea widget if the currently focused widget is
 // a CodeArea. Otherwise it returns the error ErrFocusedWidgetNotCodeArea.
 func FocusedCodeArea(a cli.App) (tk.CodeArea, error) {
-	if w, ok := a.FocusedWidget().(tk.CodeArea); ok {
+	widget := a.FocusedWidget()
+	if w, ok := widget.(tk.CodeArea); ok {
 		return w, nil
+	}
+	if w, ok := widget.(tk.ComboBox); ok {
+		return w.CodeArea(), nil
 	}
 	return nil, ErrFocusedWidgetNotCodeArea
 }


### PR DESCRIPTION
Trying to use bindings like `edit:kill-word-left` inside modes like location will error with `focused widget is not a code area` because the focused widget is a `tk.ComboBox`. But comboboxes only have a single code area so we can just treat the combobox's code area as the "focused" code area.